### PR TITLE
fix(pgdump): post-merge follow-up cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
   operators reading load logs. Existing customers using only ASCII letters,
   digits, and underscore are unaffected; customers using PG quoted
   identifiers with non-Latin characters are also unaffected.
+- `list-tables` now validates every emitted schema, table, and column name
+  for control bytes, Unicode bidi/format codepoints, and (on column names)
+  embedded commas, and aborts before printing any row when a hit is found.
+  Prevents a malicious dump from smuggling tab/newline/ANSI-escape bytes or
+  bidirectional spoofing into the TSV output that operators pipe into shells.
 
 ## [3.0.0] - 2026-05-26
 

--- a/src/coordination/coordinator.rs
+++ b/src/coordination/coordinator.rs
@@ -156,8 +156,12 @@ fn align_pgdump_schema_to_copy_columns(
 
     if copy_set != target_set {
         let target_names: Vec<&str> = resolved.columns.iter().map(|c| c.name.as_str()).collect();
-        let missing_in_target: Vec<&str> = copy_set.difference(&target_set).copied().collect();
-        let missing_in_dump: Vec<&str> = target_set.difference(&copy_set).copied().collect();
+        // Sort the diff lists so the bail message is deterministic across runs
+        // (HashSet::difference iteration order is not stable).
+        let mut missing_in_target: Vec<&str> = copy_set.difference(&target_set).copied().collect();
+        let mut missing_in_dump: Vec<&str> = target_set.difference(&copy_set).copied().collect();
+        missing_in_target.sort_unstable();
+        missing_in_dump.sort_unstable();
         anyhow::bail!(
             "pg_dump column-set mismatch for {}.{}:\n  \
              dump COPY columns:    {:?}\n  \
@@ -267,7 +271,8 @@ pub struct LoadResult {
     pub chunks_processed: usize,
     pub records_loaded: u64,
     pub records_failed: u64,
-    /// Estimated row count from file size (for mismatch detection)
+    /// Sum of per-chunk row estimates obtained by sampling the source bytes;
+    /// used to flag a large delta vs records actually loaded.
     pub estimated_rows: Option<u64>,
     pub duration: Duration,
     /// Detailed results for each chunk (accessed in integration tests)
@@ -752,11 +757,12 @@ impl Coordinator {
             }
         }
 
-        // --exclude-columns on resume must match the original job's exclusion set;
-        // the manifest is authoritative and silently dropping the flag would hide bugs.
-        // Compare as sets (sorted) because the manifest stores the list in schema order
-        // while the user-passed list is in CLI order - semantically equivalent lists
-        // should not trip the check.
+        // --exclude-columns on resume: the flag may be omitted (the manifest's list
+        // is authoritative), but if supplied it must match the manifest as a set.
+        // Avoids forcing operators to retype the list while still catching accidental
+        // drift. Compare as sets (sorted) because the manifest stores the list in
+        // schema order while the user-passed list is in CLI order — semantically
+        // equivalent lists should not trip the check.
         if !config.exclude_columns.is_empty() {
             let mut requested = config.exclude_columns.clone();
             let mut stored = manifest.table.excluded_columns.clone();

--- a/src/formats/pgdump/scan.rs
+++ b/src/formats/pgdump/scan.rs
@@ -429,7 +429,7 @@ async fn find_terminator(reader: &dyn ByteReader, start: u64, size: u64) -> Resu
                     second_byte = b;
                 }
                 last_byte = b;
-                span = span.saturating_add(1);
+                span += 1;
                 if span > MAX_DATA_LINE_BYTES {
                     return Err(line_too_long(line_start, MAX_DATA_LINE_BYTES));
                 }

--- a/src/formats/pgdump/tests.rs
+++ b/src/formats/pgdump/tests.rs
@@ -147,7 +147,7 @@ async fn case_insensitive_copy_keyword() {
 }
 
 #[tokio::test]
-async fn no_column_list_is_supported() {
+async fn copy_without_column_list_is_rejected() {
     let data = b"COPY public.t FROM stdin;\n1\ta\n\\.\n";
     let reader = MockByteReader::new(data.to_vec());
     let err = find_copy_block(&reader, "public", "t").await.unwrap_err();
@@ -577,6 +577,21 @@ async fn find_terminator_handles_eof_without_trailing_newline() {
     // data_end points to the start of the `\.` line (offset of the `\\` byte).
     let expected_data_end = data.len() as u64 - 2; // \. is the last 2 bytes
     assert_eq!(block.data_end, expected_data_end);
+}
+
+#[tokio::test]
+async fn find_terminator_rejects_backslash_dot_cr_at_eof() {
+    // `\.\r` at EOF (no trailing `\n`) is NOT a valid terminator: the file
+    // ends mid-CRLF, which indicates corruption rather than a clean truncate.
+    // Pinning the deliberate strictness so a future "preserve more inputs"
+    // refactor doesn't silently accept a likely-malformed dump.
+    let data = b"COPY public.t (a) FROM stdin;\n1\n\\.\r";
+    let reader = MockByteReader::new(data.to_vec());
+    let result = find_copy_block(&reader, "public", "t").await;
+    assert!(
+        result.is_err(),
+        "\\.\\r at EOF must be rejected as MissingTerminator"
+    );
 }
 
 #[tokio::test]

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -4251,10 +4251,10 @@ mod tests {
         .await?;
 
         // NOTE: empty TEXT (`note = ''`) and empty BYTEA (`'\x'`) are
-        // intentionally omitted. The loader's v1 NULL handling collapses
-        // empty strings to SQL NULL during INSERT generation, so a `''` in
-        // the source would round-trip as NULL — a documented trade-off
-        // (see PgDumpReader rustdoc), not a regression for this test.
+        // intentionally omitted. The loader collapses empty strings to SQL
+        // NULL during INSERT generation, so a `''` in the source would
+        // round-trip as NULL — a documented trade-off (see PgDumpReader
+        // rustdoc), not a regression for this test.
         sqlx::query(&format!(
             "INSERT INTO {src} (id, name, note, blob, payload, ts) VALUES
                 (1, 'plain',         E'tab\\there',  E'\\\\xDEADBEEF', '{{\"a\":1}}'::jsonb,  '2024-01-15 12:34:56+00'),

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -369,7 +369,7 @@ fn validate_load_args(args: &LoadArgs) -> Result<()> {
             anyhow::bail!(
                 "create_table_if_missing (--if-not-exists) is not supported with \
                  pg_dump: schema inference from a COPY-format byte stream is not \
-                 implemented in v1; pre-create the target table"
+                 currently supported; pre-create the target table"
             );
         }
     }


### PR DESCRIPTION
## Summary

Small follow-ups to PR #30 (pg_dump `--data-only` input format) that were sitting in my working tree post-merge:

- **Deterministic error messages.** `coordinator::align_pgdump_schema_to_copy_columns` builds the `missing_in_target` / `missing_in_dump` lists from `HashSet::difference`, whose iteration order is unstable. Sorting them so the bail string is deterministic across runs prevents flaky test output and makes the error easier to scan.
- **Comment cleanups.** Drop the now-outdated \"v1\" wording (`runner.rs`, `integ_tests.rs`) and tighten the rustdoc for `LoadResult.estimated_rows` and the `--exclude-columns` resume comment so they match the actual behavior.
- **`span.saturating_add(1)` → `span += 1`** in `find_terminator`. The surrounding length check enforces the bound; saturating arithmetic would silently mask a real bug.
- **Regression test** pinning that `\\.\\r` at EOF (no trailing newline) is rejected as a malformed terminator — guards against a future \"preserve more inputs\" refactor silently accepting a likely-corrupt dump.
- **Test rename** `no_column_list_is_supported` → `copy_without_column_list_is_rejected` to reflect post-merge behavior.
- **CHANGELOG entry** documenting the `list-tables` identifier hardening (control bytes, Unicode bidi/format codepoints, embedded commas) that landed in PR #30 but didn't get a user-facing changelog entry.

## Test plan

- [x] 192 unit tests passing (`cargo test --lib`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Existing CI gates (CI matrix, gated pg_dump E2E) re-run on this branch.