### PR TITLE
Switch Linux builds to musl for broader compatibility

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,15 +59,16 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             artifact_name: aurora-dsql-loader
-            asset_name: aurora-dsql-loader-x86_64-unknown-linux-gnu
+            asset_name: aurora-dsql-loader-x86_64-unknown-linux-musl
             archive_ext: tar.gz
+            cross: true
 
           - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
             artifact_name: aurora-dsql-loader
-            asset_name: aurora-dsql-loader-aarch64-unknown-linux-gnu
+            asset_name: aurora-dsql-loader-aarch64-unknown-linux-musl
             archive_ext: tar.gz
             cross: true
 
@@ -98,9 +99,11 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross
+      - name: Setup cross-compilation toolchain
         if: matrix.cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -114,13 +117,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.target }}-cargo-release-
 
       - name: Build release binary
-        run: |
-          if [ "${{ matrix.cross }}" = "true" ]; then
-            cross build --release --target ${{ matrix.target }}
-          else
-            cargo build --release --target ${{ matrix.target }}
-          fi
-        shell: bash
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Create archive (Linux and macOS)
         if: matrix.archive_ext == 'tar.gz'


### PR DESCRIPTION
Replace glibc-based Linux builds with musl to support older systems (RHEL8 with glibc 2.28, RHEL9/AL2023 with glibc 2.34).

Changes:
- Update release workflow to use x86_64/aarch64-unknown-linux-musl targets
- Use setup-cross-toolchain-action for native cross-compilation
- Add .cargo/config.toml with static linking flags
- Musl binaries are fully static



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
