### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/aurora-dsql-loader/security/code-scanning/1](https://github.com/aws-samples/aurora-dsql-loader/security/code-scanning/1)

In general, fix this by adding an explicit `permissions` block with least-privilege settings either at the workflow root (affecting all jobs without their own block) or on each job. In this workflow, the `build-release` job already has `permissions: contents: write` because it needs to upload release assets, but the `test` job only needs read access to the repository contents. The best targeted fix is to add a `permissions:` block under the `test` job with `contents: read`.

Concretely, in `.github/workflows/release.yml`, edit the `test` job definition (lines 13–16 area). Add:

```yaml
permissions:
  contents: read
```

between `runs-on: ubuntu-latest` and `steps:`. This does not alter any existing behavior, as the job does not perform any write operations; it only narrows the `GITHUB_TOKEN` scope to the minimal required permission.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
