### PR TITLE
Make DelimitedConfig user-configurable via CLI

### DIFF
--- a/src/formats/delimited/reader.rs
+++ b/src/formats/delimited/reader.rs
@@ -89,17 +89,24 @@ impl<R: ByteReader + 'static> FileReader for GenericDelimitedReader<R> {
             .context("Failed to read chunk data")?;
 
         // Parse the CSV data
-        // Convert string delimiter to byte (handle \t specially)
-        let delimiter_byte = if self.config.delimiter == "\\t" {
-            b'\t'
+        // Convert string delimiter to byte (handle escape sequences)
+        let delimiter_byte =
+            parse_escape_sequence(&self.config.delimiter).context("Invalid delimiter")?;
+
+        let quote_byte =
+            parse_escape_sequence(&self.config.quote).context("Invalid quote character")?;
+
+        // Convert escape string to optional byte
+        let escape_byte = if let Some(ref escape_str) = self.config.escape {
+            Some(parse_escape_sequence(escape_str).context("Invalid escape character")?)
         } else {
-            self.config.delimiter.as_bytes()[0]
+            None
         };
-        let quote_byte = self.config.quote.as_bytes()[0];
 
         let mut csv_reader = csv::ReaderBuilder::new()
             .delimiter(delimiter_byte)
             .quote(quote_byte)
+            .escape(escape_byte)
             .has_headers(false) // We handle headers at the file level
             .from_reader(buffer.as_slice());
 
@@ -123,5 +130,33 @@ impl<R: ByteReader + 'static> FileReader for GenericDelimitedReader<R> {
             records,
             bytes_read: chunk.end_offset - chunk.start_offset,
         })
+    }
+}
+
+/// Parse a string that may contain escape sequences into a single byte
+/// Supports: \\, \t, \n, \r, \", \'
+fn parse_escape_sequence(s: &str) -> Result<u8> {
+    if s.len() == 1 {
+        // Single character, no escape sequence
+        return Ok(s.as_bytes()[0]);
+    }
+
+    if s.len() == 2 && s.starts_with('\\') {
+        // Two-character escape sequence
+        match s.chars().nth(1) {
+            Some('\\') => Ok(b'\\'),
+            Some('t') => Ok(b'\t'),
+            Some('n') => Ok(b'\n'),
+            Some('r') => Ok(b'\r'),
+            Some('"') => Ok(b'"'),
+            Some('\'') => Ok(b'\''),
+            Some(c) => anyhow::bail!("Unknown escape sequence: \\{}", c),
+            None => anyhow::bail!("Invalid escape sequence"),
+        }
+    } else {
+        anyhow::bail!(
+            "Character must be exactly one character (got {} bytes). Use escape sequences like \\t, \\n, or \\\\",
+            s.len()
+        )
     }
 }

--- a/src/formats/reader.rs
+++ b/src/formats/reader.rs
@@ -57,6 +57,7 @@ pub struct DelimitedConfig {
     pub delimiter: String,
     pub has_header: bool,
     pub quote: String,
+    pub escape: Option<String>,
 }
 
 impl Default for DelimitedConfig {
@@ -65,6 +66,7 @@ impl Default for DelimitedConfig {
             delimiter: ",".to_string(),
             has_header: true,
             quote: "\"".to_string(),
+            escape: None,
         }
     }
 }
@@ -79,6 +81,7 @@ impl DelimitedConfig {
             delimiter: "\\t".to_string(),
             has_header: true,
             quote: "\"".to_string(),
+            escape: None,
         }
     }
 }
@@ -104,15 +107,18 @@ impl ReaderFactory {
     }
 
     /// Create a FileReader based on source URI and format
+    ///
+    /// If delimited_config is provided for CSV/TSV formats, it will be used instead of defaults
     pub async fn create_reader(
         &self,
         source_uri: &SourceUri,
         format: Format,
+        delimited_config: Option<DelimitedConfig>,
     ) -> Result<Arc<dyn FileReader>> {
         match (source_uri, format) {
             // Local CSV
             (SourceUri::Local(path), Format::Csv) => {
-                let config = DelimitedConfig::csv();
+                let config = delimited_config.unwrap_or_else(DelimitedConfig::csv);
                 let byte_reader = LocalFileByteReader::new(path);
                 let reader = GenericDelimitedReader::new(byte_reader, config);
                 Ok(Arc::new(reader) as Arc<dyn FileReader>)
@@ -120,7 +126,7 @@ impl ReaderFactory {
 
             // Local TSV
             (SourceUri::Local(path), Format::Tsv) => {
-                let config = DelimitedConfig::tsv();
+                let config = delimited_config.unwrap_or_else(DelimitedConfig::tsv);
                 let byte_reader = LocalFileByteReader::new(path);
                 let reader = GenericDelimitedReader::new(byte_reader, config);
                 Ok(Arc::new(reader) as Arc<dyn FileReader>)
@@ -128,7 +134,7 @@ impl ReaderFactory {
 
             // S3 CSV
             (SourceUri::S3 { bucket, key }, Format::Csv) => {
-                let config = DelimitedConfig::csv();
+                let config = delimited_config.unwrap_or_else(DelimitedConfig::csv);
                 let byte_reader =
                     S3ByteReader::new(Arc::clone(&self.s3_client), bucket.clone(), key.clone());
                 let reader = GenericDelimitedReader::new(byte_reader, config);
@@ -137,7 +143,7 @@ impl ReaderFactory {
 
             // S3 TSV
             (SourceUri::S3 { bucket, key }, Format::Tsv) => {
-                let config = DelimitedConfig::tsv();
+                let config = delimited_config.unwrap_or_else(DelimitedConfig::tsv);
                 let byte_reader =
                     S3ByteReader::new(Arc::clone(&self.s3_client), bucket.clone(), key.clone());
                 let reader = GenericDelimitedReader::new(byte_reader, config);

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -478,6 +478,10 @@ mod tests {
             column_mappings: std::collections::HashMap::new(),
             resume_job_id: None,
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            delimiter: None,
+            quote: None,
+            escape: None,
+            has_header: None,
             test_pool: Some(pool.clone()),
         };
 
@@ -567,6 +571,10 @@ mod tests {
             column_mappings: std::collections::HashMap::new(),
             resume_job_id: None,
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            delimiter: None,
+            quote: None,
+            escape: None,
+            has_header: None,
             test_pool: Some(pool.clone()),
         };
 
@@ -705,6 +713,10 @@ mod tests {
             column_mappings: std::collections::HashMap::new(),
             resume_job_id: None,
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            delimiter: None,
+            quote: None,
+            escape: None,
+            has_header: None,
             test_pool: Some(pool),
         };
 
@@ -974,6 +986,10 @@ mod tests {
             column_mappings: std::collections::HashMap::new(),
             resume_job_id: None,
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            delimiter: None,
+            quote: None,
+            escape: None,
+            has_header: None,
             test_pool: Some(pool.clone()),
         };
 
@@ -1073,6 +1089,10 @@ mod tests {
             column_mappings: std::collections::HashMap::new(),
             resume_job_id: None,
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            delimiter: None,
+            quote: None,
+            escape: None,
+            has_header: None,
             test_pool: Some(pool.clone()),
         };
 
@@ -1158,6 +1178,10 @@ mod tests {
             column_mappings: std::collections::HashMap::new(),
             resume_job_id: Some(job_id.clone()),
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            delimiter: None,
+            quote: None,
+            escape: None,
+            has_header: None,
             test_pool: Some(pool.clone()),
         };
 
@@ -1275,6 +1299,10 @@ mod tests {
             column_mappings: std::collections::HashMap::new(),
             resume_job_id: None,
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            delimiter: None,
+            quote: None,
+            escape: None,
+            has_header: None,
             test_pool: Some(pool.clone()),
         };
 
@@ -1366,6 +1394,10 @@ mod tests {
             column_mappings: std::collections::HashMap::new(),
             resume_job_id: Some(job_id.clone()),
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            delimiter: None,
+            quote: None,
+            escape: None,
+            has_header: None,
             test_pool: Some(pool.clone()),
         };
 
@@ -1993,5 +2025,110 @@ mod tests {
             "Parameter limit hint should not appear for CHECK constraint errors. Got: {}",
             error_msg
         );
+    }
+
+    #[tokio::test]
+    async fn test_csv_config_all_parameters() {
+        // Comprehensive test for all 4 CSV configuration parameters:
+        // delimiter, quote, escape, and has_header
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create a custom-formatted file:
+        // - Pipe-delimited (|)
+        // - Single quote as quote character (')
+        // - Backslash as escape character (\)
+        // - No header row
+        let csv_path = create_csv_with_content(
+            &temp_dir,
+            "custom_format.txt",
+            &[
+                "1|'Alice\\'s Data'|100\n",
+                "2|'Bob said: \\'Hi\\''|200\n",
+                "3|'Charlie, Jr.'|300\n",
+                "4|'Dave | likes | pipes | '|400",
+            ],
+        )
+        .await;
+
+        let pool = setup_sqlite_table("test_all_params", "col1 TEXT, col2 TEXT, col3 TEXT").await;
+
+        let args = LoadArgs {
+            endpoint: "test".to_string(),
+            region: "us-west-2".to_string(),
+            username: "test".to_string(),
+            source_uri: csv_path,
+            target_table: "test_all_params".to_string(),
+            schema: "public".to_string(),
+            format: Format::Csv,
+            worker_count: 1,
+            chunk_size_bytes: 1000,
+            batch_size: 10,
+            batch_concurrency: 1,
+            create_table_if_missing: false,
+            manifest_dir: None,
+            quiet: true,
+            debug: false,
+            column_mappings: std::collections::HashMap::new(),
+            resume_job_id: None,
+            on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            delimiter: Some("|".to_string()),
+            quote: Some("'".to_string()),
+            escape: Some("\\".to_string()),
+            has_header: Some(false),
+            test_pool: Some(pool.clone()),
+        };
+
+        let result = run_load(args).await.unwrap();
+
+        assert_eq!(result.records_loaded, 4, "Should load all 4 records");
+        assert_eq!(result.records_failed, 0, "Should have no failures");
+        assert_eq!(get_table_count(&pool, "test_all_params").await, 4);
+
+        // Verify data was parsed correctly with all custom parameters
+        let mut conn = pool.acquire().await.unwrap();
+        if let PoolConnection::Sqlite(ref mut sqlite_conn) = conn {
+            // Verify first record - escape character in quoted field
+            let (col1, col2, col3): (String, String, String) =
+                sqlx::query_as("SELECT col1, col2, col3 FROM test_all_params WHERE col1 = '1'")
+                    .fetch_one(&mut **sqlite_conn)
+                    .await
+                    .unwrap();
+            assert_eq!(col1, "1");
+            assert_eq!(col2, "Alice's Data", "Escaped quotes should be unescaped");
+            assert_eq!(col3, "100");
+
+            // Verify second record - multiple escaped quotes
+            let (col2_2,): (String,) =
+                sqlx::query_as("SELECT col2 FROM test_all_params WHERE col1 = '2'")
+                    .fetch_one(&mut **sqlite_conn)
+                    .await
+                    .unwrap();
+            assert_eq!(
+                col2_2, "Bob said: 'Hi'",
+                "Multiple escaped quotes should be handled"
+            );
+
+            // Verify third record - comma inside quoted field (shouldn't be confused with delimiter)
+            let (col2_3,): (String,) =
+                sqlx::query_as("SELECT col2 FROM test_all_params WHERE col1 = '3'")
+                    .fetch_one(&mut **sqlite_conn)
+                    .await
+                    .unwrap();
+            assert_eq!(
+                col2_3, "Charlie, Jr.",
+                "Comma in quoted field should be preserved"
+            );
+
+            // Verify fourth record - delimiter (pipe) inside quoted field
+            let (col2_4,): (String,) =
+                sqlx::query_as("SELECT col2 FROM test_all_params WHERE col1 = '4'")
+                    .fetch_one(&mut **sqlite_conn)
+                    .await
+                    .unwrap();
+            assert_eq!(
+                col2_4, "Dave | likes | pipes | ",
+                "Delimiter (pipe) inside quoted field should be preserved and not treated as field separator"
+            );
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ struct ConnectionArgs {
 }
 
 #[derive(Clone, ClapArgs)]
+#[command(group = clap::ArgGroup::new("delimited").multiple(true))]
 struct SourceArgs {
     /// Path to source data file or S3 URI (local path, s3://bucket/key)
     #[arg(short, long)]
@@ -32,6 +33,23 @@ struct SourceArgs {
     /// File format (csv, tsv, parquet) - auto-detected from extension if not specified
     #[arg(short, long)]
     format: Option<String>,
+
+    // Delimited file options (CSV/TSV only)
+    /// Field delimiter (Default "," for CSV, and "\t" for TSV)
+    #[arg(long, group = "delimited")]
+    delimiter: Option<String>,
+
+    /// Quote character
+    #[arg(long, default_value = "\"", group = "delimited")]
+    quote: Option<String>,
+
+    /// Escape character to use for escaping content
+    #[arg(long, group = "delimited")]
+    escape: Option<String>,
+
+    /// File has no header row
+    #[arg(long, group = "delimited")]
+    no_header: bool,
 }
 
 #[derive(Clone, ClapArgs)]
@@ -74,23 +92,6 @@ struct LoadParams {
     /// Conflict resolution strategy (do-nothing, do-update, error)
     #[arg(long, default_value = "do-nothing")]
     on_conflict: String,
-
-    // Delimited file options (CSV/TSV)
-    /// Field delimiter (Default "," for CSV, and "\t" for TSV)
-    #[arg(long)]
-    delimiter: Option<String>,
-
-    /// Quote character
-    #[arg(long, default_value = "\"")]
-    quote: Option<String>,
-
-    /// Escape character to use for escaping content
-    #[arg(long)]
-    escape: Option<String>,
-
-    /// File has no header row
-    #[arg(long)]
-    no_header: bool,
 }
 
 #[derive(Clone, ClapArgs)]
@@ -243,6 +244,20 @@ async fn run_loader(
     // Parse format
     let format_enum = Format::parse(&format)?;
 
+    // Validate delimited options are only used with CSV/TSV
+    let has_delimited_options = source.delimiter.is_some()
+        || source.quote.is_some()
+        || source.escape.is_some()
+        || source.no_header;
+
+    if has_delimited_options && !format_enum.is_delimited() {
+        return Err(anyhow::anyhow!(
+            "Delimited file options (--delimiter, --quote, --escape, --no-header) \
+             can only be used with CSV or TSV formats, not {}",
+            format
+        ));
+    }
+
     // Handle dry-run mode
     if output.dry_run {
         println!("DRY RUN MODE - No data will be loaded");
@@ -270,7 +285,7 @@ async fn run_loader(
         endpoint: connection.endpoint,
         region,
         username: connection.username,
-        source_uri: source.source_uri,
+        source_uri: source.source_uri.clone(),
         target_table: target.table.clone(),
         schema: target.schema,
         format: format_enum,
@@ -285,10 +300,10 @@ async fn run_loader(
         column_mappings,
         resume_job_id: output.resume_job_id.clone(),
         on_conflict,
-        delimiter: load.delimiter.clone(),
-        quote: load.quote.clone(),
-        escape: load.escape.clone(),
-        has_header: if load.no_header { Some(false) } else { None },
+        delimiter: source.delimiter.clone(),
+        quote: source.quote.clone(),
+        escape: source.escape.clone(),
+        has_header: if source.no_header { Some(false) } else { None },
     };
 
     // Run the load

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,23 @@ struct LoadParams {
     /// Conflict resolution strategy (do-nothing, do-update, error)
     #[arg(long, default_value = "do-nothing")]
     on_conflict: String,
+
+    // Delimited file options (CSV/TSV)
+    /// Field delimiter (Default "," for CSV, and "\t" for TSV)
+    #[arg(long)]
+    delimiter: Option<String>,
+
+    /// Quote character
+    #[arg(long, default_value = "\"")]
+    quote: Option<String>,
+
+    /// Escape character to use for escaping content
+    #[arg(long)]
+    escape: Option<String>,
+
+    /// File has no header row
+    #[arg(long)]
+    no_header: bool,
 }
 
 #[derive(Clone, ClapArgs)]
@@ -268,6 +285,10 @@ async fn run_loader(
         column_mappings,
         resume_job_id: output.resume_job_id.clone(),
         on_conflict,
+        delimiter: load.delimiter.clone(),
+        quote: load.quote.clone(),
+        escape: load.escape.clone(),
+        has_header: if load.no_header { Some(false) } else { None },
     };
 
     // Run the load

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use aurora_dsql_loader::runner::{Format, LoadArgs, OnConflict, run_load};
-use clap::{Args as ClapArgs, Parser, Subcommand};
+use clap::{ArgGroup, Args as ClapArgs, Parser, Subcommand};
 use std::path::PathBuf;
 
 #[derive(Parser, Clone)]
@@ -24,7 +24,7 @@ struct ConnectionArgs {
 }
 
 #[derive(Clone, ClapArgs)]
-#[command(group = clap::ArgGroup::new("delimited").multiple(true))]
+#[command(group = ArgGroup::new("delimited").multiple(true))]
 struct SourceArgs {
     /// Path to source data file or S3 URI (local path, s3://bucket/key)
     #[arg(short, long)]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -53,6 +53,11 @@ impl Format {
             Format::Parquet => crate::formats::Format::Parquet,
         }
     }
+
+    /// Check if this format is a delimited text format (CSV/TSV)
+    pub fn is_delimited(self) -> bool {
+        matches!(self, Format::Csv | Format::Tsv)
+    }
 }
 
 /// Arguments for running a data load operation
@@ -104,13 +109,6 @@ pub struct LoadArgs {
     #[cfg(test)]
     pub test_pool: Option<crate::db::Pool>,
 }
-
-impl LoadArgs {
-    pub fn is_delimited(&self) -> bool {
-        self.format == Format::Csv || self.format == Format::Tsv
-    }
-}
-
 /// Result of a completed data load operation
 #[derive(Debug)]
 pub struct LoadResult {
@@ -293,7 +291,7 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
 
 // Build custom delimited config if provided
 fn maybe_delimited_config(args: &LoadArgs) -> Option<DelimitedConfig> {
-    if args.is_delimited() {
+    if args.format.is_delimited() {
         let mut config = if args.format == Format::Csv {
             DelimitedConfig::csv()
         } else {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -90,9 +90,25 @@ pub struct LoadArgs {
     // Conflict resolution strategy
     pub on_conflict: OnConflict,
 
+    // Delimited file options (CSV/TSV)
+    /// Field delimiter (default: "," for CSV, "\t" for TSV)
+    pub delimiter: Option<String>,
+    /// Quote character (default: "\"")
+    pub quote: Option<String>,
+    /// Escape character for escaping quotes (default: None)
+    pub escape: Option<String>,
+    /// Whether file has a header row (default: true)
+    pub has_header: Option<bool>,
+
     // Test-only: inject a pre-created pool (for SQLite testing)
     #[cfg(test)]
     pub test_pool: Option<crate::db::Pool>,
+}
+
+impl LoadArgs {
+    pub fn is_delimited(&self) -> bool {
+        self.format == Format::Csv || self.format == Format::Tsv
+    }
 }
 
 /// Result of a completed data load operation
@@ -142,6 +158,10 @@ pub struct LoadResult {
 ///     debug: false,
 ///     resume_job_id: None,
 ///     on_conflict: OnConflict::DoNothing,
+///     delimiter: None,
+///     quote: None,
+///     escape: None,
+///     has_header: None,
 /// };
 ///
 /// let result = run_load(args).await?;
@@ -150,6 +170,8 @@ pub struct LoadResult {
 /// # }
 /// ```
 pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
+    let delimited_config = maybe_delimited_config(&args);
+
     // Set up manifest directory (use temp dir if not provided)
     let (mut temp_dir, manifest_dir_path) = if let Some(dir) = args.manifest_dir {
         (None, dir)
@@ -194,13 +216,23 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     // Create reader factory and file reader
     let reader_factory = ReaderFactory::new(&aws_config);
     let file_reader = reader_factory
-        .create_reader(&parsed_uri, args.format.to_internal())
+        .create_reader(
+            &parsed_uri,
+            args.format.to_internal(),
+            delimited_config.clone(),
+        )
         .await?;
 
     // Determine file format config based on format
     let (has_header, file_format) = match args.format {
-        Format::Csv => (true, FileFormat::Csv(DelimitedConfig::csv())),
-        Format::Tsv => (true, FileFormat::Tsv(DelimitedConfig::tsv())),
+        Format::Csv => {
+            let config = delimited_config.unwrap_or_else(DelimitedConfig::csv);
+            (config.has_header, FileFormat::Csv(config))
+        }
+        Format::Tsv => {
+            let config = delimited_config.unwrap_or_else(DelimitedConfig::tsv);
+            (config.has_header, FileFormat::Tsv(config))
+        }
         Format::Parquet => (false, FileFormat::Parquet(ParquetConfig::default())),
     };
 
@@ -257,4 +289,32 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
         duration: result.duration,
         persisted_manifest_dir,
     })
+}
+
+// Build custom delimited config if provided
+fn maybe_delimited_config(args: &LoadArgs) -> Option<DelimitedConfig> {
+    if args.is_delimited() {
+        let mut config = if args.format == Format::Csv {
+            DelimitedConfig::csv()
+        } else {
+            DelimitedConfig::tsv()
+        };
+
+        if let Some(delimiter) = args.delimiter.clone() {
+            config.delimiter = delimiter;
+        }
+        if let Some(quote) = args.quote.clone() {
+            config.quote = quote;
+        }
+        if let Some(escape) = args.escape.clone() {
+            config.escape = Some(escape);
+        }
+        if let Some(has_header) = args.has_header {
+            config.has_header = has_header;
+        }
+
+        Some(config)
+    } else {
+        None
+    }
 }


### PR DESCRIPTION
*Description of changes:*

Added CLI parameters to customize delimiter, quote, escape, and header settings for delimited files (CSV/TSV).

When loading a particular CSV, I noticed that the data was wrongly formatted in the database and was actually even missing. In my case, it was a different escape character and missing  headers. Decided to expose quote and delimiter while at it

### Testing

Apart from the integ test

#### New docs
Only the new ones are shown, and open to naming/docs feedback. Because of creating them with `SourceArgs`, they nicely sit next to the `--format` option
```
$ cargo run -- load --help
```

```
  -f, --format <FORMAT>
          File format (csv, tsv, parquet) - auto-detected from extension if not specified
      --delimiter <DELIMITER>
          Field delimiter (Default "," for CSV, and "\t" for TSV)
      --quote <QUOTE>
          Quote character [default: "]
      --escape <ESCAPE>
          Escape character to use for escaping content
      --no-header
          File has no header row
```

#### CSV from S3

Redacted links. This is the publicly available `keyword.csv` from the IMDB dataset, that I've uploaded to S3

```
$ wc -l keyword.csv
134170 keyword.csv
```

#### Before
```
$ cargo run -- load \             
  --endpoint XXX.dsql.us-west-2.on.aws \
  --source-uri s3://XXX/imdb/keyword.csv \
  --table keyword_before 
```
```
postgres=> select count(*) from keyword_before;
 count
-------
 11204
(1 row)
```
##### After
```
$ cargo run -- load \ 
  --endpoint XXX.dsql.us-west-2.on.aws \
  --source-uri s3://XXX/imdb/keyword.csv \
  --table keyword_new_1 --no-header --escape "\"
```
```
postgres=> select count(*) from keyword_new_1;
 count
--------
 134170
(1 row)
```


> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
