### PR TITLE
chore: switch to dsql connector lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,12 +400,12 @@ dependencies = [
  "arrow",
  "async-stream",
  "async-trait",
+ "aurora-dsql-sqlx-connector",
  "aws-config",
  "aws-credential-types",
  "aws-sdk-dsql",
  "aws-sdk-s3",
  "aws-types",
- "bb8",
  "bytes",
  "chrono",
  "clap",
@@ -429,6 +429,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "aurora-dsql-sqlx-connector"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86556e26a0518c82f81b69988b4cac4b5f856b35184e39e9d2466b2b5501c9f"
+dependencies = [
+ "aws-config",
+ "aws-sdk-dsql",
+ "derive_builder",
+ "regex",
+ "sqlx",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +459,7 @@ checksum = "a0149602eeaf915158e14029ba0c78dedb8c08d554b024d54c8f239aab46511d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
+ "aws-sdk-signin",
  "aws-sdk-sso",
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
@@ -452,15 +470,20 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
+ "base64-simd",
  "bytes",
  "fastrand",
  "hex",
  "http 1.4.0",
+ "p256 0.13.2",
+ "rand 0.8.5",
  "ring",
+ "sha2",
  "time",
  "tokio",
  "tracing",
  "url",
+ "uuid",
  "zeroize",
 ]
 
@@ -582,6 +605,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-signin"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c084bd63941916e1348cb8d9e05ac2e49bdd40a380e9167702683184c6c6be53"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-sso"
 version = "1.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,7 +711,7 @@ dependencies = [
  "hmac",
  "http 0.2.12",
  "http 1.4.0",
- "p256",
+ "p256 0.11.1",
  "percent-encoding",
  "ring",
  "sha2",
@@ -910,6 +955,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,18 +981,6 @@ name = "base64ct"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
-
-[[package]]
-name = "bb8"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457d7ed3f888dfd2c7af56d4975cade43c622f74bdcddfed6d4352f57acc6310"
-dependencies = [
- "futures-util",
- "parking_lot",
- "portable-atomic",
- "tokio",
-]
 
 [[package]]
 name = "bitflags"
@@ -1245,8 +1284,10 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
+ "generic-array",
  "rand_core 0.6.4",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1418,9 +1459,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
  "der 0.6.1",
- "elliptic-curve",
- "rfc6979",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
  "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1438,16 +1493,36 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "crypto-bigint 0.4.9",
  "der 0.6.1",
  "digest",
- "ff",
+ "ff 0.12.1",
  "generic-array",
- "group",
+ "group 0.12.1",
  "pkcs8 0.9.0",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
+ "digest",
+ "ff 0.13.1",
+ "generic-array",
+ "group 0.13.0",
+ "pem-rfc7468",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -1507,6 +1582,16 @@ name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -1685,6 +1770,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1722,7 +1808,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.1",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2544,8 +2641,20 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
  "sha2",
 ]
 
@@ -2715,6 +2824,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve 0.13.8",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2859,6 +2977,16 @@ dependencies = [
  "crypto-bigint 0.4.9",
  "hmac",
  "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -3036,10 +3164,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "der 0.6.1",
  "generic-array",
  "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.10",
+ "generic-array",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ aws-credential-types = "1.2"
 aws-sdk-dsql = "1.40"
 aws-sdk-s3 = "1.112"
 aws-types = "1.3"
-bb8 = "0.9.1"
+aurora-dsql-sqlx-connector = { version = "0.1", features = ["pool"] }
 bytes = "1.11"
 chrono = "0.4"
 clap = { version = "4.5.53", features = ["derive"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,16 +6,6 @@
 use std::time::Duration;
 
 // ============================================================================
-// Connection Pool Configuration
-// ============================================================================
-
-pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(45);
-
-pub const PING_TIMEOUT: Duration = Duration::from_secs(5);
-
-pub const TOKEN_VALIDITY_DURATION: Duration = Duration::from_secs(900); // 15 minutes
-
-// ============================================================================
 // Worker Configuration
 // ============================================================================
 

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -1,36 +1,27 @@
-//! Adapter between bb8 and the sqlx::Postgres driver.
-use anyhow::{Context, Result, anyhow};
+//! Connection pooling with aurora-dsql-sqlx-connector for automatic IAM token refresh.
+use anyhow::Result;
 use async_stream::try_stream;
-use aws_config::{BehaviorVersion, Region, default_provider::credentials::default_provider};
-use aws_credential_types::provider::SharedCredentialsProvider;
-use aws_sdk_dsql::auth_token::{AuthTokenGenerator, Config};
-use aws_types::SdkConfig;
+use aurora_dsql_sqlx_connector::{DsqlConnectOptionsBuilder, pool as dsql_pool};
+use aws_config::Region;
 use derive_builder::Builder;
 use either::Either;
 use futures::TryStreamExt;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
-use sqlx::{ConnectOptions, postgres::PgConnectOptions};
 use sqlx::{Database, Describe, Error, Execute, Executor, postgres::PgConnection};
-use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::RwLock;
-
-use crate::config::{CONNECT_TIMEOUT, PING_TIMEOUT, TOKEN_VALIDITY_DURATION};
-
-pub type Bb8Connection<'a> = bb8::PooledConnection<'a, ConnectionManager>;
 
 /// Inner pool variants
 #[derive(Debug, Clone)]
 enum PoolInner {
-    Postgres(bb8::Pool<ConnectionManager>),
+    Postgres(sqlx::PgPool),
     #[cfg(test)]
     Sqlite(sqlx::SqlitePool),
 }
 
 /// Connection that can be either Postgres or SQLite
 pub enum PoolConnection {
-    Postgres(Bb8Connection<'static>),
+    Postgres(sqlx::pool::PoolConnection<sqlx::Postgres>),
     #[cfg(test)]
     Sqlite(sqlx::pool::PoolConnection<sqlx::Sqlite>),
 }
@@ -68,7 +59,7 @@ pub struct PoolArgs {
     #[builder(setter(into))]
     endpoint: String,
     #[builder(setter(into))]
-    region: Region,
+    region: String,
     #[builder(setter(into))]
     username: String,
     #[builder(default = "100")]
@@ -85,35 +76,32 @@ pub async fn pool(args: PoolArgs) -> anyhow::Result<Pool> {
         min_idle,
         max_pool_size,
     } = args;
-    let connect_options = sqlx::postgres::PgConnectOptions::new()
+
+    let pg_options = sqlx::postgres::PgConnectOptions::new()
         .host(&endpoint)
         .username(&username)
-        .database("postgres")
-        .ssl_mode(sqlx::postgres::PgSslMode::VerifyFull)
-        .to_owned();
+        .database("postgres");
 
-    let auth = DsqlIamDbAuthTokenProvider::new(
-        &endpoint,
-        region.clone(),
-        TokenType::from(username.as_ref()),
-        SharedCredentialsProvider::new(default_provider().await),
-    )
-    .await
-    .context("Failed to set up IAM authentication for DSQL cluster")?;
+    let mut builder = DsqlConnectOptionsBuilder::default();
+    builder.pg_connect_options(pg_options);
+    builder.orm_prefix(Some("dsql-loader".to_string()));
+    builder.region(Some(Region::new(region)));
 
-    let connector = Postgres::create_with_token_refresh(auth, connect_options).await?;
-    let conn_manager = ConnectionManager::new(connector);
+    let config = builder
+        .build()
+        .map_err(|e| anyhow::anyhow!("Failed to build DSQL connection options: {}", e))?;
 
-    let bb8_pool = bb8::Builder::new()
-        .min_idle(min_idle)
-        .max_size(max_pool_size)
-        .max_lifetime(Duration::from_secs(60 * 55))
-        .build(conn_manager)
+    let pool_options = sqlx::postgres::PgPoolOptions::new()
+        .min_connections(min_idle)
+        .max_connections(max_pool_size)
+        .max_lifetime(Duration::from_secs(60 * 55));
+
+    let sqlx_pool = dsql_pool::connect_with(&config, pool_options)
         .await
-        .context("Failed to create connection pool")?;
+        .map_err(|e| anyhow::anyhow!("Failed to create DSQL connection pool: {}", e))?;
 
     Ok(Pool {
-        inner: PoolInner::Postgres(bb8_pool),
+        inner: PoolInner::Postgres(sqlx_pool),
     })
 }
 
@@ -137,10 +125,7 @@ impl Pool {
     pub async fn acquire(&self) -> Result<PoolConnection, sqlx::Error> {
         match &self.inner {
             PoolInner::Postgres(pool) => {
-                let conn = pool.get_owned().await.map_err(|e| match e {
-                    bb8::RunError::User(e) => e,
-                    bb8::RunError::TimedOut => sqlx::Error::PoolTimedOut,
-                })?;
+                let conn = pool.acquire().await?;
                 Ok(PoolConnection::Postgres(conn))
             }
             #[cfg(test)]
@@ -155,10 +140,7 @@ impl Pool {
     pub async fn execute_query(&self, sql: &str) -> Result<(), sqlx::Error> {
         match &self.inner {
             PoolInner::Postgres(pool) => {
-                let mut conn = pool.get().await.map_err(|e| match e {
-                    bb8::RunError::User(e) => e,
-                    bb8::RunError::TimedOut => sqlx::Error::PoolTimedOut,
-                })?;
+                let mut conn = pool.acquire().await?;
                 sqlx::query(sql).execute(&mut *conn).await?;
                 Ok(())
             }
@@ -187,10 +169,7 @@ impl Pool {
     {
         match &self.inner {
             PoolInner::Postgres(pool) => {
-                let mut conn = pool.get().await.map_err(|e| match e {
-                    bb8::RunError::User(e) => e,
-                    bb8::RunError::TimedOut => sqlx::Error::PoolTimedOut,
-                })?;
+                let mut conn = pool.acquire().await?;
                 let mut query = sqlx::query_as::<_, T>(sql);
                 for value in bind_values {
                     query = query.bind(*value);
@@ -256,10 +235,7 @@ impl Pool {
     ) -> Result<bool, sqlx::Error> {
         match &self.inner {
             PoolInner::Postgres(pool) => {
-                let mut conn = pool.get().await.map_err(|e| match e {
-                    bb8::RunError::User(e) => e,
-                    bb8::RunError::TimedOut => sqlx::Error::PoolTimedOut,
-                })?;
+                let mut conn = pool.acquire().await?;
 
                 // Check for primary key or unique constraints in pg_constraint
                 let constraint_sql = r#"
@@ -341,10 +317,7 @@ impl Pool {
     ) -> Result<Vec<String>, sqlx::Error> {
         match &self.inner {
             PoolInner::Postgres(pool) => {
-                let mut conn = pool.get().await.map_err(|e| match e {
-                    bb8::RunError::User(e) => e,
-                    bb8::RunError::TimedOut => sqlx::Error::PoolTimedOut,
-                })?;
+                let mut conn = pool.acquire().await?;
 
                 // Query for constraint columns, prioritizing primary key over unique constraints
                 // Returns all columns from the first matching constraint
@@ -422,42 +395,6 @@ impl Pool {
     }
 }
 
-// Wrap `Arc<connector::Postgres>` so that we can implement the bb8::ManageConnection trait.
-pub struct ConnectionManager {
-    connector: Arc<Postgres>,
-}
-
-impl ConnectionManager {
-    /// Create a new `ConnectionManager` with the specified connect options.
-    pub fn new(connector: Arc<Postgres>) -> Self {
-        Self { connector }
-    }
-}
-
-impl bb8::ManageConnection for ConnectionManager {
-    type Connection = PgConnection;
-    type Error = sqlx::Error;
-
-    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
-        self.connector.connect().await
-    }
-
-    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
-        tokio::time::timeout(PING_TIMEOUT, sqlx::Connection::ping(conn))
-            .await
-            // Convert tokio timeouts into sqlx pool timeouts. bb8 will retry a different connection on ping failure.
-            .map_err(|_| sqlx::Error::PoolTimedOut)
-            // Make sure that we also look at the actual ping result
-            .and_then(|result| result)?;
-        Ok(())
-    }
-
-    fn has_broken(&self, _conn: &mut Self::Connection) -> bool {
-        // sqlx::PgConnection provides no non-async way to check for closed/broken connections.
-        false
-    }
-}
-
 impl Executor<'_> for &'_ Pool {
     type Database = sqlx::Postgres;
 
@@ -475,10 +412,7 @@ impl Executor<'_> for &'_ Pool {
         };
 
         Box::pin(try_stream! {
-            let mut conn = pool.get().await.map_err(|e| match e {
-                bb8::RunError::User(e) => e,
-                bb8::RunError::TimedOut => sqlx::Error::PoolTimedOut,
-            })?;
+            let mut conn = pool.acquire().await?;
             let mut stream = conn.fetch_many(query);
             while let Some(item) = stream.try_next().await? {
                 yield item;
@@ -500,10 +434,7 @@ impl Executor<'_> for &'_ Pool {
         };
 
         Box::pin(async move {
-            let mut conn = pool.get().await.map_err(|e| match e {
-                bb8::RunError::User(e) => e,
-                bb8::RunError::TimedOut => sqlx::Error::PoolTimedOut,
-            })?;
+            let mut conn = pool.acquire().await?;
             conn.fetch_optional(query).await
         })
     }
@@ -520,10 +451,7 @@ impl Executor<'_> for &'_ Pool {
         };
 
         Box::pin(async move {
-            let mut conn = pool.get().await.map_err(|e| match e {
-                bb8::RunError::User(e) => e,
-                bb8::RunError::TimedOut => sqlx::Error::PoolTimedOut,
-            })?;
+            let mut conn = pool.acquire().await?;
             conn.prepare_with(sql, parameters).await
         })
     }
@@ -540,147 +468,8 @@ impl Executor<'_> for &'_ Pool {
         };
 
         Box::pin(async move {
-            let mut conn = pool.get().await.map_err(|e| match e {
-                bb8::RunError::User(e) => e,
-                bb8::RunError::TimedOut => sqlx::Error::PoolTimedOut,
-            })?;
+            let mut conn = pool.acquire().await?;
             conn.describe(sql).await
         })
-    }
-}
-
-pub struct Postgres {
-    iam_auth_token_provider: DsqlIamDbAuthTokenProvider,
-    connect_options: RwLock<Arc<PgConnectOptions>>,
-}
-
-impl Postgres {
-    // NOTE: Ideally, we'd just generate a fresh token on every connection.
-    // Unfortunately, `sqlx::PgConnectOptions` provides no way to update only
-    // the password on every connection. The alternative that we use here uses
-    // an `RwLock` to periodically update the connection options. One
-    // alternative would be to just clone the connect options on each connection
-    // and update the password. However, this seems expensive because connect
-    // options include things like parsed SSL certs.
-    pub async fn create_with_token_refresh(
-        iam_auth_token_provider: DsqlIamDbAuthTokenProvider,
-        connect_options: PgConnectOptions,
-    ) -> Result<Arc<Self>> {
-        let token = iam_auth_token_provider.generate_token().await?;
-        let base_connect_options = connect_options.password(&token);
-        let connector = Arc::new(Self {
-            iam_auth_token_provider,
-            connect_options: RwLock::new(Arc::new(base_connect_options.clone())),
-        });
-        connector
-            .clone()
-            .spawn_token_refresh(base_connect_options.get_host().to_string());
-        Ok(connector)
-    }
-
-    async fn connect(&self) -> Result<sqlx::postgres::PgConnection, sqlx::Error> {
-        let connect_options = self
-            .connect_options
-            .read()
-            .await
-            // Clone the Arc so we don't hold the RwLockReadGuard across an async await point
-            .clone();
-
-        let conn = tokio::time::timeout(CONNECT_TIMEOUT, connect_options.connect())
-            .await
-            .map_err(|_| sqlx::Error::PoolTimedOut)??;
-
-        Ok(conn)
-    }
-
-    fn spawn_token_refresh(self: Arc<Postgres>, endpoint: String) {
-        tracing::info!(endpoint, "spawn token refresh task");
-
-        tokio::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(60));
-            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-
-            tracing::info!(interval = ?interval.period(), "token refresh interval",);
-
-            loop {
-                interval.tick().await;
-                tracing::debug!("refreshing credentials");
-
-                let _ = self.update_token().await;
-            }
-        });
-    }
-
-    async fn update_token(&self) -> Result<()> {
-        let token = self
-            .iam_auth_token_provider
-            .generate_token()
-            .await
-            .map_err(|err| anyhow!("Failed to generate token: {err}"))?;
-        let base = self.connect_options.read().await.clone();
-        let base = Arc::unwrap_or_clone(base);
-        let connect_options = base.password(token.as_str());
-        let mut guard = self.connect_options.write().await;
-        *guard = Arc::new(connect_options);
-        Ok(())
-    }
-}
-
-pub struct DsqlIamDbAuthTokenProvider {
-    sdk_config: SdkConfig,
-    signer: AuthTokenGenerator,
-    token_type: TokenType,
-}
-
-pub enum TokenType {
-    Admin,
-    Regular,
-}
-
-impl From<&str> for TokenType {
-    fn from(value: &str) -> Self {
-        match value.to_ascii_lowercase().trim_ascii() {
-            "admin" => Self::Admin,
-            _ => Self::Regular,
-        }
-    }
-}
-
-impl DsqlIamDbAuthTokenProvider {
-    pub async fn new(
-        hostname: &str,
-        region: Region,
-        token_type: TokenType,
-        credential_provider: SharedCredentialsProvider,
-    ) -> anyhow::Result<Self> {
-        Ok(Self {
-            sdk_config: aws_config::defaults(BehaviorVersion::latest())
-                .credentials_provider(credential_provider.clone())
-                .region(region.clone())
-                .load()
-                .await,
-            signer: AuthTokenGenerator::new(
-                Config::builder()
-                    .expires_in(TOKEN_VALIDITY_DURATION.as_secs())
-                    .hostname(hostname)
-                    .region(region)
-                    .build()
-                    .map_err(|err| anyhow!(err))?,
-            ),
-            token_type,
-        })
-    }
-
-    async fn generate_token(&self) -> anyhow::Result<String> {
-        match self.token_type {
-            TokenType::Admin => {
-                self.signer
-                    .db_connect_admin_auth_token(&self.sdk_config)
-                    .await
-            }
-            TokenType::Regular => self.signer.db_connect_auth_token(&self.sdk_config).await,
-        }
-        .map(|token| token.to_string())
-        .map_err(|err| anyhow!(err))
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -165,7 +165,7 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
         test_pool
     } else {
         let pool_args = PoolArgsBuilder::default()
-            .region(Region::new(args.region.clone()))
+            .region(&args.region)
             .endpoint(&args.endpoint)
             .username(&args.username)
             .build()?;
@@ -175,7 +175,7 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     #[cfg(not(test))]
     let pool = {
         let pool_args = PoolArgsBuilder::default()
-            .region(Region::new(args.region.clone()))
+            .region(&args.region)
             .endpoint(&args.endpoint)
             .username(&args.username)
             .build()?;


### PR DESCRIPTION
Now the sqlx connector lib is released, we should use it! This swaps over to using that pooling instead of rolling our own with bb8.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
