### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/aurora-dsql-loader/security/code-scanning/2](https://github.com/aws-samples/aurora-dsql-loader/security/code-scanning/2)

In general, the fix is to explicitly specify a minimal `permissions` block for the workflow or for the individual job so that the `GITHUB_TOKEN` has only the scopes it needs. For this CI workflow, the job only needs to read repository contents (to allow `actions/checkout` to work). None of the steps require write access to contents, issues, PRs, or other resources, so we can safely set `contents: read` as the only permission.

The best way to fix this without changing functionality is to add a `permissions` block at the workflow (root) level so it applies to all current and future jobs that don’t override it. We will insert:

```yaml
permissions:
  contents: read
```

between the `on:` trigger section and the `env:` block, keeping indentation consistent with other top-level keys. This will constrain the default `GITHUB_TOKEN` to read-only repository contents and satisfy CodeQL’s recommendation, with no impact on the existing steps.

Concretely:
- Edit `.github/workflows/ci.yml`.
- After line 7 (the end of the `pull_request` branches block) and before line 9 (`env:`), add the `permissions` mapping shown above.
- No imports or additional methods are required, since this is a configuration-only change in the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
