### PR TITLE
fix(#28): default CSV/TSV header to false; add --header flag (3.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@
   ```
 - If your file has no header, no change is needed — the new default already
   matches the actual file shape.
-- The `--no-header` flag continues to work but is now a no-op (it matches the
-  default). It will be removed in a future release.
+- The `--no-header` flag continues to work; it explicitly sets header behavior
+  to `false`, which matches the new default. Emits no diagnostic and will be
+  removed in a future release.
 
 ## [2.1.0] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [3.0.0] - 2026-05-26
+
+### Changed
+- **Breaking**: CSV/TSV loads now default to `--no-header` (treat first row as
+  data). Previously, the loader assumed a header row existed and silently
+  dropped the first data row when one did not. This caused customers loading
+  headerless files to lose exactly one row per file with no diagnostic
+  ([#28](https://github.com/aws-samples/aurora-dsql-loader/issues/28)).
+  The new default aligns with PostgreSQL `COPY FROM` (HEADER false), Amazon
+  Redshift (`IGNOREHEADER 0`), Snowflake (`SKIP_HEADER 0`), and BigQuery
+  (`--skip_leading_rows 0`).
+
+### Added
+- `--header` flag for CSV/TSV loads to opt into header-row skipping.
+- Mutual-exclusion validation: `--header` and `--no-header` cannot both be set.
+
+### Migration from 2.x
+- If your CSV/TSV has a header row, **add `--header`** to your invocation:
+  ```
+  aurora-dsql-loader load ... --source-uri data.csv --header
+  ```
+- If your file has no header, no change is needed — the new default already
+  matches the actual file shape.
+- The `--no-header` flag continues to work but is now a no-op (it matches the
+  default). It will be removed in a future release.
+
 ## [2.1.0] - 2026-05-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,7 +394,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aurora-dsql-loader"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aurora-dsql-loader"
-version = "2.1.0"
+version = "3.0.0"
 edition = "2024"
 description = "A data loader for Aurora DSQL with support for CSV, TSV, and Parquet files"
 homepage = "https://github.com/aws-samples/aurora-dsql-loader"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,36 @@ aurora-dsql-loader load \
 ```
 Listed columns are dropped from the INSERT so DSQL applies the column's `DEFAULT` expression (e.g. `gen_random_uuid()`, `CURRENT_TIMESTAMP`). Source records must still contain these columns in their original positions.
 
+### CSV/TSV header behavior
+
+By default, the loader treats every row of a CSV or TSV file as data — it does
+**not** skip the first row. This matches PostgreSQL `COPY FROM` (default
+`HEADER false`), Redshift, Snowflake, and BigQuery defaults.
+
+If your file has a header row, pass `--header` so it gets skipped:
+
+```bash
+aurora-dsql-loader load \
+  --endpoint $DSQL_ENDPOINT \
+  --source-uri sales_with_header.csv \
+  --table sales \
+  --header
+```
+
+If your file has no header row, no flag is needed:
+
+```bash
+aurora-dsql-loader load \
+  --endpoint $DSQL_ENDPOINT \
+  --source-uri sales_data_only.csv \
+  --table sales
+```
+
+> **Migrating from 2.x:** the previous default was the opposite — the loader
+> assumed a header row and silently dropped the first data row when one was
+> missing. Add `--header` to any 2.x invocation that loaded a header-bearing
+> file. See the [CHANGELOG](CHANGELOG.md) for full migration notes.
+
 ## Key Features
 
 - **Fast**: Parallel loading with configurable workers

--- a/src/coordination/worker.rs
+++ b/src/coordination/worker.rs
@@ -319,11 +319,11 @@ impl Worker {
         // numbers are unreliable as absolute source-file positions whenever drops
         // occurred upstream. Chunk-level errors from those drop paths use
         // line_number: 0 as a sentinel (see ErrorRecord doc comment).
-        let has_header = matches!(
-            manifest.file_format,
-            crate::coordination::manifest::FileFormat::Csv(_)
-                | crate::coordination::manifest::FileFormat::Tsv(_)
-        );
+        let has_header = match &manifest.file_format {
+            crate::coordination::manifest::FileFormat::Csv(c)
+            | crate::coordination::manifest::FileFormat::Tsv(c) => c.has_header,
+            crate::coordination::manifest::FileFormat::Parquet(_) => false,
+        };
         let mut current_line = if has_header { 2u64 } else { 1u64 };
 
         for batch in batches {

--- a/src/formats/reader.rs
+++ b/src/formats/reader.rs
@@ -81,9 +81,7 @@ impl DelimitedConfig {
     pub fn tsv() -> Self {
         Self {
             delimiter: "\\t".to_string(),
-            has_header: false,
-            quote: "\"".to_string(),
-            escape: None,
+            ..Self::default()
         }
     }
 }

--- a/src/formats/reader.rs
+++ b/src/formats/reader.rs
@@ -66,7 +66,7 @@ impl Default for DelimitedConfig {
     fn default() -> Self {
         Self {
             delimiter: ",".to_string(),
-            has_header: true,
+            has_header: false,
             quote: "\"".to_string(),
             escape: None,
         }
@@ -81,7 +81,7 @@ impl DelimitedConfig {
     pub fn tsv() -> Self {
         Self {
             delimiter: "\\t".to_string(),
-            has_header: true,
+            has_header: false,
             quote: "\"".to_string(),
             escape: None,
         }
@@ -225,7 +225,12 @@ mod tests {
         temp_file.flush().unwrap();
 
         let byte_reader = LocalFileByteReader::new(temp_file.path());
-        let reader = GenericDelimitedReader::new(byte_reader, DelimitedConfig::csv());
+        // Fixture has a header row, so override the has_header default.
+        let config = DelimitedConfig {
+            has_header: true,
+            ..DelimitedConfig::csv()
+        };
+        let reader = GenericDelimitedReader::new(byte_reader, config);
         let metadata = reader.metadata().await.unwrap();
 
         // Create chunks and use the first one (which skips the header)

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -2228,6 +2228,119 @@ mod tests {
         assert_eq!(result.records_failed, 0);
     }
 
+    /// Library-API validation: `has_header: Some(_)` is meaningless with Parquet
+    /// and must be rejected by `run_load` before any I/O. Mirrors the CLI's
+    /// `validate_delimited_options` so library consumers don't get silent drops.
+    #[tokio::test]
+    async fn test_run_load_rejects_has_header_with_parquet() {
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        let args = LoadArgs {
+            endpoint: "test".to_string(),
+            region: "us-west-2".to_string(),
+            username: "test".to_string(),
+            source_uri: "/dev/null".to_string(),
+            target_table: "t".to_string(),
+            schema: "public".to_string(),
+            format: Format::Parquet,
+            worker_count: 1,
+            chunk_size_bytes: 10_000_000,
+            batch_size: 100,
+            batch_concurrency: 1,
+            create_table_if_missing: false,
+            manifest_dir: None,
+            quiet: true,
+            debug: false,
+            column_mappings: HashMap::new(),
+            resume_job_id: None,
+            on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            exclude_columns: Vec::new(),
+            delimiter: None,
+            quote: None,
+            escape: None,
+            has_header: Some(true),
+            test_pool: Some(pool),
+        };
+        let err = run_load(args).await.expect_err("must reject");
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("has_header") && msg.contains("Parquet"),
+            "error message must name the offending option and format: {msg}"
+        );
+    }
+
+    /// Regression: worker `current_line` must start at 1 for headerless CSVs.
+    ///
+    /// Pre-fix, `has_header` was derived from the format variant rather than the
+    /// manifest's `DelimitedConfig.has_header`, so headerless CSV/TSV loads
+    /// reported error line numbers off by one.
+    #[tokio::test]
+    async fn test_headerless_csv_error_line_numbers_are_one_based() {
+        let temp_dir = TempDir::new().unwrap();
+        // Headerless CSV with a duplicate id; first row is line 1.
+        let csv_path = create_csv_with_content(
+            &temp_dir,
+            "dup_headerless.csv",
+            &["1,Alice\n", "1,Alice_Duplicate\n"],
+        )
+        .await;
+
+        let pool =
+            setup_sqlite_table("test_dup_headerless", "id TEXT PRIMARY KEY, name TEXT").await;
+
+        let byte_reader = LocalFileByteReader::new(&csv_path);
+        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
+            byte_reader,
+            DelimitedConfig::csv(),
+        ));
+        let manifest_dir = TempDir::new().unwrap();
+        let manifest_storage: Arc<dyn ManifestStorage> =
+            Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
+        let coordinator = Coordinator::new(
+            manifest_storage,
+            file_reader,
+            SchemaInferrer { has_header: false },
+            pool.clone(),
+        );
+
+        // Use OnConflict::Error so the duplicate triggers a batch_error
+        // (which reports `line_number = line_offset` derived from current_line).
+        let config = LoadConfigBuilder::default()
+            .source_uri(csv_path)
+            .target_table("test_dup_headerless".to_string())
+            .schema("public".to_string())
+            .dsql_config(DsqlConfig {
+                endpoint: "test".to_string(),
+                region: "us-west-2".to_string(),
+                username: "test".to_string(),
+            })
+            .worker_count(1)
+            .chunk_size_bytes(1000)
+            .batch_size(10)
+            .batch_concurrency(1)
+            .create_table_if_missing(false)
+            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .column_mappings(HashMap::new())
+            .quiet(true)
+            .on_conflict(OnConflict::Error)
+            .build()
+            .unwrap();
+
+        let result = coordinator.run_load(&config).await.unwrap();
+        assert_eq!(result.records_failed, 2, "Both rows fail as a batch");
+
+        let batch_errors: Vec<_> = result
+            .chunk_results
+            .iter()
+            .flat_map(|r| r.errors.iter())
+            .filter(|e| e.error_type == "batch_error")
+            .collect();
+        assert_eq!(batch_errors.len(), 1);
+        assert_eq!(
+            batch_errors[0].line_number, 1,
+            "Headerless CSV must report line_offset starting at 1, not 2"
+        );
+    }
+
     #[tokio::test]
     async fn test_rfc4180_crlf_line_endings() {
         let temp_dir = TempDir::new().unwrap();

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -75,6 +75,27 @@ mod tests {
         pool
     }
 
+    /// Helper that builds a CSV `DelimitedConfig` with `has_header: true`.
+    ///
+    /// Most tests in this file create header-bearing fixtures via
+    /// `create_test_csv` / `create_csv_with_content`, but the library default
+    /// for `DelimitedConfig::csv()` is `has_header: false` (matches Postgres
+    /// `COPY FROM` HEADER default). This helper makes the test intent explicit.
+    fn csv_with_header() -> DelimitedConfig {
+        DelimitedConfig {
+            has_header: true,
+            ..DelimitedConfig::csv()
+        }
+    }
+
+    /// Helper that builds a TSV `DelimitedConfig` with `has_header: true`.
+    fn tsv_with_header() -> DelimitedConfig {
+        DelimitedConfig {
+            has_header: true,
+            ..DelimitedConfig::tsv()
+        }
+    }
+
     /// Helper to run a basic CSV load test with defaults
     async fn run_csv_load(
         pool: &Pool,
@@ -84,10 +105,8 @@ mod tests {
         chunk_size: u64,
     ) -> LoadResult {
         let byte_reader = LocalFileByteReader::new(csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::default(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
 
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
@@ -114,7 +133,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(2)
             .create_table_if_missing(true)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .debug(true) // Enable debug for tests to verify verbose output
@@ -133,10 +152,8 @@ mod tests {
         chunk_size: u64,
     ) -> LoadResult {
         let byte_reader = LocalFileByteReader::new(tsv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::tsv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, tsv_with_header()));
 
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
@@ -163,7 +180,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(2)
             .create_table_if_missing(true)
-            .file_format(FileFormat::Tsv(DelimitedConfig::tsv()))
+            .file_format(FileFormat::Tsv(tsv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .build()
@@ -485,7 +502,7 @@ mod tests {
             delimiter: None,
             quote: None,
             escape: None,
-            has_header: None,
+            has_header: Some(true),
             test_pool: Some(pool.clone()),
         };
 
@@ -605,10 +622,8 @@ mod tests {
         let pool = Pool::sqlite_in_memory().await.unwrap();
 
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::default(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
 
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
@@ -635,7 +650,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false) // This is the key - not creating the table
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .build()
@@ -722,7 +737,7 @@ mod tests {
             delimiter: None,
             quote: None,
             escape: None,
-            has_header: None,
+            has_header: Some(true),
             test_pool: Some(pool),
         };
 
@@ -824,10 +839,8 @@ mod tests {
         .await;
 
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::default(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
 
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
@@ -854,7 +867,7 @@ mod tests {
             .batch_size(3) // All 3 records in one batch
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .debug(true) // Enable debug mode to get verbose output
@@ -922,10 +935,8 @@ mod tests {
         .await;
 
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
 
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
@@ -949,7 +960,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(2)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .build()
@@ -996,7 +1007,7 @@ mod tests {
             delimiter: None,
             quote: None,
             escape: None,
-            has_header: None,
+            has_header: Some(true),
             test_pool: Some(pool.clone()),
         };
 
@@ -1016,10 +1027,8 @@ mod tests {
         let pool = Pool::sqlite_in_memory().await.unwrap();
 
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
 
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
@@ -1043,7 +1052,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(true)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .build()
@@ -1100,7 +1109,7 @@ mod tests {
             delimiter: None,
             quote: None,
             escape: None,
-            has_header: None,
+            has_header: Some(true),
             test_pool: Some(pool.clone()),
         };
 
@@ -1190,7 +1199,7 @@ mod tests {
             delimiter: None,
             quote: None,
             escape: None,
-            has_header: None,
+            has_header: Some(true),
             test_pool: Some(pool.clone()),
         };
 
@@ -1312,7 +1321,7 @@ mod tests {
             delimiter: None,
             quote: None,
             escape: None,
-            has_header: None,
+            has_header: Some(true),
             test_pool: Some(pool.clone()),
         };
 
@@ -1408,7 +1417,7 @@ mod tests {
             delimiter: None,
             quote: None,
             escape: None,
-            has_header: None,
+            has_header: Some(true),
             test_pool: Some(pool.clone()),
         };
 
@@ -1467,10 +1476,8 @@ mod tests {
 
         // Load initial data with do-nothing mode
         let byte_reader = LocalFileByteReader::new(&csv_path1);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
 
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
@@ -1497,7 +1504,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
@@ -1522,10 +1529,8 @@ mod tests {
 
         // Load with do-update mode (upsert)
         let byte_reader2 = LocalFileByteReader::new(&csv_path2);
-        let file_reader2: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader2,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader2: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader2, csv_with_header()));
 
         let coordinator2 = Coordinator::new(
             manifest_storage,
@@ -1548,7 +1553,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoUpdate)
@@ -1604,10 +1609,8 @@ mod tests {
 
         // Load initial data
         let byte_reader = LocalFileByteReader::new(&csv_path1);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
 
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
@@ -1634,7 +1637,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::Error)
@@ -1653,10 +1656,8 @@ mod tests {
         .await;
 
         let byte_reader2 = LocalFileByteReader::new(&csv_path2);
-        let file_reader2: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader2,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader2: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader2, csv_with_header()));
 
         let coordinator2 = Coordinator::new(
             manifest_storage,
@@ -1679,7 +1680,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::Error)
@@ -1706,10 +1707,8 @@ mod tests {
         let pool = setup_sqlite_table("test_no_constraints", "id TEXT, name TEXT").await;
 
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
 
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
@@ -1736,7 +1735,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoUpdate)
@@ -1787,10 +1786,8 @@ mod tests {
         }
 
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
 
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
@@ -1817,7 +1814,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .debug(true) // Enable debug mode to verify verbose output
@@ -2006,7 +2003,7 @@ mod tests {
             None,
             None,
             None,
-            None,
+            Some(true),
         )
         .await;
 
@@ -2048,7 +2045,7 @@ mod tests {
             None,
             None,
             None,
-            None,
+            Some(true),
         )
         .await;
 
@@ -2155,7 +2152,8 @@ mod tests {
 
         let pool = setup_sqlite_table("test_crlf", "col1 TEXT, col2 TEXT").await;
         let result =
-            run_csv_load_with_opts(&pool, "test_crlf", &csv_path, None, None, None, None).await;
+            run_csv_load_with_opts(&pool, "test_crlf", &csv_path, None, None, None, Some(true))
+                .await;
 
         assert_eq!(result.records_loaded, 2);
         assert_eq!(result.records_failed, 0);
@@ -2172,9 +2170,16 @@ mod tests {
         .await;
 
         let pool = setup_sqlite_table("test_no_trailing", "col1 TEXT, col2 TEXT").await;
-        let result =
-            run_csv_load_with_opts(&pool, "test_no_trailing", &csv_path, None, None, None, None)
-                .await;
+        let result = run_csv_load_with_opts(
+            &pool,
+            "test_no_trailing",
+            &csv_path,
+            None,
+            None,
+            None,
+            Some(true),
+        )
+        .await;
 
         assert_eq!(result.records_loaded, 2);
         assert_eq!(result.records_failed, 0);
@@ -2191,8 +2196,16 @@ mod tests {
         .await;
 
         let pool = setup_sqlite_table("test_spaces", "col1 TEXT, col2 TEXT").await;
-        let result =
-            run_csv_load_with_opts(&pool, "test_spaces", &csv_path, None, None, None, None).await;
+        let result = run_csv_load_with_opts(
+            &pool,
+            "test_spaces",
+            &csv_path,
+            None,
+            None,
+            None,
+            Some(true),
+        )
+        .await;
 
         assert_eq!(result.records_loaded, 2);
         assert_eq!(result.records_failed, 0);
@@ -2209,8 +2222,16 @@ mod tests {
         .await;
 
         let pool = setup_sqlite_table("test_quoted", "col1 TEXT, col2 TEXT").await;
-        let result =
-            run_csv_load_with_opts(&pool, "test_quoted", &csv_path, None, None, None, None).await;
+        let result = run_csv_load_with_opts(
+            &pool,
+            "test_quoted",
+            &csv_path,
+            None,
+            None,
+            None,
+            Some(true),
+        )
+        .await;
 
         assert_eq!(result.records_loaded, 2);
         assert_eq!(result.records_failed, 0);
@@ -2227,9 +2248,16 @@ mod tests {
         .await;
 
         let pool = setup_sqlite_table("test_embedded_nl", "col1 TEXT, col2 TEXT").await;
-        let result =
-            run_csv_load_with_opts(&pool, "test_embedded_nl", &csv_path, None, None, None, None)
-                .await;
+        let result = run_csv_load_with_opts(
+            &pool,
+            "test_embedded_nl",
+            &csv_path,
+            None,
+            None,
+            None,
+            Some(true),
+        )
+        .await;
 
         assert_eq!(result.records_loaded, 2);
         assert_eq!(result.records_failed, 0);
@@ -2253,7 +2281,7 @@ mod tests {
             None,
             None,
             None,
-            None,
+            Some(true),
         )
         .await;
 
@@ -2280,7 +2308,7 @@ mod tests {
             None,
             None,
             None,
-            None,
+            Some(true),
         )
         .await;
 
@@ -2313,7 +2341,7 @@ mod tests {
             None,
             None,
             Some("\\".to_string()),
-            None,
+            Some(true),
         )
         .await;
 
@@ -2339,7 +2367,7 @@ mod tests {
             None,
             None,
             None,
-            None,
+            Some(true),
         )
         .await;
 
@@ -2389,8 +2417,16 @@ mod tests {
         .await;
 
         let pool = setup_sqlite_table("test_unicode", "col1 TEXT, col2 TEXT").await;
-        let result =
-            run_csv_load_with_opts(&pool, "test_unicode", &csv_path, None, None, None, None).await;
+        let result = run_csv_load_with_opts(
+            &pool,
+            "test_unicode",
+            &csv_path,
+            None,
+            None,
+            None,
+            Some(true),
+        )
+        .await;
 
         assert_eq!(result.records_loaded, 3);
         assert_eq!(result.records_failed, 0);
@@ -2414,7 +2450,7 @@ mod tests {
             None,
             None,
             None,
-            None,
+            Some(true),
         )
         .await;
 
@@ -2452,10 +2488,8 @@ mod tests {
         .await;
 
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
             Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
@@ -2480,7 +2514,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
@@ -2534,10 +2568,8 @@ mod tests {
         .await;
 
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
             Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
@@ -2562,7 +2594,7 @@ mod tests {
             .batch_size(50)
             .batch_concurrency(2)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
@@ -2734,10 +2766,8 @@ mod tests {
         .await;
 
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
             Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
@@ -2762,7 +2792,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
@@ -2803,10 +2833,8 @@ mod tests {
         let pool = setup_sqlite_table("test_unknown", "id TEXT PRIMARY KEY, name TEXT").await;
 
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
             Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
@@ -2831,7 +2859,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
@@ -2875,10 +2903,8 @@ mod tests {
         .await;
 
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
             Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
@@ -2906,7 +2932,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(mappings)
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
@@ -2935,10 +2961,8 @@ mod tests {
         .await;
 
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
             Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
@@ -2966,7 +2990,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(mappings)
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
@@ -2992,10 +3016,8 @@ mod tests {
         let pool = Pool::sqlite_in_memory().await.unwrap();
 
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
             Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
@@ -3020,7 +3042,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(true)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
@@ -3052,10 +3074,8 @@ mod tests {
         .await;
 
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
         let manifest_dir = TempDir::new().unwrap();
         let manifest_storage: Arc<dyn ManifestStorage> =
             Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
@@ -3080,7 +3100,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoUpdate)
@@ -3118,10 +3138,8 @@ mod tests {
             Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
 
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
         let coordinator = Coordinator::new(
             manifest_storage.clone(),
             file_reader,
@@ -3143,7 +3161,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
@@ -3157,10 +3175,8 @@ mod tests {
 
         // Resume with a DIFFERENT exclude list must fail
         let byte_reader2 = LocalFileByteReader::new(&csv_path);
-        let file_reader2: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader2,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader2: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader2, csv_with_header()));
         let coordinator2 = Coordinator::new(
             manifest_storage.clone(),
             file_reader2,
@@ -3181,7 +3197,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
@@ -3226,10 +3242,8 @@ mod tests {
             Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
 
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
         let coordinator = Coordinator::new(
             manifest_storage.clone(),
             file_reader,
@@ -3251,7 +3265,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
@@ -3265,10 +3279,8 @@ mod tests {
 
         // Resume with exclude_columns omitted entirely should inherit from manifest.
         let byte_reader2 = LocalFileByteReader::new(&csv_path);
-        let file_reader2: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader2,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader2: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader2, csv_with_header()));
         let coordinator2 = Coordinator::new(
             manifest_storage.clone(),
             file_reader2,
@@ -3289,7 +3301,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
@@ -3310,10 +3322,8 @@ mod tests {
         // Resume with the same exclude list in reversed order must also succeed
         // (sort-before-compare makes the check order-independent).
         let byte_reader3 = LocalFileByteReader::new(&csv_path);
-        let file_reader3: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader3,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader3: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader3, csv_with_header()));
         let coordinator3 = Coordinator::new(
             manifest_storage,
             file_reader3,
@@ -3334,7 +3344,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
@@ -3372,10 +3382,8 @@ mod tests {
         let manifest_storage: Arc<dyn ManifestStorage> =
             Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
         let coordinator = Coordinator::new(
             manifest_storage.clone(),
             file_reader,
@@ -3397,7 +3405,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
@@ -3420,10 +3428,8 @@ mod tests {
         std::fs::write(&manifest_path, serde_json::to_string(&mf).unwrap()).unwrap();
 
         let byte_reader2 = LocalFileByteReader::new(&csv_path);
-        let file_reader2: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader2,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader2: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader2, csv_with_header()));
         let coordinator2 = Coordinator::new(
             manifest_storage,
             file_reader2,
@@ -3444,7 +3450,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
@@ -3481,10 +3487,8 @@ mod tests {
         let manifest_storage: Arc<dyn ManifestStorage> =
             Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
         let byte_reader = LocalFileByteReader::new(&csv_path);
-        let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
         let coordinator = Coordinator::new(
             manifest_storage.clone(),
             file_reader,
@@ -3506,7 +3510,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
@@ -3528,10 +3532,8 @@ mod tests {
         std::fs::write(&manifest_path, serde_json::to_string(&mf).unwrap()).unwrap();
 
         let byte_reader2 = LocalFileByteReader::new(&csv_path);
-        let file_reader2: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-            byte_reader2,
-            DelimitedConfig::csv(),
-        ));
+        let file_reader2: Arc<dyn FileReader> =
+            Arc::new(GenericDelimitedReader::new(byte_reader2, csv_with_header()));
         let coordinator2 = Coordinator::new(
             manifest_storage,
             file_reader2,
@@ -3552,7 +3554,7 @@ mod tests {
             .batch_size(10)
             .batch_concurrency(1)
             .create_table_if_missing(false)
-            .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+            .file_format(FileFormat::Csv(csv_with_header()))
             .column_mappings(HashMap::new())
             .quiet(true)
             .on_conflict(OnConflict::DoNothing)
@@ -3603,10 +3605,8 @@ mod tests {
             let manifest_storage: Arc<dyn ManifestStorage> =
                 Arc::new(LocalManifestStorage::new(manifest_dir.path().to_path_buf()));
             let byte_reader = LocalFileByteReader::new(&csv_path);
-            let file_reader: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-                byte_reader,
-                DelimitedConfig::csv(),
-            ));
+            let file_reader: Arc<dyn FileReader> =
+                Arc::new(GenericDelimitedReader::new(byte_reader, csv_with_header()));
             let coordinator = Coordinator::new(
                 manifest_storage.clone(),
                 file_reader,
@@ -3631,7 +3631,7 @@ mod tests {
                     .batch_size(10)
                     .batch_concurrency(1)
                     .create_table_if_missing(false)
-                    .file_format(FileFormat::Csv(DelimitedConfig::csv()))
+                    .file_format(FileFormat::Csv(csv_with_header()))
                     .column_mappings(HashMap::new())
                     .quiet(true)
                     .on_conflict(OnConflict::DoNothing)
@@ -3661,10 +3661,8 @@ mod tests {
             std::fs::write(&manifest_path, serde_json::to_string(&mf).unwrap()).unwrap();
 
             let byte_reader2 = LocalFileByteReader::new(&csv_path);
-            let file_reader2: Arc<dyn FileReader> = Arc::new(GenericDelimitedReader::new(
-                byte_reader2,
-                DelimitedConfig::csv(),
-            ));
+            let file_reader2: Arc<dyn FileReader> =
+                Arc::new(GenericDelimitedReader::new(byte_reader2, csv_with_header()));
             let coordinator2 = Coordinator::new(
                 manifest_storage,
                 file_reader2,

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -2109,6 +2109,17 @@ mod tests {
         path.to_str().unwrap().to_string()
     }
 
+    async fn create_headerless_tsv(dir: &TempDir, filename: &str, num_rows: usize) -> String {
+        let path = dir.path().join(filename);
+        let mut file = File::create(&path).await.unwrap();
+        for i in 0..num_rows {
+            let line = format!("{}\tname_{}\t{}.5\t{}\n", i, i, i, i * 10);
+            file.write_all(line.as_bytes()).await.unwrap();
+        }
+        file.flush().await.unwrap();
+        path.to_str().unwrap().to_string()
+    }
+
     #[tokio::test]
     async fn test_headerless_csv_loads_all_rows_by_default() {
         // Reproduces issue #28: a CSV with no header row must not silently
@@ -2165,6 +2176,55 @@ mod tests {
         .await;
 
         assert_eq!(result.records_loaded, 1000);
+        assert_eq!(result.records_failed, 0);
+    }
+
+    #[tokio::test]
+    async fn test_headerless_tsv_loads_all_rows_by_default() {
+        // Symmetric coverage to test_headerless_csv_loads_all_rows_by_default:
+        // a TSV with no header row must not silently drop the first data row
+        // when the user passes no header-related flags.
+        let temp_dir = TempDir::new().unwrap();
+        let tsv_path = create_headerless_tsv(&temp_dir, "headerless.tsv", 1000).await;
+
+        let pool = setup_sqlite_table(
+            "headerless_tsv",
+            "id INTEGER, name TEXT, value REAL, amount INTEGER",
+        )
+        .await;
+
+        let args = LoadArgs {
+            endpoint: "test".to_string(),
+            region: "us-west-2".to_string(),
+            username: "test".to_string(),
+            source_uri: tsv_path,
+            target_table: "headerless_tsv".to_string(),
+            schema: "public".to_string(),
+            format: Format::Tsv,
+            worker_count: 1,
+            chunk_size_bytes: 10_000_000,
+            batch_size: 100,
+            batch_concurrency: 1,
+            create_table_if_missing: false,
+            manifest_dir: None,
+            quiet: true,
+            debug: false,
+            column_mappings: HashMap::new(),
+            resume_job_id: None,
+            on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            exclude_columns: Vec::new(),
+            delimiter: None,
+            quote: None,
+            escape: None,
+            has_header: None,
+            test_pool: Some(pool.clone()),
+        };
+        let result = run_load(args).await.unwrap();
+
+        assert_eq!(
+            result.records_loaded, 1000,
+            "All 1000 data rows must load when TSV has no header (issue #28 symmetric case)"
+        );
         assert_eq!(result.records_failed, 0);
     }
 

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -2141,6 +2141,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_csv_with_header_loads_all_rows_when_header_flag_set() {
+        // Verifies the new --header CLI flag (which sets has_header: Some(true))
+        // correctly skips the header row and loads every data row.
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path = create_test_csv(&temp_dir, "with_header.csv", 1000).await;
+
+        let pool = setup_sqlite_table(
+            "with_header",
+            "id INTEGER, name TEXT, value REAL, amount INTEGER",
+        )
+        .await;
+
+        let result = run_csv_load_with_opts(
+            &pool,
+            "with_header",
+            &csv_path,
+            None,
+            None,
+            None,
+            /* has_header */ Some(true),
+        )
+        .await;
+
+        assert_eq!(result.records_loaded, 1000);
+        assert_eq!(result.records_failed, 0);
+    }
+
+    #[tokio::test]
     async fn test_rfc4180_crlf_line_endings() {
         let temp_dir = TempDir::new().unwrap();
         let csv_path = create_csv_with_content(

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -2228,6 +2228,88 @@ mod tests {
         assert_eq!(result.records_failed, 0);
     }
 
+    #[tokio::test]
+    async fn test_tsv_with_header_loads_all_rows_when_header_flag_set() {
+        // Symmetric to test_csv_with_header_loads_all_rows_when_header_flag_set:
+        // a header-bearing TSV with `has_header: Some(true)` must skip the
+        // header and load every data row.
+        let temp_dir = TempDir::new().unwrap();
+        let tsv_path = create_test_tsv(&temp_dir, "with_header.tsv", 1000).await;
+
+        let pool = setup_sqlite_table(
+            "tsv_with_header",
+            "id INTEGER, name TEXT, value REAL, amount INTEGER",
+        )
+        .await;
+
+        let args = LoadArgs {
+            endpoint: "test".to_string(),
+            region: "us-west-2".to_string(),
+            username: "test".to_string(),
+            source_uri: tsv_path,
+            target_table: "tsv_with_header".to_string(),
+            schema: "public".to_string(),
+            format: Format::Tsv,
+            worker_count: 1,
+            chunk_size_bytes: 10_000_000,
+            batch_size: 100,
+            batch_concurrency: 1,
+            create_table_if_missing: false,
+            manifest_dir: None,
+            quiet: true,
+            debug: false,
+            column_mappings: HashMap::new(),
+            resume_job_id: None,
+            on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            exclude_columns: Vec::new(),
+            delimiter: None,
+            quote: None,
+            escape: None,
+            has_header: Some(true),
+            test_pool: Some(pool.clone()),
+        };
+        let result = run_load(args).await.unwrap();
+
+        assert_eq!(result.records_loaded, 1000);
+        assert_eq!(result.records_failed, 0);
+    }
+
+    #[tokio::test]
+    async fn test_header_csv_without_header_flag_eats_header_as_data() {
+        // Symmetric mirror of issue #28: a header-bearing CSV loaded WITHOUT
+        // `--header` under the new 3.0.0 default (`has_header: None` → false)
+        // treats the header line as a data row. With a TEXT schema the row
+        // gets silently inserted (records_loaded = data_rows + 1), which is
+        // the failure mode the post-load `--header` advisory exists to flag.
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path = create_test_csv(&temp_dir, "header_no_flag.csv", 1000).await;
+
+        // TEXT-only schema so the header line ("id,name,value,amount") parses
+        // as a valid row instead of failing on type coercion.
+        let pool = setup_sqlite_table(
+            "header_no_flag",
+            "id TEXT, name TEXT, value TEXT, amount TEXT",
+        )
+        .await;
+
+        let result = run_csv_load_with_opts(
+            &pool,
+            "header_no_flag",
+            &csv_path,
+            None,
+            None,
+            None,
+            /* has_header */ None,
+        )
+        .await;
+
+        assert_eq!(
+            result.records_loaded, 1001,
+            "header line should be loaded as a 1001st data row when --header is not set"
+        );
+        assert_eq!(result.records_failed, 0);
+    }
+
     /// Library-API validation: `has_header: Some(_)` is meaningless with Parquet
     /// and must be rejected by `run_load` before any I/O. Mirrors the CLI's
     /// `validate_delimited_options` so library consumers don't get silent drops.

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -2100,6 +2100,49 @@ mod tests {
         run_load(args).await.unwrap()
     }
 
+    /// Helper to create a CSV file with NO header row (just data).
+    async fn create_headerless_csv(dir: &TempDir, filename: &str, num_rows: usize) -> String {
+        let path = dir.path().join(filename);
+        let mut file = File::create(&path).await.unwrap();
+        for i in 0..num_rows {
+            let line = format!("{},name_{},{}.5,{}\n", i, i, i, i * 10);
+            file.write_all(line.as_bytes()).await.unwrap();
+        }
+        file.flush().await.unwrap();
+        path.to_str().unwrap().to_string()
+    }
+
+    #[tokio::test]
+    async fn test_headerless_csv_loads_all_rows_by_default() {
+        // Reproduces issue #28: a CSV with no header row must not silently
+        // drop the first data row when the user passes no header-related flags.
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path = create_headerless_csv(&temp_dir, "headerless.csv", 1000).await;
+
+        let pool = setup_sqlite_table(
+            "headerless",
+            "id INTEGER, name TEXT, value REAL, amount INTEGER",
+        )
+        .await;
+
+        let result = run_csv_load_with_opts(
+            &pool,
+            "headerless",
+            &csv_path,
+            None,
+            None,
+            None,
+            /* has_header */ None,
+        )
+        .await;
+
+        assert_eq!(
+            result.records_loaded, 1000,
+            "All 1000 data rows must load when CSV has no header (issue #28)"
+        );
+        assert_eq!(result.records_failed, 0);
+    }
+
     #[tokio::test]
     async fn test_rfc4180_crlf_line_endings() {
         let temp_dir = TempDir::new().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,8 +53,8 @@ struct SourceArgs {
     #[arg(long, groups = ["delimited", "header_mode"])]
     header: bool,
 
-    /// CSV/TSV file has no header row (default behavior; kept for backward
-    /// compatibility with 2.x scripts — will be removed in a future release)
+    /// Deprecated alias for the default no-header behavior. Has no effect
+    /// beyond rejecting an accompanying `--header`. Prefer omitting the flag.
     #[arg(long, groups = ["delimited", "header_mode"])]
     no_header: bool,
 }
@@ -314,6 +314,7 @@ async fn run_loader(
         delimiter: source.delimiter.clone(),
         quote: source.quote.clone(),
         escape: source.escape.clone(),
+        // `header_mode` ArgGroup makes --header/--no-header mutually exclusive at parse time.
         has_header: if source.header {
             Some(true)
         } else if source.no_header {
@@ -662,6 +663,54 @@ mod tests {
         // Assert on ErrorKind (the stable contract) rather than message wording,
         // which clap is free to re-phrase between releases.
         assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn header_and_no_header_are_mutually_exclusive_at_parse_time() {
+        let result = Args::try_parse_from([
+            "aurora-dsql-loader",
+            "load",
+            "--endpoint",
+            "xxxx.dsql.us-east-1.on.aws",
+            "--source-uri",
+            "test.csv",
+            "--table",
+            "t",
+            "--header",
+            "--no-header",
+            "--dry-run",
+        ]);
+        let err = match result {
+            Ok(_) => panic!("clap should reject --header + --no-header"),
+            Err(e) => e,
+        };
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn header_flag_rejected_with_parquet_format() {
+        let args = Args::try_parse_from([
+            "aurora-dsql-loader",
+            "load",
+            "--endpoint",
+            "xxxx.dsql.us-east-1.on.aws",
+            "--source-uri",
+            "test_file.parquet",
+            "--table",
+            "my_table",
+            "--header",
+            "--dry-run",
+        ])
+        .expect("args should parse (clap groups don't restrict by format)");
+
+        let Command::Load { source, .. } = args.command;
+        let err = validate_delimited_options("parquet", Format::Parquet, &source)
+            .expect_err("--header on parquet must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--header"),
+            "error should name the offending --header flag: {msg}"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,6 @@ struct ConnectionArgs {
 
 #[derive(Clone, ClapArgs)]
 #[command(group = ArgGroup::new("delimited").multiple(true))]
-#[command(group = ArgGroup::new("header_mode").multiple(false))]
 struct SourceArgs {
     /// Path to source data file or S3 URI (local path, s3://bucket/key)
     #[arg(short, long)]
@@ -50,12 +49,12 @@ struct SourceArgs {
     escape: Option<String>,
 
     /// CSV/TSV file has a header row that should be skipped
-    #[arg(long, groups = ["delimited", "header_mode"])]
+    #[arg(long, group = "delimited", conflicts_with = "no_header")]
     header: bool,
 
-    /// Deprecated alias for the default no-header behavior. Has no effect
-    /// beyond rejecting an accompanying `--header`. Prefer omitting the flag.
-    #[arg(long, groups = ["delimited", "header_mode"])]
+    /// Deprecated. Explicitly sets header behavior to false, which matches the
+    /// new default. Prefer omitting the flag; will be removed in a future release.
+    #[arg(long, group = "delimited")]
     no_header: bool,
 }
 
@@ -352,7 +351,7 @@ async fn run_loader(
                 total_processed, estimated
             );
             println!(
-                "This may indicate silent parse errors. Check --delimiter, --quote, and --escape settings."
+                "This may indicate silent parse errors. Check --header, --delimiter, --quote, and --escape settings."
             );
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ struct ConnectionArgs {
 
 #[derive(Clone, ClapArgs)]
 #[command(group = ArgGroup::new("delimited").multiple(true))]
+#[command(group = ArgGroup::new("header_mode").multiple(false))]
 struct SourceArgs {
     /// Path to source data file or S3 URI (local path, s3://bucket/key)
     #[arg(short, long)]
@@ -48,8 +49,13 @@ struct SourceArgs {
     #[arg(long, group = "delimited")]
     escape: Option<String>,
 
-    /// File has no header row
-    #[arg(long, group = "delimited")]
+    /// CSV/TSV file has a header row that should be skipped
+    #[arg(long, groups = ["delimited", "header_mode"])]
+    header: bool,
+
+    /// CSV/TSV file has no header row (default behavior; kept for backward
+    /// compatibility with 2.x scripts — will be removed in a future release)
+    #[arg(long, groups = ["delimited", "header_mode"])]
     no_header: bool,
 }
 
@@ -308,7 +314,13 @@ async fn run_loader(
         delimiter: source.delimiter.clone(),
         quote: source.quote.clone(),
         escape: source.escape.clone(),
-        has_header: if source.no_header { Some(false) } else { None },
+        has_header: if source.header {
+            Some(true)
+        } else if source.no_header {
+            Some(false)
+        } else {
+            None
+        },
     };
 
     // Run the load
@@ -387,11 +399,12 @@ fn validate_delimited_options(
     let has_delimited_options = source.delimiter.is_some()
         || source.quote.is_some()
         || source.escape.is_some()
+        || source.header
         || source.no_header;
 
     if has_delimited_options && !format_enum.is_delimited() {
         return Err(anyhow::anyhow!(
-            "Delimited file options (--delimiter, --quote, --escape, --no-header) \
+            "Delimited file options (--delimiter, --quote, --escape, --header, --no-header) \
              can only be used with CSV or TSV formats, not {}",
             format
         ));

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -165,7 +165,11 @@ pub struct LoadResult {
 ///     delimiter: None,
 ///     quote: None,
 ///     escape: None,
-///     has_header: None,
+///     // The CSV in this example has a header row that names the destination
+///     // columns. With `create_table_if_missing: true`, leaving this as `None`
+///     // would name columns from row 1's data values (the new 3.0 default
+///     // treats every row as data). Set explicitly when loading a header-bearing file.
+///     has_header: Some(true),
 ///     exclude_columns: Vec::new(),
 /// };
 ///
@@ -175,6 +179,8 @@ pub struct LoadResult {
 /// # }
 /// ```
 pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
+    validate_load_args(&args)?;
+
     let delimited_config = maybe_delimited_config(&args);
 
     // Set up manifest directory (use temp dir if not provided)
@@ -296,6 +302,26 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
         duration: result.duration,
         persisted_manifest_dir,
     })
+}
+
+/// Reject combinations that would otherwise cause silent drops downstream.
+///
+/// Mirrors the CLI's `validate_delimited_options` so library consumers calling
+/// `run_load` directly get the same feedback as CLI users.
+fn validate_load_args(args: &LoadArgs) -> Result<()> {
+    let has_delimited_options = args.delimiter.is_some()
+        || args.quote.is_some()
+        || args.escape.is_some()
+        || args.has_header.is_some();
+
+    if has_delimited_options && !args.format.is_delimited() {
+        return Err(anyhow::anyhow!(
+            "Delimited file options (delimiter, quote, escape, has_header) \
+             can only be used with CSV or TSV formats, not {:?}",
+            args.format
+        ));
+    }
+    Ok(())
 }
 
 // Build custom delimited config if provided

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -105,7 +105,7 @@ pub struct LoadArgs {
     pub quote: Option<String>,
     /// Escape character for escaping quotes (default: None)
     pub escape: Option<String>,
-    /// Whether file has a header row (default: true)
+    /// Whether file has a header row (default: false; matches PostgreSQL `COPY FROM`)
     pub has_header: Option<bool>,
 
     // Test-only: inject a pre-created pool (for SQLite testing)

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -105,7 +105,8 @@ pub struct LoadArgs {
     pub quote: Option<String>,
     /// Escape character for escaping quotes (default: None)
     pub escape: Option<String>,
-    /// Whether file has a header row (default: false; matches PostgreSQL `COPY FROM`)
+    /// Override for header-row handling. `None` uses the format default
+    /// (CSV/TSV: no header — matches PostgreSQL `COPY FROM`).
     pub has_header: Option<bool>,
 
     // Test-only: inject a pre-created pool (for SQLite testing)


### PR DESCRIPTION
## Summary
- Fixes #28: CSV/TSV loads were silently dropping the first data row when the
  file had no header, because `DelimitedConfig` defaulted `has_header` to
  `true`.
- Flips the default to `has_header: false` to match Postgres `COPY FROM`,
  Redshift, Snowflake, and BigQuery conventions.
- Adds a `--header` CLI flag (mutually exclusive with `--no-header`) for
  files that *do* have a header row.
- Bumps version to **3.0.0** (breaking change).

## Migration
If your scripts load CSVs/TSVs that contain a header row, add `--header`:

```diff
- aurora-dsql-loader load ... --source-uri data.csv
+ aurora-dsql-loader load ... --source-uri data.csv --header
```

If your files have no header, no change is needed.

`--no-header` continues to work but is now a no-op (it matches the new
default) and will be removed in a future release.

## Test plan
- [x] New integ test `test_headerless_csv_loads_all_rows_by_default` reproduces
      the issue: a 1000-row headerless CSV loaded with default flags now loads
      all 1000 rows (was 999).
- [x] New integ test `test_csv_with_header_loads_all_rows_when_header_flag_set`
      exercises `--header` end-to-end on a header-bearing CSV.
- [x] New integ test `test_headerless_tsv_loads_all_rows_by_default` covers
      the symmetric TSV regression.
- [x] New unit test `header_and_no_header_are_mutually_exclusive_at_parse_time`
      pins the clap mutual-exclusion contract (asserts `ErrorKind::ArgumentConflict`).
- [x] New unit test `header_flag_rejected_with_parquet_format` pins
      `validate_delimited_options` rejection of `--header --format parquet`.
- [x] All existing integ tests updated to pass `has_header: Some(true)` (or use
      new `csv_with_header()` / `tsv_with_header()` test-private helpers) where
      they relied on the old default with header-bearing fixtures.
- [x] `cargo test --lib` — 119 passed, 0 failed.
- [x] `cargo test --bins` — 10 passed, 0 failed.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt -- --check` clean.
- [x] Verified at runtime: `aurora-dsql-loader load ... --header --no-header`
      is rejected by clap with `the argument '--header' cannot be used with '--no-header'`.

## Docs
- CHANGELOG.md gets a [3.0.0] entry with migration guide.
- README.md gets a new "CSV/TSV header behavior" subsection under
  Common Examples.
- The library-public `LoadArgs::has_header` rustdoc updated to reflect the
  new default behavior.