### PR TITLE
Add --exclude-columns flag to skip DB-default columns from INSERT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "hex",
  "indicatif",
  "parquet",
+ "proptest",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -981,6 +982,21 @@ name = "base64ct"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -2842,6 +2858,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2913,6 +2954,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3126,6 +3176,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3966,6 +4028,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4069,6 +4137,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ strip = true
 lto = true
 
 [dev-dependencies]
+proptest = "1"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ aurora-dsql-loader load \
   --dry-run
 ```
 
+**Use DB-side defaults (e.g. server-generated UUIDs):**
+```bash
+aurora-dsql-loader load \
+  --endpoint your-cluster.dsql.us-east-1.on.aws \
+  --source-uri data.csv \
+  --table my_table \
+  --exclude-columns pk_id,created_at
+```
+Listed columns are dropped from the INSERT so DSQL applies the column's `DEFAULT` expression (e.g. `gen_random_uuid()`, `CURRENT_TIMESTAMP`). Source records must still contain these columns in their original positions.
+
 ## Key Features
 
 - **Fast**: Parallel loading with configurable workers

--- a/src/coordination/coordinator.rs
+++ b/src/coordination/coordinator.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use chrono::Utc;
 use derive_builder::Builder;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
@@ -17,6 +18,93 @@ use crate::db::{Pool, SchemaInferrer};
 use crate::formats::FileReader;
 use crate::formats::reader::{Chunk, FileMetadata};
 use crate::telemetry::{ProgressStats, TelemetryEvent};
+
+/// Validate that every excluded name exists in the schema and that at least
+/// one column would remain after exclusion.
+fn validate_excluded_columns(schema: &Schema, exclude: &[String]) -> Result<()> {
+    for name in exclude {
+        if !schema.columns.iter().any(|c| &c.name == name) {
+            let available: Vec<&str> = schema.columns.iter().map(|c| c.name.as_str()).collect();
+            return Err(anyhow::anyhow!(
+                "Column '{}' not found in table schema. Available columns: {:?}",
+                name,
+                available
+            ));
+        }
+    }
+    if exclude.len() >= schema.columns.len() {
+        return Err(anyhow::anyhow!(
+            "Cannot exclude all columns - at least one column must remain for insertion"
+        ));
+    }
+    Ok(())
+}
+
+/// Reject any column name present in both --exclude-columns and --column-map.
+fn validate_no_exclude_rename_conflict(
+    exclude: &[String],
+    mappings: &HashMap<String, String>,
+) -> Result<()> {
+    for name in exclude {
+        if mappings.contains_key(name) {
+            return Err(anyhow::anyhow!(
+                "Column '{}' cannot be both excluded and renamed",
+                name
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Return the indices of excluded columns, walking the schema in its original
+/// order. Output is naturally sorted because `enumerate` yields strictly
+/// increasing indices.
+fn compute_excluded_positions(schema: &Schema, exclude: &[String]) -> Vec<usize> {
+    schema
+        .columns
+        .iter()
+        .enumerate()
+        .filter_map(|(i, c)| exclude.contains(&c.name).then_some(i))
+        .collect()
+}
+
+/// Remove excluded columns from the schema in place, preserving original column order.
+fn filter_schema(schema: &mut Schema, exclude: &[String]) {
+    schema.columns.retain(|c| !exclude.contains(&c.name));
+}
+
+/// Error if ALL conflict columns are excluded under do-update (ON CONFLICT can never match),
+/// warn if SOME are excluded.
+fn validate_conflict_columns_not_all_excluded(
+    exclude: &[String],
+    conflict_columns: &[String],
+    on_conflict: OnConflict,
+) -> Result<()> {
+    if on_conflict != OnConflict::DoUpdate || conflict_columns.is_empty() {
+        return Ok(());
+    }
+
+    let excluded_conflict: Vec<&String> = conflict_columns
+        .iter()
+        .filter(|c| exclude.contains(c))
+        .collect();
+
+    if excluded_conflict.len() == conflict_columns.len() {
+        return Err(anyhow::anyhow!(
+            "All conflict columns are excluded. ON CONFLICT can never match — \
+             use --on-conflict do-nothing or remove conflicting columns from --exclude-columns"
+        ));
+    }
+
+    if !excluded_conflict.is_empty() {
+        warn!(
+            "Some conflict columns are excluded: {:?}. ON CONFLICT may not behave as expected.",
+            excluded_conflict
+        );
+    }
+
+    Ok(())
+}
 
 /// Maximum bytes to read for schema inference
 ///
@@ -42,7 +130,7 @@ pub struct LoadConfig {
     create_table_if_missing: bool,
     file_format: FileFormat,
     #[builder(default)]
-    column_mappings: std::collections::HashMap<String, String>,
+    column_mappings: HashMap<String, String>,
     quiet: bool,
     #[builder(default)]
     debug: bool,
@@ -50,6 +138,8 @@ pub struct LoadConfig {
     resume_job_id: Option<String>,
     #[builder(default)]
     on_conflict: OnConflict,
+    #[builder(default)]
+    exclude_columns: Vec<String>,
 }
 
 /// Result of a completed data load operation
@@ -267,7 +357,7 @@ impl Coordinator {
     /// Apply column mappings to schema if provided
     fn apply_column_mappings(
         schema: &mut Option<Schema>,
-        column_mappings: &std::collections::HashMap<String, String>,
+        column_mappings: &HashMap<String, String>,
     ) {
         if !column_mappings.is_empty()
             && let Some(s) = schema
@@ -289,11 +379,39 @@ impl Coordinator {
         let job_id = Uuid::new_v4().to_string();
         info!("Starting load job: {job_id}");
 
+        // Reject --exclude-columns combined with --if-not-exists before any I/O: the loader
+        // would otherwise generate a CREATE TABLE that silently omits the excluded columns
+        // entirely, producing a broken table with no DEFAULT to fall back to.
+        if !config.exclude_columns.is_empty() && config.create_table_if_missing {
+            return Err(anyhow::anyhow!(
+                "--exclude-columns is not supported with --if-not-exists. \
+                 The table must already exist with DEFAULT expressions on the excluded columns \
+                 (e.g. `pk_id UUID DEFAULT gen_random_uuid()`)."
+            ));
+        }
+
         validate_schema_exists(&self.pool, &config.schema).await?;
 
         let (file_metadata, chunks) = self.create_file_chunks(config.chunk_size_bytes).await?;
 
         let mut schema = self.resolve_table_schema(config, &chunks).await?;
+
+        // Apply --exclude-columns before renames. Produces the effective schema
+        // that downstream code uses for INSERT generation.
+        let excluded_positions = if !config.exclude_columns.is_empty() {
+            let s = schema.as_mut().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Internal error: table schema is missing while --exclude-columns is active"
+                )
+            })?;
+            validate_excluded_columns(s, &config.exclude_columns)?;
+            validate_no_exclude_rename_conflict(&config.exclude_columns, &config.column_mappings)?;
+            let positions = compute_excluded_positions(s, &config.exclude_columns);
+            filter_schema(s, &config.exclude_columns);
+            positions
+        } else {
+            Vec::new()
+        };
 
         Self::apply_column_mappings(&mut schema, &config.column_mappings);
 
@@ -306,6 +424,7 @@ impl Coordinator {
             &chunks,
             schema,
             table_created,
+            excluded_positions,
         )
         .await?;
 
@@ -328,6 +447,13 @@ impl Coordinator {
             .context("Failed to read manifest for resume")?;
 
         self.verify_resume_compatibility(&manifest, config).await?;
+
+        if !manifest.table.excluded_columns.is_empty() {
+            info!(
+                "Resuming with excluded columns from manifest: {:?}",
+                manifest.table.excluded_columns
+            );
+        }
 
         info!("Cleaning up incomplete claims...");
         self.manifest_storage.cleanup_old_claims(resume_id).await?;
@@ -403,6 +529,74 @@ impl Coordinator {
             ));
         }
 
+        // Manifest integrity: the two exclusion fields are written together and must
+        // stay in lock-step (length parity), and every position must be strictly
+        // increasing (implying unique + sorted) and satisfy
+        // `p < schema.columns.len() + excluded_positions.len()` (the reconstructed
+        // original arity). A mismatch indicates a corrupted or hand-edited manifest
+        // and would cause silent data misalignment at worker field-mapping time.
+        if manifest.table.excluded_columns.len() != manifest.table.excluded_positions.len() {
+            return Err(anyhow::anyhow!(
+                "Cannot resume: manifest exclusion fields disagree \
+                 (excluded_columns.len() = {}, excluded_positions.len() = {})",
+                manifest.table.excluded_columns.len(),
+                manifest.table.excluded_positions.len()
+            ));
+        }
+        if !manifest.table.excluded_positions.is_empty() {
+            let schema = manifest.table.schema.as_ref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Cannot resume: manifest has excluded_positions but no stored schema"
+                )
+            })?;
+            let full_len = schema.columns.len() + manifest.table.excluded_positions.len();
+            let mut prev: Option<usize> = None;
+            for &p in &manifest.table.excluded_positions {
+                if p >= full_len {
+                    return Err(anyhow::anyhow!(
+                        "Cannot resume: manifest excluded_position {} is out of range \
+                         for original schema size {}",
+                        p,
+                        full_len
+                    ));
+                }
+                if let Some(prev) = prev
+                    && p <= prev
+                {
+                    return Err(anyhow::anyhow!(
+                        "Cannot resume: manifest excluded_positions are not strictly \
+                         increasing (saw {} after {})",
+                        p,
+                        prev
+                    ));
+                }
+                prev = Some(p);
+            }
+        }
+
+        // --exclude-columns on resume must match the original job's exclusion set;
+        // the manifest is authoritative and silently dropping the flag would hide bugs.
+        // Compare as sets (sorted) because the manifest stores the list in schema order
+        // while the user-passed list is in CLI order - semantically equivalent lists
+        // should not trip the check.
+        if !config.exclude_columns.is_empty() {
+            let mut requested = config.exclude_columns.clone();
+            let mut stored = manifest.table.excluded_columns.clone();
+            requested.sort();
+            stored.sort();
+            if requested != stored {
+                return Err(anyhow::anyhow!(
+                    "Cannot resume: --exclude-columns mismatch\n\
+                     Manifest excluded_columns: {:?}\n\
+                     Requested exclude_columns: {:?}\n\
+                     To resume an existing job, either omit --exclude-columns (the manifest value is used) \
+                     or pass the same list as the original job.",
+                    manifest.table.excluded_columns,
+                    config.exclude_columns
+                ));
+            }
+        }
+
         Ok(())
     }
 
@@ -448,6 +642,7 @@ impl Coordinator {
     }
 
     /// Create and write the manifest file
+    #[allow(clippy::too_many_arguments)]
     async fn create_and_write_manifest(
         &self,
         job_id: &str,
@@ -456,6 +651,7 @@ impl Coordinator {
         chunks: &[Chunk],
         schema: Option<Schema>,
         table_created: bool,
+        excluded_positions: Vec<usize>,
     ) -> Result<()> {
         // Detect unique constraints and get conflict columns if needed
         info!("Checking for unique constraints on table...");
@@ -488,6 +684,14 @@ impl Coordinator {
             );
         }
 
+        // Conflict-column validation must run after `conflict_columns` is fetched
+        // from the database (it requires a DB query).
+        validate_conflict_columns_not_all_excluded(
+            &config.exclude_columns,
+            &conflict_columns,
+            config.on_conflict,
+        )?;
+
         // Build manifest
         let chunk_infos: Vec<ChunkInfo> = chunks
             .iter()
@@ -508,7 +712,21 @@ impl Coordinator {
             has_unique_constraints,
             on_conflict: config.on_conflict,
             conflict_columns,
+            excluded_columns: config.exclude_columns.clone(),
+            excluded_positions,
         };
+        // TableInfo invariant: the two exclusion vectors are written together and
+        // must stay in lock-step. Promoted from debug_assert to a real guard so a
+        // release-mode regression can't ship a corrupted manifest that the resume
+        // path would then reject only on the next run.
+        if table.excluded_columns.len() != table.excluded_positions.len() {
+            return Err(anyhow::anyhow!(
+                "Internal error: TableInfo exclusion fields disagree \
+                 (excluded_columns.len() = {}, excluded_positions.len() = {})",
+                table.excluded_columns.len(),
+                table.excluded_positions.len()
+            ));
+        }
 
         let manifest = ManifestFile {
             job_id: job_id.to_string(),
@@ -698,5 +916,215 @@ impl Coordinator {
             duration,
             chunk_results,
         })
+    }
+}
+
+#[cfg(test)]
+mod exclusion_tests {
+    use super::*;
+    use crate::db::schema::{Column, Schema, SqlType};
+    use std::collections::HashSet;
+
+    fn mk_schema(names: &[&str]) -> Schema {
+        Schema {
+            columns: names
+                .iter()
+                .map(|n| Column {
+                    name: n.to_string(),
+                    sql_type: SqlType::Text,
+                    nullable: true,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn validate_excluded_columns_ok() {
+        let s = mk_schema(&["id", "name", "email"]);
+        validate_excluded_columns(&s, &["id".to_string()]).unwrap();
+    }
+
+    #[test]
+    fn validate_excluded_columns_unknown_name() {
+        let s = mk_schema(&["id", "name"]);
+        let err = validate_excluded_columns(&s, &["nope".to_string()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Column 'nope' not found"));
+        assert!(err.contains("\"id\""));
+    }
+
+    #[test]
+    fn validate_excluded_columns_all_excluded_errors() {
+        let s = mk_schema(&["id", "name"]);
+        let err = validate_excluded_columns(&s, &["id".to_string(), "name".to_string()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Cannot exclude all columns"));
+    }
+
+    #[test]
+    fn validate_no_exclude_rename_conflict_detects_overlap() {
+        let mut map = HashMap::new();
+        map.insert("id".to_string(), "new_id".to_string());
+        let err = validate_no_exclude_rename_conflict(&["id".to_string()], &map)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Column 'id' cannot be both excluded and renamed"));
+    }
+
+    #[test]
+    fn validate_no_exclude_rename_conflict_disjoint_ok() {
+        let mut map = HashMap::new();
+        map.insert("name".to_string(), "full_name".to_string());
+        validate_no_exclude_rename_conflict(&["id".to_string()], &map).unwrap();
+    }
+
+    #[test]
+    fn exclude_then_rename_ordering_applies_rename_to_remaining_columns() {
+        // Design invariant: exclusion uses ORIGINAL schema names; rename is applied
+        // to the effective schema (post-exclusion). This verifies the compose:
+        //   filter(pk_id) then rename(name -> full_name) == [full_name, email]
+        let mut schema = Some(mk_schema(&["pk_id", "name", "email"]));
+
+        // Step 1: exclusion (matches setup_new_job order)
+        let exclude = vec!["pk_id".to_string()];
+        let s = schema.as_mut().unwrap();
+        validate_excluded_columns(s, &exclude).unwrap();
+        let positions = compute_excluded_positions(s, &exclude);
+        filter_schema(s, &exclude);
+        assert_eq!(positions, vec![0]);
+
+        // Step 2: rename
+        let mut mappings = HashMap::new();
+        mappings.insert("name".to_string(), "full_name".to_string());
+        Coordinator::apply_column_mappings(&mut schema, &mappings);
+
+        let names: Vec<&str> = schema
+            .as_ref()
+            .unwrap()
+            .columns
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["full_name", "email"]);
+    }
+
+    #[test]
+    fn compute_excluded_positions_returns_sorted_indices_in_schema_order() {
+        let s = mk_schema(&["id", "name", "email", "created_at"]);
+        let positions =
+            compute_excluded_positions(&s, &["created_at".to_string(), "id".to_string()]);
+        assert_eq!(positions, vec![0, 3]);
+    }
+
+    #[test]
+    fn filter_schema_preserves_order_and_types() {
+        let mut s = mk_schema(&["id", "name", "email", "created_at"]);
+        filter_schema(&mut s, &["id".to_string(), "created_at".to_string()]);
+        let names: Vec<&str> = s.columns.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["name", "email"]);
+    }
+
+    #[test]
+    fn validate_conflict_columns_all_excluded_do_update_errors() {
+        let err = validate_conflict_columns_not_all_excluded(
+            &["pk_id".to_string()],
+            &["pk_id".to_string()],
+            OnConflict::DoUpdate,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("All conflict columns are excluded"));
+        assert!(err.contains("--on-conflict do-nothing"));
+    }
+
+    #[test]
+    fn validate_conflict_columns_some_excluded_do_update_warns_but_ok() {
+        // Warn path: should succeed
+        validate_conflict_columns_not_all_excluded(
+            &["a".to_string()],
+            &["a".to_string(), "b".to_string()],
+            OnConflict::DoUpdate,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn validate_conflict_columns_none_excluded_do_update_ok() {
+        validate_conflict_columns_not_all_excluded(
+            &["x".to_string()],
+            &["a".to_string(), "b".to_string()],
+            OnConflict::DoUpdate,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn validate_conflict_columns_all_excluded_do_nothing_skipped() {
+        // do-nothing: validation should be a no-op even when all conflict cols excluded
+        validate_conflict_columns_not_all_excluded(
+            &["pk_id".to_string()],
+            &["pk_id".to_string()],
+            OnConflict::DoNothing,
+        )
+        .unwrap();
+    }
+
+    // Feature: loader-column-exclusion, Property 2: Schema filtering preserves order
+    proptest::proptest! {
+        #[test]
+        fn prop_filter_schema_preserves_non_excluded_in_order(
+            names in proptest::collection::vec("[a-z][a-z0-9]{0,7}", 2..10),
+            // which indices to exclude (by position) — always leave at least one
+            exclude_mask in proptest::collection::vec(proptest::bool::ANY, 2..10),
+        ) {
+            // Dedup names (schema columns are unique)
+            let mut seen = HashSet::new();
+            let unique_names: Vec<String> = names.into_iter().filter(|n| seen.insert(n.clone())).collect();
+            proptest::prop_assume!(unique_names.len() >= 2);
+
+            // Build exclusion list; ensure we don't exclude everything
+            let n = unique_names.len();
+            let mask: Vec<bool> = exclude_mask.into_iter().take(n).chain(std::iter::repeat(false)).take(n).collect();
+            let exclude: Vec<String> = unique_names.iter().zip(&mask).filter_map(|(name, &ex)| if ex { Some(name.clone()) } else { None }).collect();
+            proptest::prop_assume!(!exclude.is_empty() && exclude.len() < n);
+
+            let mut schema = Schema {
+                columns: unique_names.iter().map(|n| Column {
+                    name: n.clone(),
+                    sql_type: SqlType::Text,
+                    nullable: true,
+                }).collect(),
+            };
+            filter_schema(&mut schema, &exclude);
+
+            // Expected: non-excluded names in original order
+            let expected: Vec<String> = unique_names.iter().filter(|n| !exclude.contains(n)).cloned().collect();
+            let actual: Vec<String> = schema.columns.iter().map(|c| c.name.clone()).collect();
+            proptest::prop_assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn prop_validate_excluded_columns_rejects_unknown(
+            names in proptest::collection::vec("[a-z][a-z0-9]{0,7}", 2..8),
+            bogus in "[A-Z][A-Z0-9]{0,7}",
+        ) {
+            // `bogus` starts uppercase so it can't collide with lowercase `names`
+            let mut seen = HashSet::new();
+            let unique_names: Vec<String> = names.into_iter().filter(|n| seen.insert(n.clone())).collect();
+            proptest::prop_assume!(unique_names.len() >= 2);
+
+            let schema = Schema {
+                columns: unique_names.iter().map(|n| Column {
+                    name: n.clone(),
+                    sql_type: SqlType::Text,
+                    nullable: true,
+                }).collect(),
+            };
+
+            let result = validate_excluded_columns(&schema, &[bogus]);
+            proptest::prop_assert!(result.is_err());
+        }
     }
 }

--- a/src/coordination/manifest.rs
+++ b/src/coordination/manifest.rs
@@ -122,6 +122,15 @@ pub struct TableInfo {
     /// Columns involved in unique constraints (for ON CONFLICT targeting)
     #[serde(default)]
     pub conflict_columns: Vec<String>,
+    /// Original column names excluded from INSERT. Used for logging and as the
+    /// authoritative set on resume (compared against a user-supplied
+    /// --exclude-columns). Invariant: `excluded_columns.len() == excluded_positions.len()`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub excluded_columns: Vec<String>,
+    /// Zero-based indices of excluded columns in the schema captured at manifest-write time.
+    /// Workers use these positions to skip fields in source records.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub excluded_positions: Vec<usize>,
 }
 
 /// The manifest file structure written by the coordinator
@@ -172,7 +181,11 @@ pub struct ChunkResultFile {
     pub errors: Vec<ErrorRecord>,
 }
 
-/// Record of an error that occurred during processing
+/// Record of an error that occurred during processing.
+///
+/// `line_number == 0` is a sentinel indicating a chunk-level error not tied to
+/// a specific source-file line (e.g. `parse_error` and `field_count_mismatch`
+/// are aggregated across the chunk).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrorRecord {
     pub line_number: u64,
@@ -509,6 +522,65 @@ mod tests {
     }
 
     #[test]
+    fn test_table_info_backward_compat_no_exclusion_fields() {
+        let json = r#"{
+            "name": "t",
+            "schema_name": "public",
+            "was_created": false,
+            "has_unique_constraints": false,
+            "on_conflict": "do-nothing",
+            "conflict_columns": []
+        }"#;
+        let table: TableInfo = serde_json::from_str(json).unwrap();
+        assert!(table.excluded_columns.is_empty());
+        assert!(table.excluded_positions.is_empty());
+    }
+
+    #[test]
+    fn test_table_info_excluded_fields_roundtrip() {
+        let table = TableInfo {
+            name: "users".to_string(),
+            schema_name: "public".to_string(),
+            schema: None,
+            was_created: false,
+            has_unique_constraints: false,
+            on_conflict: OnConflict::DoNothing,
+            conflict_columns: Vec::new(),
+            excluded_columns: vec!["id".to_string(), "created_at".to_string()],
+            excluded_positions: vec![0, 3],
+        };
+        let json = serde_json::to_string(&table).unwrap();
+        let round: TableInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(round.excluded_columns, table.excluded_columns);
+        assert_eq!(round.excluded_positions, table.excluded_positions);
+    }
+
+    // Feature: loader-column-exclusion, Property 4: Manifest serialization round-trip
+    proptest::proptest! {
+        #[test]
+        fn prop_table_info_exclusion_roundtrip(
+            excluded in proptest::collection::vec("[a-zA-Z_][a-zA-Z0-9_]*", 0..8),
+            positions in proptest::collection::vec(0usize..64, 0..8),
+        ) {
+            let table = TableInfo {
+                name: "t".to_string(),
+                schema_name: "public".to_string(),
+                schema: None,
+                was_created: false,
+                has_unique_constraints: false,
+                on_conflict: OnConflict::DoNothing,
+                conflict_columns: Vec::new(),
+                excluded_columns: excluded.clone(),
+                excluded_positions: positions.clone(),
+            };
+            let json = serde_json::to_string(&table).unwrap();
+            let round: TableInfo = serde_json::from_str(&json).unwrap();
+            proptest::prop_assert_eq!(round.excluded_columns, excluded);
+            proptest::prop_assert_eq!(round.excluded_positions, positions);
+        }
+    }
+
+    #[test]
     fn test_manifest_with_file_format() {
         let manifest = ManifestFile {
             job_id: "test-job".to_string(),
@@ -522,6 +594,8 @@ mod tests {
                 has_unique_constraints: false,
                 on_conflict: OnConflict::DoNothing,
                 conflict_columns: Vec::new(),
+                excluded_columns: Vec::new(),
+                excluded_positions: Vec::new(),
             },
             file_format: FileFormat::Csv(DelimitedConfig::csv()),
             dsql_config: DsqlConfig {

--- a/src/coordination/worker.rs
+++ b/src/coordination/worker.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
 use rand::Rng;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -11,6 +12,42 @@ use crate::config::{BASE_DELAY, MAX_DELAY, MAX_RETRIES, QUERY_TIMEOUT};
 use crate::db::Pool;
 use crate::formats::{FileReader, Record};
 use crate::telemetry::TelemetryEvent;
+
+/// Apply `--exclude-columns` field filtering to a batch of records.
+///
+/// Skip-mode only: each record must have `full_len = effective_len + excluded_positions.len()`
+/// fields. Matching records drop fields at `excluded_positions`; mismatched records are
+/// excluded from the returned batch and counted.
+///
+/// Returns `(filtered_records, mismatch_count, first_mismatch)` where
+/// `first_mismatch` is `(record_index_within_chunk, observed_field_count)` for the
+/// first mismatched record, useful for locating the offending row in the source file.
+fn apply_field_exclusion(
+    records: Vec<Record>,
+    excluded_positions: &[usize],
+    full_len: usize,
+) -> (Vec<Record>, u64, Option<(usize, usize)>) {
+    let excluded_set: HashSet<usize> = excluded_positions.iter().copied().collect();
+    let mut filtered = Vec::with_capacity(records.len());
+    let mut mismatch = 0u64;
+    let mut first_mismatch: Option<(usize, usize)> = None;
+    for (idx, record) in records.into_iter().enumerate() {
+        if record.fields.len() == full_len {
+            let kept: Vec<String> = record
+                .fields
+                .into_iter()
+                .enumerate()
+                .filter(|(i, _)| !excluded_set.contains(i))
+                .map(|(_, f)| f)
+                .collect();
+            filtered.push(Record { fields: kept });
+        } else {
+            first_mismatch.get_or_insert((idx, record.fields.len()));
+            mismatch += 1;
+        }
+    }
+    (filtered, mismatch, first_mismatch)
+}
 
 /// Type category for SQL type conversion strategy
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -215,10 +252,48 @@ impl Worker {
             estimated_rows: chunk_info.estimated_rows,
         };
 
-        let chunk_data = file_reader
+        let mut chunk_data = file_reader
             .read_chunk(&chunk)
             .await
             .context("Failed to read chunk data")?;
+
+        // Apply --exclude-columns field filtering before batching. Skip-mode:
+        // each source record must contain all table columns; we drop fields at
+        // excluded positions so downstream batch INSERTs target only the effective
+        // schema. Records with the wrong field count are dropped and counted as
+        // failures, mirroring the existing `parse_errors` aggregation pattern.
+        let excluded_positions: &[usize] = &manifest.table.excluded_positions;
+
+        // Snapshot the record count before exclusion so bytes_per_record divides by
+        // the true number of records the chunk's bytes came from. Dividing by the
+        // post-filter count would overstate per-record size (numerator unchanged,
+        // denominator smaller) and, when multiplied by records_loaded downstream,
+        // would cause reported bytes_processed to exceed bytes actually read.
+        let pre_filter_record_count = chunk_data.records.len();
+
+        let (field_mapping_errors, first_mismatch, full_len) = if !excluded_positions.is_empty() {
+            // Invariant: setup_new_job refuses to activate exclusion without a
+            // resolved schema. Fail loudly rather than silently mis-batch every record.
+            let effective_len = manifest
+                .table
+                .schema
+                .as_ref()
+                .map(|s| s.columns.len())
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Internal error: manifest has excluded_positions but no schema; \
+                         cannot compute effective field count"
+                    )
+                })?;
+            let full_len = effective_len + excluded_positions.len();
+            let original_records = std::mem::take(&mut chunk_data.records);
+            let (filtered, mismatch, first_sample) =
+                apply_field_exclusion(original_records, excluded_positions, full_len);
+            chunk_data.records = filtered;
+            (mismatch, first_sample, Some(full_len))
+        } else {
+            (0u64, None, None)
+        };
 
         // Split chunk into batches with line offset tracking
         let batches: Vec<Vec<Record>> = chunk_data
@@ -228,17 +303,22 @@ impl Worker {
             .collect();
 
         // Calculate average bytes per record for telemetry
-        let bytes_per_record = if chunk_data.records.is_empty() {
+        let bytes_per_record = if pre_filter_record_count == 0 {
             0
         } else {
-            chunk_data.bytes_read / chunk_data.records.len() as u64
+            chunk_data.bytes_read / pre_filter_record_count as u64
         };
 
         // Process batches in parallel with JoinSet for concurrency control
         let mut join_set: JoinSet<BatchResult> = JoinSet::new();
         let mut results = Vec::new();
 
-        // Track line numbers: chunk records start at line 1, +1 if file has header (to skip header line)
+        // Track line numbers: chunk records start at line 1, +1 if file has header (to skip header line).
+        // Note: `current_line` under-counts by the number of records dropped before
+        // batching (parse_errors or field_count_mismatch paths), so per-batch line
+        // numbers are unreliable as absolute source-file positions whenever drops
+        // occurred upstream. Chunk-level errors from those drop paths use
+        // line_number: 0 as a sentinel (see ErrorRecord doc comment).
         let has_header = matches!(
             manifest.file_format,
             crate::coordination::manifest::FileFormat::Csv(_)
@@ -314,6 +394,32 @@ impl Worker {
                 error_message: format!(
                     "{} record(s) failed to parse from source file. Check delimiter, quote, and escape settings.",
                     chunk_data.parse_errors
+                ),
+            });
+        }
+
+        // Include --exclude-columns field-count mismatches as failed records.
+        // `field_mapping_errors > 0` implies exclusion was active, so `full_len` is Some.
+        if let Some(full_len) = full_len
+            && field_mapping_errors > 0
+        {
+            records_failed += field_mapping_errors;
+            let first_sample = first_mismatch
+                .map(|(idx, n)| {
+                    format!(
+                        " (first mismatch at chunk record index {} had {} fields)",
+                        idx, n
+                    )
+                })
+                .unwrap_or_default();
+            errors.push(ErrorRecord {
+                line_number: 0,
+                error_type: "field_count_mismatch".to_string(),
+                error_message: format!(
+                    "{} record(s) in chunk {} had wrong field count; expected {}{} \
+                     (source file must include all table columns including excluded \
+                     ones, which will be skipped)",
+                    field_mapping_errors, chunk_id, full_len, first_sample
                 ),
             });
         }
@@ -818,4 +924,119 @@ async fn run_raw_sql_sqlite(
 ) -> Result<sqlx::sqlite::SqliteQueryResult, sqlx::Error> {
     use sqlx::Executor;
     (&mut **conn).execute(sqlx::raw_sql(sql)).await
+}
+
+#[cfg(test)]
+mod field_exclusion_tests {
+    use super::*;
+
+    fn mk_record(fields: &[&str]) -> Record {
+        Record {
+            fields: fields.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn skip_mode_drops_excluded_positions() {
+        let records = vec![mk_record(&[
+            "uuid-1",
+            "Alice",
+            "alice@ex.com",
+            "2025-01-01",
+        ])];
+        let (filtered, mismatch, _first) = apply_field_exclusion(records, &[0, 3], 4);
+        assert_eq!(mismatch, 0);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].fields, vec!["Alice", "alice@ex.com"]);
+    }
+
+    #[test]
+    fn mismatched_field_count_is_counted_and_dropped() {
+        let records = vec![
+            mk_record(&["uuid-1", "Alice", "alice@ex.com", "2025-01-01"]),
+            mk_record(&["Alice", "alice@ex.com"]),
+            mk_record(&["uuid-2", "Bob", "bob@ex.com", "2025-01-02", "extra"]),
+        ];
+        let (filtered, mismatch, first) = apply_field_exclusion(records, &[0, 3], 4);
+        assert_eq!(mismatch, 2);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].fields, vec!["Alice", "alice@ex.com"]);
+        // First mismatch is the 2-field record at chunk index 1.
+        assert_eq!(first, Some((1, 2)));
+    }
+
+    #[test]
+    fn empty_excluded_positions_is_identity_over_fields() {
+        let records = vec![mk_record(&["a", "b"])];
+        let (filtered, mismatch, _first) = apply_field_exclusion(records, &[], 2);
+        assert_eq!(mismatch, 0);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].fields, vec!["a", "b"]);
+    }
+
+    // Feature: loader-column-exclusion, Property 3: field mapping correctly skips excluded positions
+    proptest::proptest! {
+        #[test]
+        fn prop_skip_mode_preserves_non_excluded_fields_in_order(
+            full_len in 2usize..10,
+            exclude_mask in proptest::collection::vec(proptest::bool::ANY, 2..10),
+            record_count in 1usize..5,
+        ) {
+            let mask: Vec<bool> = exclude_mask
+                .into_iter()
+                .take(full_len)
+                .chain(std::iter::repeat(false))
+                .take(full_len)
+                .collect();
+            let excluded_positions: Vec<usize> = mask
+                .iter()
+                .enumerate()
+                .filter_map(|(i, &b)| b.then_some(i))
+                .collect();
+            proptest::prop_assume!(
+                !excluded_positions.is_empty() && excluded_positions.len() < full_len
+            );
+
+            let records: Vec<Record> = (0..record_count)
+                .map(|r| Record {
+                    fields: (0..full_len).map(|i| format!("r{}_c{}", r, i)).collect(),
+                })
+                .collect();
+
+            let (filtered, mismatch, _first) =
+                apply_field_exclusion(records.clone(), &excluded_positions, full_len);
+            proptest::prop_assert_eq!(mismatch, 0);
+            proptest::prop_assert_eq!(filtered.len(), record_count);
+
+            let expected_len = full_len - excluded_positions.len();
+            for (r_idx, record) in filtered.iter().enumerate() {
+                proptest::prop_assert_eq!(record.fields.len(), expected_len);
+                let expected: Vec<String> = (0..full_len)
+                    .filter(|i| !excluded_positions.contains(i))
+                    .map(|i| format!("r{}_c{}", r_idx, i))
+                    .collect();
+                proptest::prop_assert_eq!(&record.fields, &expected);
+            }
+        }
+
+        #[test]
+        fn prop_wrong_field_count_always_counts_as_mismatch(
+            full_len in 2usize..8,
+            offset in proptest::sample::select(vec![-2i32, -1, 1, 2, 3]),
+        ) {
+            let actual_len = (full_len as i32 + offset).max(0) as usize;
+            proptest::prop_assume!(actual_len != full_len);
+
+            let excluded_positions: Vec<usize> = vec![0];
+
+            let records = vec![Record {
+                fields: (0..actual_len).map(|i| format!("c{}", i)).collect(),
+            }];
+            let (filtered, mismatch, first) =
+                apply_field_exclusion(records, &excluded_positions, full_len);
+            proptest::prop_assert_eq!(mismatch, 1);
+            proptest::prop_assert!(filtered.is_empty());
+            proptest::prop_assert_eq!(first, Some((0, actual_len)));
+        }
+    }
 }

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -9,13 +9,16 @@ mod tests {
         coordination::{
             Coordinator, DsqlConfig, FileFormat, LoadConfigBuilder,
             coordinator::LoadResult,
-            manifest::{ChunkResultFile, ChunkStatus, LocalManifestStorage, ManifestStorage},
+            manifest::{
+                ChunkResultFile, ChunkStatus, LocalManifestStorage, ManifestStorage, OnConflict,
+            },
         },
         db::{Pool, SchemaInferrer, pool::PoolConnection},
         formats::{DelimitedConfig, FileReader, delimited::reader::GenericDelimitedReader},
         io::LocalFileByteReader,
         runner::{Format, LoadArgs, run_load},
     };
+    use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
     use tempfile::TempDir;
     use tokio::fs::{self, File};
@@ -112,7 +115,7 @@ mod tests {
             .batch_concurrency(2)
             .create_table_if_missing(true)
             .file_format(FileFormat::Csv(DelimitedConfig::csv()))
-            .column_mappings(std::collections::HashMap::new())
+            .column_mappings(HashMap::new())
             .quiet(true)
             .debug(true) // Enable debug for tests to verify verbose output
             .build()
@@ -161,7 +164,7 @@ mod tests {
             .batch_concurrency(2)
             .create_table_if_missing(true)
             .file_format(FileFormat::Tsv(DelimitedConfig::tsv()))
-            .column_mappings(std::collections::HashMap::new())
+            .column_mappings(HashMap::new())
             .quiet(true)
             .build()
             .unwrap();
@@ -214,7 +217,7 @@ mod tests {
         assert_eq!(result.records_failed, 0);
 
         // Verify work was distributed across multiple workers
-        let unique_workers: std::collections::HashSet<_> =
+        let unique_workers: HashSet<_> =
             result.chunk_results.iter().map(|r| &r.worker_id).collect();
         assert!(
             unique_workers.len() >= 2,
@@ -313,7 +316,7 @@ mod tests {
             .batch_concurrency(2)
             .create_table_if_missing(false) // Table already created
             .file_format(FileFormat::Parquet(ParquetConfig::default()))
-            .column_mappings(std::collections::HashMap::new())
+            .column_mappings(HashMap::new())
             .quiet(true)
             .build()
             .unwrap();
@@ -475,9 +478,10 @@ mod tests {
             manifest_dir: None,
             quiet: true,
             debug: true,
-            column_mappings: std::collections::HashMap::new(),
+            column_mappings: HashMap::new(),
             resume_job_id: None,
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            exclude_columns: Vec::new(),
             delimiter: None,
             quote: None,
             escape: None,
@@ -568,9 +572,10 @@ mod tests {
             manifest_dir: None,
             quiet: true,
             debug: true,
-            column_mappings: std::collections::HashMap::new(),
+            column_mappings: HashMap::new(),
             resume_job_id: None,
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            exclude_columns: Vec::new(),
             delimiter: None,
             quote: None,
             escape: None,
@@ -631,7 +636,7 @@ mod tests {
             .batch_concurrency(1)
             .create_table_if_missing(false) // This is the key - not creating the table
             .file_format(FileFormat::Csv(DelimitedConfig::csv()))
-            .column_mappings(std::collections::HashMap::new())
+            .column_mappings(HashMap::new())
             .quiet(true)
             .build()
             .unwrap();
@@ -710,9 +715,10 @@ mod tests {
             manifest_dir: None, // Don't specify manifest dir - this is key
             quiet: true,
             debug: true,
-            column_mappings: std::collections::HashMap::new(),
+            column_mappings: HashMap::new(),
             resume_job_id: None,
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            exclude_columns: Vec::new(),
             delimiter: None,
             quote: None,
             escape: None,
@@ -849,7 +855,7 @@ mod tests {
             .batch_concurrency(1)
             .create_table_if_missing(false)
             .file_format(FileFormat::Csv(DelimitedConfig::csv()))
-            .column_mappings(std::collections::HashMap::new())
+            .column_mappings(HashMap::new())
             .quiet(true)
             .debug(true) // Enable debug mode to get verbose output
             .build()
@@ -944,7 +950,7 @@ mod tests {
             .batch_concurrency(2)
             .create_table_if_missing(false)
             .file_format(FileFormat::Csv(DelimitedConfig::csv()))
-            .column_mappings(std::collections::HashMap::new())
+            .column_mappings(HashMap::new())
             .quiet(true)
             .build()
             .unwrap();
@@ -983,9 +989,10 @@ mod tests {
             manifest_dir: None,
             quiet: true,
             debug: true,
-            column_mappings: std::collections::HashMap::new(),
+            column_mappings: HashMap::new(),
             resume_job_id: None,
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            exclude_columns: Vec::new(),
             delimiter: None,
             quote: None,
             escape: None,
@@ -1037,7 +1044,7 @@ mod tests {
             .batch_concurrency(1)
             .create_table_if_missing(true)
             .file_format(FileFormat::Csv(DelimitedConfig::csv()))
-            .column_mappings(std::collections::HashMap::new())
+            .column_mappings(HashMap::new())
             .quiet(true)
             .build()
             .unwrap();
@@ -1086,9 +1093,10 @@ mod tests {
             manifest_dir: Some(manifest_path.clone()),
             quiet: true,
             debug: true,
-            column_mappings: std::collections::HashMap::new(),
+            column_mappings: HashMap::new(),
             resume_job_id: None,
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            exclude_columns: Vec::new(),
             delimiter: None,
             quote: None,
             escape: None,
@@ -1175,9 +1183,10 @@ mod tests {
             manifest_dir: Some(manifest_path.clone()),
             quiet: true,
             debug: true,
-            column_mappings: std::collections::HashMap::new(),
+            column_mappings: HashMap::new(),
             resume_job_id: Some(job_id.clone()),
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            exclude_columns: Vec::new(),
             delimiter: None,
             quote: None,
             escape: None,
@@ -1296,9 +1305,10 @@ mod tests {
             manifest_dir: Some(manifest_path.clone()),
             quiet: true,
             debug: true,
-            column_mappings: std::collections::HashMap::new(),
+            column_mappings: HashMap::new(),
             resume_job_id: None,
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            exclude_columns: Vec::new(),
             delimiter: None,
             quote: None,
             escape: None,
@@ -1391,9 +1401,10 @@ mod tests {
             manifest_dir: Some(manifest_path.clone()),
             quiet: true,
             debug: true,
-            column_mappings: std::collections::HashMap::new(),
+            column_mappings: HashMap::new(),
             resume_job_id: Some(job_id.clone()),
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            exclude_columns: Vec::new(),
             delimiter: None,
             quote: None,
             escape: None,
@@ -1435,8 +1446,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_on_conflict_do_update_with_primary_key() {
-        use crate::coordination::manifest::OnConflict;
-
         let temp_dir = TempDir::new().unwrap();
 
         // Create initial CSV with 3 rows
@@ -1489,7 +1498,7 @@ mod tests {
             .batch_concurrency(1)
             .create_table_if_missing(false)
             .file_format(FileFormat::Csv(DelimitedConfig::csv()))
-            .column_mappings(std::collections::HashMap::new())
+            .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
             .build()
@@ -1540,7 +1549,7 @@ mod tests {
             .batch_concurrency(1)
             .create_table_if_missing(false)
             .file_format(FileFormat::Csv(DelimitedConfig::csv()))
-            .column_mappings(std::collections::HashMap::new())
+            .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoUpdate)
             .build()
@@ -1581,8 +1590,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_on_conflict_error_mode() {
-        use crate::coordination::manifest::OnConflict;
-
         let temp_dir = TempDir::new().unwrap();
 
         // Create initial CSV
@@ -1628,7 +1635,7 @@ mod tests {
             .batch_concurrency(1)
             .create_table_if_missing(false)
             .file_format(FileFormat::Csv(DelimitedConfig::csv()))
-            .column_mappings(std::collections::HashMap::new())
+            .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::Error)
             .build()
@@ -1673,7 +1680,7 @@ mod tests {
             .batch_concurrency(1)
             .create_table_if_missing(false)
             .file_format(FileFormat::Csv(DelimitedConfig::csv()))
-            .column_mappings(std::collections::HashMap::new())
+            .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::Error)
             .build()
@@ -1691,8 +1698,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_on_conflict_do_update_without_constraints_fails() {
-        use crate::coordination::manifest::OnConflict;
-
         let temp_dir = TempDir::new().unwrap();
         let csv_path =
             create_csv_with_content(&temp_dir, "test.csv", &["id,name\n", "1,Alice\n"]).await;
@@ -1732,7 +1737,7 @@ mod tests {
             .batch_concurrency(1)
             .create_table_if_missing(false)
             .file_format(FileFormat::Csv(DelimitedConfig::csv()))
-            .column_mappings(std::collections::HashMap::new())
+            .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoUpdate)
             .build()
@@ -1813,7 +1818,7 @@ mod tests {
             .batch_concurrency(1)
             .create_table_if_missing(false)
             .file_format(FileFormat::Csv(DelimitedConfig::csv()))
-            .column_mappings(std::collections::HashMap::new())
+            .column_mappings(HashMap::new())
             .quiet(true)
             .debug(true) // Enable debug mode to verify verbose output
             .build()
@@ -1909,9 +1914,10 @@ mod tests {
             manifest_dir: None,
             quiet: true,
             debug: false,
-            column_mappings: std::collections::HashMap::new(),
+            column_mappings: HashMap::new(),
             resume_job_id: None,
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            exclude_columns: Vec::new(),
             delimiter: Some("|".to_string()),
             quote: Some("'".to_string()),
             escape: Some("\\".to_string()),
@@ -2081,9 +2087,10 @@ mod tests {
             manifest_dir: None,
             quiet: true,
             debug: false,
-            column_mappings: std::collections::HashMap::new(),
+            column_mappings: HashMap::new(),
             resume_job_id: None,
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            exclude_columns: Vec::new(),
             delimiter,
             quote,
             escape,
@@ -2370,5 +2377,1283 @@ mod tests {
 
         assert_eq!(result.records_loaded, 3);
         assert_eq!(result.records_failed, 0);
+    }
+
+    // ============ --exclude-columns integration tests ============
+
+    /// End-to-end: CSV has all columns including the excluded PK. Loader skips
+    /// the excluded position and lets the DB apply DEFAULT. Mirrors the customer
+    /// scenario (UUID PK with gen_random_uuid() default).
+    #[tokio::test]
+    async fn test_exclude_columns_skip_mode_end_to_end() {
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path = create_csv_with_content(
+            &temp_dir,
+            "with_pk.csv",
+            &[
+                "pk_id,name,email\n",
+                "1,Alice,alice@ex.com\n",
+                "2,Bob,bob@ex.com\n",
+                "3,Charlie,charlie@ex.com\n",
+            ],
+        )
+        .await;
+
+        // pk_id gets a server-generated default; customer's table uses
+        // `DEFAULT (lower(hex(randomblob(16))))` as a SQLite-compatible analog
+        // to `DEFAULT gen_random_uuid()`.
+        let pool = setup_sqlite_table(
+            "test_exclude",
+            "pk_id TEXT DEFAULT (lower(hex(randomblob(16)))) PRIMARY KEY, name TEXT, email TEXT",
+        )
+        .await;
+
+        let byte_reader = LocalFileByteReader::new(&csv_path);
+        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader,
+            DelimitedConfig::csv(),
+        ));
+        let manifest_dir = TempDir::new().unwrap();
+        let manifest_storage: Arc<dyn ManifestStorage> =
+            Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
+        let coordinator = Coordinator::new(
+            manifest_storage,
+            file_reader,
+            SchemaInferrer { has_header: true },
+            pool.clone(),
+        );
+
+        let config = LoadConfigBuilder::default()
+            .source_uri(csv_path)
+            .target_table("test_exclude".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(1)
+            .chunk_size_bytes(1000)
+            .batch_size(10)
+            .batch_concurrency(1)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(HashMap::new())
+            .quiet(true)
+            .on_conflict(OnConflict::DoNothing)
+            .exclude_columns(vec!["pk_id".to_string()])
+            .build()
+            .unwrap();
+
+        let result = coordinator.run_load(&config).await.unwrap();
+        assert_eq!(result.records_loaded, 3);
+        assert_eq!(result.records_failed, 0);
+        assert_eq!(get_table_count(&pool, "test_exclude").await, 3);
+
+        // Verify: the CSV's pk_id values were NOT inserted; DB-generated defaults
+        // were used. The CSV had pk_id = 1/2/3; those should not appear.
+        if let Ok(mut conn) = pool.acquire().await
+            && let PoolConnection::Sqlite(ref mut sqlite_conn) = conn
+        {
+            let (count,): (i64,) =
+                sqlx::query_as("SELECT COUNT(*) FROM test_exclude WHERE pk_id IN ('1','2','3')")
+                    .fetch_one(&mut **sqlite_conn)
+                    .await
+                    .unwrap();
+            assert_eq!(
+                count, 0,
+                "pk_id values from CSV should NOT appear; DB should have generated defaults"
+            );
+        }
+    }
+
+    /// Parallel workers + multi-chunk load with `--exclude-columns`: the same
+    /// invariant as `test_multiple_workers_and_chunk_distribution` but with a
+    /// DB-defaulted PK column being skipped. Exercises the concurrent-chunk
+    /// path that production actually uses.
+    #[tokio::test]
+    async fn test_exclude_columns_parallel_workers() {
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path = temp_dir.path().join("parallel.csv");
+        let mut file = File::create(&csv_path).await.unwrap();
+        file.write_all(b"pk_id,name,email\n").await.unwrap();
+        for i in 0..500 {
+            let line = format!("{},name_{},user_{}@ex.com\n", i, i, i);
+            file.write_all(line.as_bytes()).await.unwrap();
+        }
+        file.flush().await.unwrap();
+        let csv_path = csv_path.to_str().unwrap().to_string();
+
+        let pool = setup_sqlite_table(
+            "test_exclude_parallel",
+            "pk_id TEXT DEFAULT (lower(hex(randomblob(16)))) PRIMARY KEY, name TEXT, email TEXT",
+        )
+        .await;
+
+        let byte_reader = LocalFileByteReader::new(&csv_path);
+        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader,
+            DelimitedConfig::csv(),
+        ));
+        let manifest_dir = TempDir::new().unwrap();
+        let manifest_storage: Arc<dyn ManifestStorage> =
+            Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
+        let coordinator = Coordinator::new(
+            manifest_storage,
+            file_reader,
+            SchemaInferrer { has_header: true },
+            pool.clone(),
+        );
+
+        let config = LoadConfigBuilder::default()
+            .source_uri(csv_path)
+            .target_table("test_exclude_parallel".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(4)
+            .chunk_size_bytes(800)
+            .batch_size(50)
+            .batch_concurrency(2)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(HashMap::new())
+            .quiet(true)
+            .on_conflict(OnConflict::DoNothing)
+            .exclude_columns(vec!["pk_id".to_string()])
+            .build()
+            .unwrap();
+
+        let result = coordinator.run_load(&config).await.unwrap();
+
+        assert!(result.chunks_processed > 1, "expected multiple chunks");
+        assert_eq!(result.records_loaded, 500);
+        assert_eq!(result.records_failed, 0);
+        assert_eq!(get_table_count(&pool, "test_exclude_parallel").await, 500);
+
+        let unique_workers: HashSet<_> =
+            result.chunk_results.iter().map(|r| &r.worker_id).collect();
+        assert!(
+            unique_workers.len() >= 2,
+            "expected at least 2 workers, got {}",
+            unique_workers.len()
+        );
+
+        // CSV pk_ids were 0..500; none should appear because the DB default generated them.
+        if let Ok(mut conn) = pool.acquire().await
+            && let PoolConnection::Sqlite(ref mut sqlite_conn) = conn
+        {
+            let (count,): (i64,) = sqlx::query_as(
+                "SELECT COUNT(*) FROM test_exclude_parallel WHERE pk_id IN ('0','1','2','3','499')",
+            )
+            .fetch_one(&mut **sqlite_conn)
+            .await
+            .unwrap();
+            assert_eq!(
+                count, 0,
+                "CSV pk_id values must not appear; DB-generated defaults should be used"
+            );
+        }
+    }
+
+    /// Parquet source + `--exclude-columns`: parquet emits records in the file's
+    /// column order, so this confirms the positional skipping logic works when the
+    /// reader is a Parquet reader (not just CSV).
+    #[tokio::test]
+    async fn test_exclude_columns_parquet() {
+        use crate::coordination::manifest::ParquetConfig;
+        use crate::formats::parquet::GenericParquetReader;
+        use arrow::array::*;
+        use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+        use arrow::record_batch::RecordBatch;
+        use parquet::arrow::ArrowWriter;
+        use parquet::file::properties::WriterProperties;
+
+        let temp_dir = TempDir::new().unwrap();
+        let parquet_path = temp_dir.path().join("exclude.parquet");
+        let arrow_schema = ArrowSchema::new(vec![
+            Field::new("pk_id", DataType::Utf8, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("value", DataType::Float64, false),
+        ]);
+
+        let file = std::fs::File::create(&parquet_path).unwrap();
+        let props = WriterProperties::builder()
+            .set_max_row_group_size(50)
+            .build();
+        let mut writer =
+            ArrowWriter::try_new(file, Arc::new(arrow_schema.clone()), Some(props)).unwrap();
+
+        let num_rows: i32 = 100;
+        let pk_array = StringArray::from_iter((0..num_rows).map(|i| Some(format!("csv_pk_{}", i))));
+        let name_array = StringArray::from_iter((0..num_rows).map(|i| Some(format!("name_{}", i))));
+        let value_array = Float64Array::from_iter_values((0..num_rows).map(|i| (i as f64) * 1.5));
+
+        let batch = RecordBatch::try_new(
+            Arc::new(arrow_schema),
+            vec![
+                Arc::new(pk_array),
+                Arc::new(name_array),
+                Arc::new(value_array),
+            ],
+        )
+        .unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let parquet_path_str = parquet_path.to_str().unwrap().to_string();
+
+        let pool = setup_sqlite_table(
+            "test_exclude_parquet",
+            "pk_id TEXT DEFAULT (lower(hex(randomblob(16)))) PRIMARY KEY, name TEXT, value REAL",
+        )
+        .await;
+
+        let byte_reader = LocalFileByteReader::new(&parquet_path_str);
+        let parquet_reader = GenericParquetReader::new(byte_reader).await.unwrap();
+        let file_reader: Arc<dyn FileReader> = Arc::new(parquet_reader);
+
+        let manifest_dir = TempDir::new().unwrap();
+        let manifest_storage: Arc<dyn ManifestStorage> =
+            Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
+        let coordinator = Coordinator::new(
+            manifest_storage,
+            file_reader,
+            SchemaInferrer { has_header: true },
+            pool.clone(),
+        );
+
+        let config = LoadConfigBuilder::default()
+            .source_uri(parquet_path_str)
+            .target_table("test_exclude_parquet".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(2)
+            .chunk_size_bytes(500)
+            .batch_size(20)
+            .batch_concurrency(2)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Parquet(ParquetConfig::default()))
+            .column_mappings(HashMap::new())
+            .quiet(true)
+            .on_conflict(OnConflict::DoNothing)
+            .exclude_columns(vec!["pk_id".to_string()])
+            .build()
+            .unwrap();
+
+        let result = coordinator.run_load(&config).await.unwrap();
+
+        assert_eq!(result.records_loaded, 100);
+        assert_eq!(result.records_failed, 0);
+        assert_eq!(get_table_count(&pool, "test_exclude_parquet").await, 100);
+
+        // None of the parquet-sourced pk_id values should land in the DB.
+        if let Ok(mut conn) = pool.acquire().await
+            && let PoolConnection::Sqlite(ref mut sqlite_conn) = conn
+        {
+            let (count,): (i64,) = sqlx::query_as(
+                "SELECT COUNT(*) FROM test_exclude_parquet WHERE pk_id LIKE 'csv_pk_%'",
+            )
+            .fetch_one(&mut **sqlite_conn)
+            .await
+            .unwrap();
+            assert_eq!(
+                count, 0,
+                "Parquet pk_id values must not appear; DB default should have replaced them"
+            );
+        }
+    }
+
+    /// Field-count mismatch: the CSV is missing a column. Records should be
+    /// dropped and counted as failures with one aggregated ErrorRecord.
+    #[tokio::test]
+    async fn test_exclude_columns_field_count_mismatch_is_aggregated() {
+        let temp_dir = TempDir::new().unwrap();
+        // CSV is missing pk_id — should fail because excluded still requires full schema
+        let csv_path = create_csv_with_content(
+            &temp_dir,
+            "missing_pk.csv",
+            &["name,email\n", "Alice,alice@ex.com\n", "Bob,bob@ex.com\n"],
+        )
+        .await;
+
+        let pool = setup_sqlite_table(
+            "test_exclude_mismatch",
+            "pk_id TEXT DEFAULT 'x' PRIMARY KEY, name TEXT, email TEXT",
+        )
+        .await;
+
+        let byte_reader = LocalFileByteReader::new(&csv_path);
+        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader,
+            DelimitedConfig::csv(),
+        ));
+        let manifest_dir = TempDir::new().unwrap();
+        let manifest_storage: Arc<dyn ManifestStorage> =
+            Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
+        let coordinator = Coordinator::new(
+            manifest_storage,
+            file_reader,
+            SchemaInferrer { has_header: true },
+            pool.clone(),
+        );
+
+        let config = LoadConfigBuilder::default()
+            .source_uri(csv_path)
+            .target_table("test_exclude_mismatch".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(1)
+            .chunk_size_bytes(1000)
+            .batch_size(10)
+            .batch_concurrency(1)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(HashMap::new())
+            .quiet(true)
+            .on_conflict(OnConflict::DoNothing)
+            .exclude_columns(vec!["pk_id".to_string()])
+            .build()
+            .unwrap();
+
+        let result = coordinator.run_load(&config).await.unwrap();
+        assert_eq!(result.records_loaded, 0);
+        assert_eq!(result.records_failed, 2);
+        assert_eq!(get_table_count(&pool, "test_exclude_mismatch").await, 0);
+
+        // Error aggregation: exactly one ErrorRecord of type field_count_mismatch with count 2
+        let field_count_errors: Vec<_> = result
+            .chunk_results
+            .iter()
+            .flat_map(|r| r.errors.iter())
+            .filter(|e| e.error_type == "field_count_mismatch")
+            .collect();
+        assert_eq!(field_count_errors.len(), 1);
+        let msg = &field_count_errors[0].error_message;
+        assert!(msg.contains("2 record(s)"), "msg: {}", msg);
+        assert!(
+            msg.contains("first mismatch at chunk record index") && msg.contains("had 2 fields"),
+            "msg: {}",
+            msg
+        );
+        assert_eq!(field_count_errors[0].line_number, 0);
+    }
+
+    /// Invalid column name: validator rejects before loading starts.
+    #[tokio::test]
+    async fn test_exclude_columns_unknown_name_errors() {
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path =
+            create_csv_with_content(&temp_dir, "ok.csv", &["id,name\n", "1,Alice\n"]).await;
+
+        let pool = setup_sqlite_table("test_unknown", "id TEXT PRIMARY KEY, name TEXT").await;
+
+        let byte_reader = LocalFileByteReader::new(&csv_path);
+        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader,
+            DelimitedConfig::csv(),
+        ));
+        let manifest_dir = TempDir::new().unwrap();
+        let manifest_storage: Arc<dyn ManifestStorage> =
+            Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
+        let coordinator = Coordinator::new(
+            manifest_storage,
+            file_reader,
+            SchemaInferrer { has_header: true },
+            pool.clone(),
+        );
+
+        let config = LoadConfigBuilder::default()
+            .source_uri(csv_path)
+            .target_table("test_unknown".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(1)
+            .chunk_size_bytes(1000)
+            .batch_size(10)
+            .batch_concurrency(1)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(HashMap::new())
+            .quiet(true)
+            .on_conflict(OnConflict::DoNothing)
+            .exclude_columns(vec!["does_not_exist".to_string()])
+            .build()
+            .unwrap();
+
+        let err = coordinator.run_load(&config).await.unwrap_err().to_string();
+        assert!(
+            err.contains("Column 'does_not_exist' not found"),
+            "error should identify the unknown column, got: {}",
+            err
+        );
+    }
+
+    /// Combination: --exclude-columns + --column-map on disjoint columns should work.
+    /// Exercises both features together: pk_id is excluded (DB applies DEFAULT), and
+    /// the SQLite column `full_name` is renamed to itself to cover the rename code path.
+    /// A non-trivial rename is not possible here without also mutating the SQLite schema,
+    /// so this asserts only that the combined pipeline loads both rows successfully.
+    /// Rename-after-exclude ordering is pinned by the unit test
+    /// `exclude_then_rename_ordering_applies_rename_to_remaining_columns` in coordinator.rs.
+    #[tokio::test]
+    async fn test_exclude_columns_plus_column_map() {
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path = create_csv_with_content(
+            &temp_dir,
+            "combo.csv",
+            &[
+                "pk_id,full_name,email\n",
+                "1,Alice,alice@ex.com\n",
+                "2,Bob,bob@ex.com\n",
+            ],
+        )
+        .await;
+
+        let pool = setup_sqlite_table(
+            "test_combo",
+            "pk_id TEXT DEFAULT (lower(hex(randomblob(16)))) PRIMARY KEY, full_name TEXT, email TEXT",
+        )
+        .await;
+
+        let byte_reader = LocalFileByteReader::new(&csv_path);
+        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader,
+            DelimitedConfig::csv(),
+        ));
+        let manifest_dir = TempDir::new().unwrap();
+        let manifest_storage: Arc<dyn ManifestStorage> =
+            Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
+        let coordinator = Coordinator::new(
+            manifest_storage,
+            file_reader,
+            SchemaInferrer { has_header: true },
+            pool.clone(),
+        );
+
+        let mut mappings = HashMap::new();
+        mappings.insert("full_name".to_string(), "full_name".to_string());
+
+        let config = LoadConfigBuilder::default()
+            .source_uri(csv_path)
+            .target_table("test_combo".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(1)
+            .chunk_size_bytes(1000)
+            .batch_size(10)
+            .batch_concurrency(1)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(mappings)
+            .quiet(true)
+            .on_conflict(OnConflict::DoNothing)
+            .exclude_columns(vec!["pk_id".to_string()])
+            .build()
+            .unwrap();
+
+        let result = coordinator.run_load(&config).await.unwrap();
+        assert_eq!(result.records_loaded, 2);
+        assert_eq!(result.records_failed, 0);
+        assert_eq!(get_table_count(&pool, "test_combo").await, 2);
+    }
+
+    /// Conflict: --column-map targets an excluded column — validator must reject.
+    #[tokio::test]
+    async fn test_exclude_columns_rename_conflict_errors() {
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path =
+            create_csv_with_content(&temp_dir, "conflict.csv", &["pk_id,name\n", "1,Alice\n"])
+                .await;
+
+        let pool = setup_sqlite_table(
+            "test_rename_conflict",
+            "pk_id TEXT DEFAULT 'x' PRIMARY KEY, name TEXT",
+        )
+        .await;
+
+        let byte_reader = LocalFileByteReader::new(&csv_path);
+        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader,
+            DelimitedConfig::csv(),
+        ));
+        let manifest_dir = TempDir::new().unwrap();
+        let manifest_storage: Arc<dyn ManifestStorage> =
+            Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
+        let coordinator = Coordinator::new(
+            manifest_storage,
+            file_reader,
+            SchemaInferrer { has_header: true },
+            pool.clone(),
+        );
+
+        let mut mappings = HashMap::new();
+        mappings.insert("pk_id".to_string(), "new_pk".to_string());
+
+        let config = LoadConfigBuilder::default()
+            .source_uri(csv_path)
+            .target_table("test_rename_conflict".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(1)
+            .chunk_size_bytes(1000)
+            .batch_size(10)
+            .batch_concurrency(1)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(mappings)
+            .quiet(true)
+            .on_conflict(OnConflict::DoNothing)
+            .exclude_columns(vec!["pk_id".to_string()])
+            .build()
+            .unwrap();
+
+        let err = coordinator.run_load(&config).await.unwrap_err().to_string();
+        assert!(
+            err.contains("cannot be both excluded and renamed"),
+            "error should call out exclusion/rename conflict, got: {}",
+            err
+        );
+    }
+
+    /// --if-not-exists + --exclude-columns must be rejected at setup.
+    #[tokio::test]
+    async fn test_exclude_columns_with_if_not_exists_errors() {
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path =
+            create_csv_with_content(&temp_dir, "create.csv", &["id,name\n", "1,Alice\n"]).await;
+
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+
+        let byte_reader = LocalFileByteReader::new(&csv_path);
+        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader,
+            DelimitedConfig::csv(),
+        ));
+        let manifest_dir = TempDir::new().unwrap();
+        let manifest_storage: Arc<dyn ManifestStorage> =
+            Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
+        let coordinator = Coordinator::new(
+            manifest_storage,
+            file_reader,
+            SchemaInferrer { has_header: true },
+            pool.clone(),
+        );
+
+        let config = LoadConfigBuilder::default()
+            .source_uri(csv_path)
+            .target_table("never_created".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(1)
+            .chunk_size_bytes(1000)
+            .batch_size(10)
+            .batch_concurrency(1)
+            .create_table_if_missing(true)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(HashMap::new())
+            .quiet(true)
+            .on_conflict(OnConflict::DoNothing)
+            .exclude_columns(vec!["id".to_string()])
+            .build()
+            .unwrap();
+
+        let err = coordinator.run_load(&config).await.unwrap_err().to_string();
+        assert!(
+            err.contains("not supported with --if-not-exists"),
+            "error should reject the combination, got: {}",
+            err
+        );
+    }
+
+    /// DO UPDATE with all conflict columns excluded must be rejected.
+    #[tokio::test]
+    async fn test_exclude_columns_all_conflict_cols_excluded_do_update_errors() {
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path =
+            create_csv_with_content(&temp_dir, "do_update.csv", &["pk_id,name\n", "1,Alice\n"])
+                .await;
+
+        // pk_id is the only unique column; excluding it should fail under do-update
+        let pool = setup_sqlite_table(
+            "test_all_excluded_upsert",
+            "pk_id TEXT PRIMARY KEY, name TEXT",
+        )
+        .await;
+
+        let byte_reader = LocalFileByteReader::new(&csv_path);
+        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader,
+            DelimitedConfig::csv(),
+        ));
+        let manifest_dir = TempDir::new().unwrap();
+        let manifest_storage: Arc<dyn ManifestStorage> =
+            Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
+        let coordinator = Coordinator::new(
+            manifest_storage,
+            file_reader,
+            SchemaInferrer { has_header: true },
+            pool.clone(),
+        );
+
+        let config = LoadConfigBuilder::default()
+            .source_uri(csv_path)
+            .target_table("test_all_excluded_upsert".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(1)
+            .chunk_size_bytes(1000)
+            .batch_size(10)
+            .batch_concurrency(1)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(HashMap::new())
+            .quiet(true)
+            .on_conflict(OnConflict::DoUpdate)
+            .exclude_columns(vec!["pk_id".to_string()])
+            .build()
+            .unwrap();
+
+        let err = coordinator.run_load(&config).await.unwrap_err().to_string();
+        assert!(
+            err.contains("All conflict columns are excluded"),
+            "error should call out the broken conflict target, got: {}",
+            err
+        );
+    }
+
+    /// Resume with matching --exclude-columns must succeed; mismatched must fail.
+    #[tokio::test]
+    async fn test_exclude_columns_resume_compatibility_check() {
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path = create_csv_with_content(
+            &temp_dir,
+            "resume.csv",
+            &["pk_id,name\n", "1,Alice\n", "2,Bob\n", "3,Charlie\n"],
+        )
+        .await;
+
+        let pool = setup_sqlite_table(
+            "test_resume_excl",
+            "pk_id TEXT DEFAULT (lower(hex(randomblob(16)))) PRIMARY KEY, name TEXT",
+        )
+        .await;
+
+        let manifest_dir = TempDir::new().unwrap();
+        let manifest_storage: Arc<dyn ManifestStorage> =
+            Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
+
+        let byte_reader = LocalFileByteReader::new(&csv_path);
+        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader,
+            DelimitedConfig::csv(),
+        ));
+        let coordinator = Coordinator::new(
+            manifest_storage.clone(),
+            file_reader,
+            SchemaInferrer { has_header: true },
+            pool.clone(),
+        );
+
+        let config = LoadConfigBuilder::default()
+            .source_uri(csv_path.clone())
+            .target_table("test_resume_excl".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(1)
+            .chunk_size_bytes(1000)
+            .batch_size(10)
+            .batch_concurrency(1)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(HashMap::new())
+            .quiet(true)
+            .on_conflict(OnConflict::DoNothing)
+            .exclude_columns(vec!["pk_id".to_string()])
+            .build()
+            .unwrap();
+
+        let result = coordinator.run_load(&config).await.unwrap();
+        assert_eq!(result.records_loaded, 3);
+        let job_id = result.job_id;
+
+        // Resume with a DIFFERENT exclude list must fail
+        let byte_reader2 = LocalFileByteReader::new(&csv_path);
+        let file_reader2: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader2,
+            DelimitedConfig::csv(),
+        ));
+        let coordinator2 = Coordinator::new(
+            manifest_storage.clone(),
+            file_reader2,
+            SchemaInferrer { has_header: true },
+            pool.clone(),
+        );
+        let bad_config = LoadConfigBuilder::default()
+            .source_uri(csv_path.clone())
+            .target_table("test_resume_excl".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(1)
+            .chunk_size_bytes(1000)
+            .batch_size(10)
+            .batch_concurrency(1)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(HashMap::new())
+            .quiet(true)
+            .on_conflict(OnConflict::DoNothing)
+            .exclude_columns(vec!["name".to_string()])
+            .resume_job_id(Some(job_id.clone()))
+            .build()
+            .unwrap();
+
+        let err = coordinator2
+            .run_load(&bad_config)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("--exclude-columns mismatch"),
+            "expected resume mismatch error, got: {}",
+            err
+        );
+    }
+
+    /// Resume without --exclude-columns must inherit the manifest's exclusion set.
+    /// Uses an order-reversed explicit list to also verify the sort-before-compare path.
+    #[tokio::test]
+    async fn test_exclude_columns_resume_inherits_from_manifest() {
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path = create_csv_with_content(
+            &temp_dir,
+            "inherit.csv",
+            &["pk_id,extra,name\n", "1,x,Alice\n", "2,y,Bob\n"],
+        )
+        .await;
+
+        let pool = setup_sqlite_table(
+            "test_resume_inherit",
+            "pk_id TEXT DEFAULT (lower(hex(randomblob(16)))) PRIMARY KEY, \
+             extra TEXT DEFAULT 'def', name TEXT",
+        )
+        .await;
+
+        let manifest_dir = TempDir::new().unwrap();
+        let manifest_storage: Arc<dyn ManifestStorage> =
+            Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
+
+        let byte_reader = LocalFileByteReader::new(&csv_path);
+        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader,
+            DelimitedConfig::csv(),
+        ));
+        let coordinator = Coordinator::new(
+            manifest_storage.clone(),
+            file_reader,
+            SchemaInferrer { has_header: true },
+            pool.clone(),
+        );
+
+        let config = LoadConfigBuilder::default()
+            .source_uri(csv_path.clone())
+            .target_table("test_resume_inherit".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(1)
+            .chunk_size_bytes(1000)
+            .batch_size(10)
+            .batch_concurrency(1)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(HashMap::new())
+            .quiet(true)
+            .on_conflict(OnConflict::DoNothing)
+            .exclude_columns(vec!["pk_id".to_string(), "extra".to_string()])
+            .build()
+            .unwrap();
+
+        let result = coordinator.run_load(&config).await.unwrap();
+        assert_eq!(result.records_loaded, 2);
+        let job_id = result.job_id;
+
+        // Resume with exclude_columns omitted entirely should inherit from manifest.
+        let byte_reader2 = LocalFileByteReader::new(&csv_path);
+        let file_reader2: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader2,
+            DelimitedConfig::csv(),
+        ));
+        let coordinator2 = Coordinator::new(
+            manifest_storage.clone(),
+            file_reader2,
+            SchemaInferrer { has_header: true },
+            pool.clone(),
+        );
+        let resume_omitted = LoadConfigBuilder::default()
+            .source_uri(csv_path.clone())
+            .target_table("test_resume_inherit".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(1)
+            .chunk_size_bytes(1000)
+            .batch_size(10)
+            .batch_concurrency(1)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(HashMap::new())
+            .quiet(true)
+            .on_conflict(OnConflict::DoNothing)
+            .resume_job_id(Some(job_id.clone()))
+            .build()
+            .unwrap();
+
+        coordinator2
+            .run_load(&resume_omitted)
+            .await
+            .expect("resume without exclude_columns must succeed using manifest value");
+        assert_eq!(
+            get_table_count(&pool, "test_resume_inherit").await,
+            2,
+            "resume must not re-insert rows"
+        );
+
+        // Resume with the same exclude list in reversed order must also succeed
+        // (sort-before-compare makes the check order-independent).
+        let byte_reader3 = LocalFileByteReader::new(&csv_path);
+        let file_reader3: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader3,
+            DelimitedConfig::csv(),
+        ));
+        let coordinator3 = Coordinator::new(
+            manifest_storage,
+            file_reader3,
+            SchemaInferrer { has_header: true },
+            pool.clone(),
+        );
+        let resume_reordered = LoadConfigBuilder::default()
+            .source_uri(csv_path)
+            .target_table("test_resume_inherit".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(1)
+            .chunk_size_bytes(1000)
+            .batch_size(10)
+            .batch_concurrency(1)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(HashMap::new())
+            .quiet(true)
+            .on_conflict(OnConflict::DoNothing)
+            .exclude_columns(vec!["extra".to_string(), "pk_id".to_string()])
+            .resume_job_id(Some(job_id))
+            .build()
+            .unwrap();
+
+        coordinator3
+            .run_load(&resume_reordered)
+            .await
+            .expect("reordered exclude_columns must be accepted on resume");
+        assert_eq!(
+            get_table_count(&pool, "test_resume_inherit").await,
+            2,
+            "reordered-resume must not re-insert rows"
+        );
+    }
+
+    /// Manifest integrity: resuming with a corrupted manifest where
+    /// excluded_columns and excluded_positions disagree in length must be rejected
+    /// before any worker starts.
+    #[tokio::test]
+    async fn test_exclude_columns_resume_rejects_corrupted_manifest_parity() {
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path =
+            create_csv_with_content(&temp_dir, "corrupt.csv", &["pk_id,name\n", "1,Alice\n"]).await;
+        let pool = setup_sqlite_table(
+            "test_parity",
+            "pk_id TEXT DEFAULT (lower(hex(randomblob(16)))) PRIMARY KEY, name TEXT",
+        )
+        .await;
+
+        let manifest_dir = TempDir::new().unwrap();
+        let manifest_storage: Arc<dyn ManifestStorage> =
+            Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
+        let byte_reader = LocalFileByteReader::new(&csv_path);
+        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader,
+            DelimitedConfig::csv(),
+        ));
+        let coordinator = Coordinator::new(
+            manifest_storage.clone(),
+            file_reader,
+            SchemaInferrer { has_header: true },
+            pool.clone(),
+        );
+
+        let config = LoadConfigBuilder::default()
+            .source_uri(csv_path.clone())
+            .target_table("test_parity".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(1)
+            .chunk_size_bytes(1000)
+            .batch_size(10)
+            .batch_concurrency(1)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(HashMap::new())
+            .quiet(true)
+            .on_conflict(OnConflict::DoNothing)
+            .exclude_columns(vec!["pk_id".to_string()])
+            .build()
+            .unwrap();
+
+        let result = coordinator.run_load(&config).await.unwrap();
+        let job_id = result.job_id;
+
+        // Corrupt the manifest: keep excluded_columns but drop excluded_positions.
+        let manifest_path = manifest_dir
+            .path()
+            .join("jobs")
+            .join(&job_id)
+            .join("manifest.json");
+        let raw = std::fs::read_to_string(&manifest_path).unwrap();
+        let mut mf: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        mf["table"]["excluded_positions"] = serde_json::json!([]);
+        std::fs::write(&manifest_path, serde_json::to_string(&mf).unwrap()).unwrap();
+
+        let byte_reader2 = LocalFileByteReader::new(&csv_path);
+        let file_reader2: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader2,
+            DelimitedConfig::csv(),
+        ));
+        let coordinator2 = Coordinator::new(
+            manifest_storage,
+            file_reader2,
+            SchemaInferrer { has_header: true },
+            pool,
+        );
+        let resume_config = LoadConfigBuilder::default()
+            .source_uri(csv_path)
+            .target_table("test_parity".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(1)
+            .chunk_size_bytes(1000)
+            .batch_size(10)
+            .batch_concurrency(1)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(HashMap::new())
+            .quiet(true)
+            .on_conflict(OnConflict::DoNothing)
+            .resume_job_id(Some(job_id))
+            .build()
+            .unwrap();
+
+        let err = coordinator2
+            .run_load(&resume_config)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("manifest exclusion fields disagree"),
+            "expected parity error, got: {}",
+            err
+        );
+    }
+
+    /// Manifest integrity: an out-of-range `excluded_positions` entry must be
+    /// rejected on resume even when the parity check passes.
+    #[tokio::test]
+    async fn test_exclude_columns_resume_rejects_out_of_range_position() {
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path =
+            create_csv_with_content(&temp_dir, "oor.csv", &["pk_id,name\n", "1,Alice\n"]).await;
+        let pool = setup_sqlite_table(
+            "test_oor",
+            "pk_id TEXT DEFAULT (lower(hex(randomblob(16)))) PRIMARY KEY, name TEXT",
+        )
+        .await;
+
+        let manifest_dir = TempDir::new().unwrap();
+        let manifest_storage: Arc<dyn ManifestStorage> =
+            Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
+        let byte_reader = LocalFileByteReader::new(&csv_path);
+        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader,
+            DelimitedConfig::csv(),
+        ));
+        let coordinator = Coordinator::new(
+            manifest_storage.clone(),
+            file_reader,
+            SchemaInferrer { has_header: true },
+            pool.clone(),
+        );
+
+        let config = LoadConfigBuilder::default()
+            .source_uri(csv_path.clone())
+            .target_table("test_oor".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(1)
+            .chunk_size_bytes(1000)
+            .batch_size(10)
+            .batch_concurrency(1)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(HashMap::new())
+            .quiet(true)
+            .on_conflict(OnConflict::DoNothing)
+            .exclude_columns(vec!["pk_id".to_string()])
+            .build()
+            .unwrap();
+
+        let job_id = coordinator.run_load(&config).await.unwrap().job_id;
+
+        // Parity intact (len == 1), but position 99 is out of range.
+        let manifest_path = manifest_dir
+            .path()
+            .join("jobs")
+            .join(&job_id)
+            .join("manifest.json");
+        let raw = std::fs::read_to_string(&manifest_path).unwrap();
+        let mut mf: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        mf["table"]["excluded_positions"] = serde_json::json!([99]);
+        std::fs::write(&manifest_path, serde_json::to_string(&mf).unwrap()).unwrap();
+
+        let byte_reader2 = LocalFileByteReader::new(&csv_path);
+        let file_reader2: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader2,
+            DelimitedConfig::csv(),
+        ));
+        let coordinator2 = Coordinator::new(
+            manifest_storage,
+            file_reader2,
+            SchemaInferrer { has_header: true },
+            pool,
+        );
+        let resume_config = LoadConfigBuilder::default()
+            .source_uri(csv_path)
+            .target_table("test_oor".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(1)
+            .chunk_size_bytes(1000)
+            .batch_size(10)
+            .batch_concurrency(1)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(HashMap::new())
+            .quiet(true)
+            .on_conflict(OnConflict::DoNothing)
+            .resume_job_id(Some(job_id))
+            .build()
+            .unwrap();
+
+        let err = coordinator2
+            .run_load(&resume_config)
+            .await
+            .expect_err("resume must fail when excluded_positions has an out-of-range entry")
+            .to_string();
+        // Assert on the offending position value (the one stable diagnostic) rather
+        // than exact phrasing, which clap/anyhow may re-format.
+        assert!(
+            err.contains("99"),
+            "expected error to name the offending position, got: {}",
+            err
+        );
+    }
+
+    /// Manifest integrity: duplicate / non-strictly-increasing `excluded_positions`
+    /// entries must be rejected on resume. These cannot arise from
+    /// `compute_excluded_positions`, but a hand-edited manifest can produce them
+    /// and would otherwise cause silent field-mapping misalignment.
+    #[tokio::test]
+    async fn test_exclude_columns_resume_rejects_non_strictly_increasing_positions() {
+        async fn run_corruption_case(
+            table_suffix: &str,
+            corrupted_positions: serde_json::Value,
+        ) -> String {
+            let temp_dir = TempDir::new().unwrap();
+            let csv_path = create_csv_with_content(
+                &temp_dir,
+                "nsi.csv",
+                &["pk_id,extra,name\n", "1,x,Alice\n"],
+            )
+            .await;
+            let table = format!("test_nsi_{}", table_suffix);
+            let pool = setup_sqlite_table(
+                &table,
+                "pk_id TEXT DEFAULT (lower(hex(randomblob(16)))) PRIMARY KEY, \
+                 extra TEXT DEFAULT 'def', name TEXT",
+            )
+            .await;
+
+            let manifest_dir = TempDir::new().unwrap();
+            let manifest_storage: Arc<dyn ManifestStorage> =
+                Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
+            let byte_reader = LocalFileByteReader::new(&csv_path);
+            let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+                byte_reader,
+                DelimitedConfig::csv(),
+            ));
+            let coordinator = Coordinator::new(
+                manifest_storage.clone(),
+                file_reader,
+                SchemaInferrer { has_header: true },
+                pool.clone(),
+            );
+
+            // Common builder: the two call sites below differ only in whether they
+            // set exclude_columns (initial) or resume_job_id (resume).
+            let base_builder = |csv: String, table: String| {
+                LoadConfigBuilder::default()
+                    .source_uri(csv)
+                    .target_table(table)
+                    .schema("public".to_string())
+                    .dsql_config(DsqlConfig {
+                        endpoint: "test".to_string(),
+                        region: "us-west-2".to_string(),
+                        username: "test".to_string(),
+                    })
+                    .worker_count(1)
+                    .chunk_size_bytes(1000)
+                    .batch_size(10)
+                    .batch_concurrency(1)
+                    .create_table_if_missing(false)
+                    .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+                    .column_mappings(HashMap::new())
+                    .quiet(true)
+                    .on_conflict(OnConflict::DoNothing)
+                    .clone()
+            };
+
+            let config = base_builder(csv_path.clone(), table.clone())
+                .exclude_columns(vec!["pk_id".to_string(), "extra".to_string()])
+                .build()
+                .unwrap();
+
+            let job_id = coordinator
+                .run_load(&config)
+                .await
+                .expect("initial load must succeed so we have a manifest to corrupt")
+                .job_id;
+
+            // Parity preserved (len == 2) but positions violate strictly-increasing.
+            let manifest_path = manifest_dir
+                .path()
+                .join("jobs")
+                .join(&job_id)
+                .join("manifest.json");
+            let raw = std::fs::read_to_string(&manifest_path).unwrap();
+            let mut mf: serde_json::Value = serde_json::from_str(&raw).unwrap();
+            mf["table"]["excluded_positions"] = corrupted_positions;
+            std::fs::write(&manifest_path, serde_json::to_string(&mf).unwrap()).unwrap();
+
+            let byte_reader2 = LocalFileByteReader::new(&csv_path);
+            let file_reader2: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+                byte_reader2,
+                DelimitedConfig::csv(),
+            ));
+            let coordinator2 = Coordinator::new(
+                manifest_storage,
+                file_reader2,
+                SchemaInferrer { has_header: true },
+                pool,
+            );
+            let resume_config = base_builder(csv_path, table)
+                .resume_job_id(Some(job_id))
+                .build()
+                .unwrap();
+
+            coordinator2
+                .run_load(&resume_config)
+                .await
+                .expect_err("resume must fail on non-strictly-increasing excluded_positions")
+                .to_string()
+        }
+
+        // Duplicate positions: [0, 0] — must be rejected (not strictly increasing).
+        let err = run_corruption_case("dup", serde_json::json!([0, 0])).await;
+        assert!(
+            err.contains("not strictly increasing"),
+            "expected not-strictly-increasing error for duplicates, got: {}",
+            err
+        );
+
+        // Non-sorted positions: [1, 0] — must be rejected (not strictly increasing).
+        let err = run_corruption_case("unsorted", serde_json::json!([1, 0])).await;
+        assert!(
+            err.contains("not strictly increasing"),
+            "expected not-strictly-increasing error for unsorted, got: {}",
+            err
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use aurora_dsql_loader::runner::{Format, LoadArgs, OnConflict, run_load};
 use clap::{ArgGroup, Args as ClapArgs, Parser, Subcommand};
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 #[derive(Parser, Clone)]
@@ -92,6 +93,13 @@ struct LoadParams {
     /// Conflict resolution strategy (do-nothing, do-update, error)
     #[arg(long, default_value = "do-nothing")]
     on_conflict: String,
+
+    /// Columns to exclude from INSERT statements so the DB applies DEFAULT values
+    /// (format: col1,col2). Source records must still contain these columns - the
+    /// loader skips them by position. Requires the table to already exist; cannot
+    /// be combined with --if-not-exists.
+    #[arg(long, conflicts_with = "if_not_exists")]
+    exclude_columns: Option<String>,
 }
 
 #[derive(Clone, ClapArgs)]
@@ -228,7 +236,13 @@ async fn run_loader(
             )
         })?
     } else {
-        std::collections::HashMap::new()
+        HashMap::new()
+    };
+
+    let exclude_columns = if let Some(ref excl_str) = load.exclude_columns {
+        cli::parse_exclude_columns(excl_str)?
+    } else {
+        Vec::new()
     };
 
     // Parse on_conflict mode
@@ -262,6 +276,9 @@ async fn run_loader(
                 println!("    {} -> {}", src, dest);
             }
         }
+        if !exclude_columns.is_empty() {
+            println!("  Excluded columns: {}", exclude_columns.join(", "));
+        }
         println!();
         println!("To execute, run without --dry-run");
         return Ok(());
@@ -287,6 +304,7 @@ async fn run_loader(
         column_mappings,
         resume_job_id: output.resume_job_id.clone(),
         on_conflict,
+        exclude_columns,
         delimiter: source.delimiter.clone(),
         quote: source.quote.clone(),
         escape: source.escape.clone(),
@@ -449,6 +467,35 @@ mod cli {
         }
     }
 
+    /// Parse "col1,col2,col3" into Vec<String>.
+    /// Errors on empty input, empty column names, or duplicates.
+    pub fn parse_exclude_columns(input: &str) -> anyhow::Result<Vec<String>> {
+        if input.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "At least one column name is required for --exclude-columns"
+            ));
+        }
+
+        let mut cols = Vec::new();
+        for raw in input.split(',') {
+            let name = raw.trim();
+            if name.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "Empty column name in --exclude-columns value '{}'",
+                    input
+                ));
+            }
+            if cols.iter().any(|c| c == name) {
+                return Err(anyhow::anyhow!(
+                    "Duplicate column name '{}' in --exclude-columns",
+                    name
+                ));
+            }
+            cols.push(name.to_string());
+        }
+        Ok(cols)
+    }
+
     /// Parse column mapping string "src:dest,src2:dest2" into HashMap
     pub fn parse_column_mapping(mapping_str: &str) -> anyhow::Result<HashMap<String, String>> {
         let mut mappings = HashMap::new();
@@ -495,6 +542,114 @@ mod cli {
 mod tests {
     use super::*;
     use clap::Parser;
+    use std::collections::HashSet;
+
+    #[test]
+    fn parse_exclude_columns_basic() {
+        assert_eq!(
+            cli::parse_exclude_columns("id").unwrap(),
+            vec!["id".to_string()]
+        );
+        assert_eq!(
+            cli::parse_exclude_columns("id,created_at,updated_at").unwrap(),
+            vec![
+                "id".to_string(),
+                "created_at".to_string(),
+                "updated_at".to_string()
+            ]
+        );
+        assert_eq!(
+            cli::parse_exclude_columns("id, created_at , updated_at ").unwrap(),
+            vec![
+                "id".to_string(),
+                "created_at".to_string(),
+                "updated_at".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_exclude_columns_empty_errors() {
+        let err = cli::parse_exclude_columns("").unwrap_err().to_string();
+        assert!(err.contains("At least one column name is required"));
+        let err = cli::parse_exclude_columns("   ").unwrap_err().to_string();
+        assert!(err.contains("At least one column name is required"));
+    }
+
+    #[test]
+    fn parse_exclude_columns_empty_segment_errors() {
+        let err = cli::parse_exclude_columns("id,,name")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Empty column name"));
+    }
+
+    #[test]
+    fn parse_exclude_columns_duplicate_errors() {
+        let err = cli::parse_exclude_columns("id,name,id")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Duplicate column name 'id'"));
+    }
+
+    // Feature: loader-column-exclusion, Property 1: Parsing round-trip and duplicate detection
+    // NOTE: generator restricts to ASCII identifiers so no commas/whitespace leak into inputs
+    // and break the round-trip.
+    proptest::proptest! {
+        #[test]
+        fn prop_parse_exclude_columns_roundtrip(
+            names in proptest::collection::vec("[a-zA-Z_][a-zA-Z0-9_]{0,15}", 1..8)
+        ) {
+            let unique: Vec<String> = {
+                let mut seen = HashSet::new();
+                names.into_iter().filter(|n| seen.insert(n.clone())).collect()
+            };
+            proptest::prop_assume!(!unique.is_empty());
+            let joined = unique.join(",");
+            let parsed = cli::parse_exclude_columns(&joined).unwrap();
+            proptest::prop_assert_eq!(parsed, unique);
+        }
+
+        #[test]
+        fn prop_parse_exclude_columns_duplicate_detected(
+            base in "[a-zA-Z_][a-zA-Z0-9_]{0,15}",
+            others in proptest::collection::vec("[a-zA-Z_][a-zA-Z0-9_]{0,15}", 0..4),
+        ) {
+            // Inject base twice somewhere in the list to force a duplicate
+            let mut names = others;
+            names.push(base.clone());
+            names.push(base.clone());
+            let joined = names.join(",");
+            let err = cli::parse_exclude_columns(&joined).unwrap_err().to_string();
+            // Specifically the duplicate-detection path (not some other error)
+            proptest::prop_assert!(err.contains("Duplicate column name"));
+        }
+    }
+
+    #[test]
+    fn exclude_columns_conflicts_with_if_not_exists_at_parse_time() {
+        let result = Args::try_parse_from([
+            "aurora-dsql-loader",
+            "load",
+            "--endpoint",
+            "xxxx.dsql.us-east-1.on.aws",
+            "--source-uri",
+            "test.csv",
+            "--table",
+            "t",
+            "--exclude-columns",
+            "pk_id",
+            "--if-not-exists",
+            "--dry-run",
+        ]);
+        let err = match result {
+            Ok(_) => panic!("clap should reject --exclude-columns + --if-not-exists"),
+            Err(e) => e,
+        };
+        // Assert on ErrorKind (the stable contract) rather than message wording,
+        // which clap is free to re-phrase between releases.
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
 
     #[test]
     fn parquet_without_delimited_options_parses_successfully() {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -95,6 +95,9 @@ pub struct LoadArgs {
     // Conflict resolution strategy
     pub on_conflict: OnConflict,
 
+    // Columns to exclude from INSERT statements (DB applies DEFAULT values)
+    pub exclude_columns: Vec<String>,
+
     // Delimited file options (CSV/TSV)
     /// Field delimiter (default: "," for CSV, "\t" for TSV)
     pub delimiter: Option<String>,
@@ -162,6 +165,7 @@ pub struct LoadResult {
 ///     quote: None,
 ///     escape: None,
 ///     has_header: None,
+///     exclude_columns: Vec::new(),
 /// };
 ///
 /// let result = run_load(args).await?;
@@ -266,6 +270,7 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
         .debug(args.debug)
         .resume_job_id(args.resume_job_id)
         .on_conflict(args.on_conflict)
+        .exclude_columns(args.exclude_columns)
         .build()?;
 
     // Run the load


### PR DESCRIPTION
## Summary

- Adds `--exclude-columns col1,col2` CLI flag so users can load CSVs whose source system produces columns the DB fills via `DEFAULT` (e.g. `pk_id UUID DEFAULT gen_random_uuid() PRIMARY KEY`) without preprocessing their files.
- Skip-mode only (v1): source records must include all table columns; loader drops fields at excluded positions before generating INSERTs, so DSQL applies the DEFAULT server-side.
- Rejects the combinations that would silently do the wrong thing: `--if-not-exists` + exclude (DDL would strip the column), all conflict columns excluded under `do-update` (ON CONFLICT could never match), rename targeting an excluded column, and resume with a mismatched exclude list.

## Customer scenario solved

Customer has a 10M-row CSV that contains integer sequence values for a UUID PK column, but wants DSQL's `gen_random_uuid()` default to generate fresh UUIDs on load. Today this fails because the loader always builds INSERTs for all table columns. With `--exclude-columns pk_id`, the loader skips that field from each record and omits it from the INSERT column list.

## Design

- Identity mode (source already missing excluded columns) is deferred to v2 pending header-based disambiguation — without header validation, the loader can't tell "legitimate file missing excluded columns" from "malformed file missing a different column" and would silently map data into the wrong columns.

## Scope

- `src/main.rs` — CLI flag, `parse_exclude_columns`, dry-run output
- `src/runner.rs` — `LoadArgs.exclude_columns` plumbing
- `src/coordination/coordinator.rs` — validators, schema filter, resume compatibility check, conflict-column check
- `src/coordination/worker.rs` — `apply_field_exclusion` (skip-mode filter using `mem::take` to avoid cloning strings), aggregated error recording matching the existing `parse_errors` pattern
- `src/coordination/manifest.rs` — `excluded_columns` + `excluded_positions` on `TableInfo` with `#[serde(default, skip_serializing_if = "Vec::is_empty")]` for back-compat

## Tests

118 total (+38 over baseline), all passing. Covers:

- 4 property-based tests (parse round-trip, schema filter, field mapping in both directions, manifest round-trip)
- Unit tests for each validator (valid/invalid/empty/duplicate/overlap/all-excluded/conflict paths)
- Exclude-then-rename ordering invariant at coordinator level
- 8 end-to-end integration tests:
  - Customer scenario: CSV with PK values → DB-generated UUIDs (asserts CSV values NOT present in loaded table)
  - Field-count mismatch aggregation (one ErrorRecord per chunk, count + first observed size in message)
  - Unknown column name, all-excluded, rename conflict, `--if-not-exists` guard, `do-update` with all conflict columns excluded, resume mismatch detection

## Review iterations

Three internal review rounds before opening this PR, addressing: `--if-not-exists` silent DDL strip, resume-path validation, `mem::replace` awkwardness, sort-before-compare for resume, error-message diagnosis value (names chunk_id + first observed field count), and replacing a no-op column-map integration test with a coordinator-level ordering assertion.

## Test plan

- [ ] `cargo test` — all 118 tests pass
- [ ] `cargo clippy --all-targets` — clean
- [ ] `cargo fmt --check` — clean
- [ ] End-to-end against a real DSQL cluster with a `pk_id UUID DEFAULT gen_random_uuid() PRIMARY KEY` table and a CSV containing integer values for that column; confirm rows load and each gets a fresh UUID
- [ ] Try `--dry-run --exclude-columns foo,bar`; confirm the echo
- [ ] Try `--resume-job-id` after a partial load; confirm the exclude list is inherited from the manifest and mismatches are rejected