### PR TITLE
fix: use checked_div to satisfy clippy manual_checked_ops lint

### DIFF
--- a/src/coordination/worker.rs
+++ b/src/coordination/worker.rs
@@ -737,12 +737,10 @@ impl Worker {
 
         // PostgreSQL/DSQL limit: 65,535, SQLite limit: 32,766
         // Suggest a batch size that keeps us well under both limits
-        let suggested_batch_size = if num_columns > 0 {
+        let suggested_batch_size = match 20000usize.checked_div(num_columns) {
             // Target ~20,000 parameters to stay safely under both limits
-            let safe_batch = 20000 / num_columns;
-            safe_batch.max(1).min(batch_size - 1)
-        } else {
-            batch_size / 2
+            Some(safe_batch) => safe_batch.max(1).min(batch_size - 1),
+            None => batch_size / 2,
         };
 
         format!(


### PR DESCRIPTION
## Summary
- Rust 1.95's `clippy::manual-checked-ops` lint failed CI on `main` ([run](https://github.com/aws-samples/aurora-dsql-loader/actions/runs/24700329708/job/72241974786)).
- Replaces the manual `if num_columns > 0 { 20000 / num_columns }` pattern in `get_parameter_limit_hint` with `checked_div`, per clippy's suggestion.

## Test plan
- [x] CI clippy job passes
- [x] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)