### PR TITLE
Fix inference on constraint query

### DIFF
--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -349,7 +349,7 @@ impl Pool {
                 // Query for constraint columns, prioritizing primary key over unique constraints
                 // Returns all columns from the first matching constraint
                 let sql = r#"
-                    SELECT a.attname, c.contype
+                    SELECT a.attname, c.contype::text
                     FROM pg_constraint c
                     JOIN pg_class t ON c.conrelid = t.oid
                     JOIN pg_namespace n ON t.relnamespace = n.oid


### PR DESCRIPTION
The loader was failing while querying constraint columns with primary keys as SQLX was expecting to decode this to text.

Fixes: #12 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
