### PR TITLE
feat(verify): count-level load verification (L1 source, L2 target)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,26 @@
   formats up front with a diagnostic that points to `-Fp`, instead of
   failing later with a generic "no COPY block found" after streaming the
   binary file.
+- New `--verify <off|count>` flag on `load` and `migrate`. `count` adds
+  pre/post `count(*)` per loaded table and emits one verdict —
+  `Match`, `LoaderDropped(N)`, `MissingTarget(N)`, `ExtraTarget(N)`,
+  `RowsConflictedAtTarget(N)`, or `SkippedNoExactSourceCount`. Source-row
+  counting (L1) runs parser-side regardless of the flag for pgdump and
+  parquet. Defaults: `load=off` (avoid `count(*)` on populated targets),
+  `migrate=count` (fresh-cluster pre-counts are sub-ms). Any verdict
+  other than `Match` or `SkippedNoExactSourceCount` exits non-zero.
+  Assumes the loader is the sole writer to the target during the run.
 
 ### Changed
+- A worker-crash that leaves a chunk result file unwritten now fails
+  the load instead of being treated as 0 rows. Previously the missing
+  rows were invisible: `records_failed` stayed 0 and `source_rows`
+  collapsed to `None`, so the load exited green with rows silently
+  dropped. Re-run with `--resume-job-id=<id>` to retry the missing
+  chunks.
+- `Pool::qualified_table_name` now escape-doubles embedded `"`
+  defensively. A breaking change to the upstream identifier validators
+  no longer becomes an instant SQL identifier injection.
 - `migrate` now scans the dump for COPY blocks once and reuses the
   resolved blocks + AWS config across every per-table load. Previously
   each table re-walked the entire dump and re-ran the credential chain

--- a/README.md
+++ b/README.md
@@ -198,6 +198,13 @@ access yet.
   collapsed and will surface as `Unfixable` — drop it from the dump or
   inline the sequence.
 
+**Halt-on-failure:** if any per-table load reports failed records (or
+verify=count's post-count fails mid-run), `migrate` halts at that table
+and exits non-zero. Without DSQL FK enforcement, continuing past a
+partially-loaded parent would silently load child rows pointing at
+missing parents. The persisted manifest path is printed for each failed
+table so the operator can inspect the dropped chunks before re-running.
+
 **Destructive-statement caveat:** `migrate` is intended for fresh /
 empty DSQL clusters. `dsql-lint` does not flag `DROP TABLE`,
 `DROP SCHEMA`, `DROP INDEX`, `DELETE`, or `UPDATE` statements; if your

--- a/README.md
+++ b/README.md
@@ -271,6 +271,10 @@ aurora-dsql-loader load \
 
 Resume automatically retries failed chunks and skips completed ones. For safety against duplicates on retry, use unique constraints on your table—the loader will use `ON CONFLICT DO NOTHING` to skip duplicates.
 
+## Verification
+
+`--verify=count` cross-checks row counts after a load and reports one verdict per table: `Match`, `LoaderDropped(N)`, `MissingTarget(N)`, `ExtraTarget(N)`, `RowsConflictedAtTarget(N)`, or `SkippedNoExactSourceCount` (csv/tsv). A non-Match verdict exits non-zero. Default: `off` for `load`, `count` for `migrate`. Assumes the loader is the sole writer to the target during the run.
+
 ## Performance Tuning
 
 The loader parallelizes work on two axes. Total in-flight INSERTs ≈ `workers × batch-concurrency`.

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Resume automatically retries failed chunks and skips completed ones. For safety 
 
 ## Verification
 
-`--verify=count` cross-checks row counts after a load and reports one verdict per table: `Match`, `LoaderDropped(N)`, `MissingTarget(N)`, `ExtraTarget(N)`, `RowsConflictedAtTarget(N)`, or `SkippedNoExactSourceCount` (csv/tsv). A non-Match verdict exits non-zero. Default: `off` for `load`, `count` for `migrate`. Assumes the loader is the sole writer to the target during the run.
+`--verify=count` cross-checks row counts after a load and reports one verdict per table: `Match`, `LoaderDropped(N)`, `MissingTarget(N)`, `ExtraTarget(N)`, `RowsConflictedAtTarget(N)`, or `SkippedNoExactSourceCount` (csv/tsv). Any verdict other than `Match` or `SkippedNoExactSourceCount` exits non-zero. Default: `off` for `load`, `count` for `migrate`. Assumes the loader is the sole writer to the target during the run.
 
 ## Performance Tuning
 

--- a/src/coordination/coordinator.rs
+++ b/src/coordination/coordinator.rs
@@ -274,6 +274,11 @@ pub struct LoadResult {
     /// Sum of per-chunk row estimates obtained by sampling the source bytes;
     /// used to flag a large delta vs records actually loaded.
     pub estimated_rows: Option<u64>,
+    /// Exact source-row count summed across all chunks. `Some` only when every
+    /// chunk reported a count (pgdump and parquet do; csv/tsv leave `None`),
+    /// so a single missing chunk count collapses the total to `None`. Drives
+    /// the L1 verification cross-check.
+    pub source_rows: Option<u64>,
     pub duration: Duration,
     /// Detailed results for each chunk (accessed in integration tests)
     #[cfg_attr(not(test), allow(dead_code))]
@@ -1069,6 +1074,16 @@ impl Coordinator {
 
         let total_records_loaded: u64 = chunk_results.iter().map(|r| r.records_loaded).sum();
         let total_records_failed: u64 = chunk_results.iter().map(|r| r.records_failed).sum();
+        // Sum source-row counts only when every chunk reported one; a single
+        // missing count (e.g. csv/tsv reader, or a chunk-result file from a
+        // pre-verify run that had no field) collapses the whole total to
+        // `None` so the L1 verdict path skips cleanly with
+        // `SkippedNoExactSourceCount` instead of comparing against a
+        // partial sum.
+        let total_source_rows: Option<u64> = chunk_results
+            .iter()
+            .map(|r| r.source_rows_in_chunk)
+            .try_fold(0u64, |acc, n| n.map(|x| acc + x));
         let duration = start_time.elapsed();
 
         // Warn if significantly fewer records were processed than estimated
@@ -1097,6 +1112,7 @@ impl Coordinator {
             records_loaded: total_records_loaded,
             records_failed: total_records_failed,
             estimated_rows: Some(total_estimated).filter(|&e| e > 0),
+            source_rows: total_source_rows,
             duration,
             chunk_results,
         })

--- a/src/coordination/coordinator.rs
+++ b/src/coordination/coordinator.rs
@@ -1068,11 +1068,16 @@ impl Coordinator {
 
         let total_records_loaded: u64 = chunk_results.iter().map(|r| r.records_loaded).sum();
         let total_records_failed: u64 = chunk_results.iter().map(|r| r.records_failed).sum();
-        // All-or-nothing fold: any missing chunk count → None.
-        let total_source_rows: Option<u64> = chunk_results
-            .iter()
-            .map(|r| r.source_rows_in_chunk)
-            .try_fold(0u64, |acc, n| n.map(|x| acc + x));
+        // A missing chunk-result file (worker crashed) shrinks records_loaded
+        // and source_rows together, so a naive fold would silently report Match.
+        let total_source_rows: Option<u64> = if chunk_results.len() < chunks.len() {
+            None
+        } else {
+            chunk_results
+                .iter()
+                .map(|r| r.source_rows_in_chunk)
+                .try_fold(0u64, |acc, n| n.map(|x| acc + x))
+        };
         let duration = start_time.elapsed();
 
         // Warn if significantly fewer records were processed than estimated

--- a/src/coordination/coordinator.rs
+++ b/src/coordination/coordinator.rs
@@ -107,8 +107,9 @@ fn validate_conflict_columns_not_all_excluded(
 }
 
 /// L1 source-row total across chunks. `None` if any chunk lacks a count
-/// (csv/tsv) or `chunk_results` is short of `expected_chunks` (worker crash) —
-/// forces classify() to SkippedNoExactSourceCount instead of a false Match.
+/// (csv/tsv), `chunk_results` is short of `expected_chunks` (worker crash),
+/// or the per-chunk counts overflow `u64` (adversarial parquet footer).
+/// Forces classify() to SkippedNoExactSourceCount instead of a false Match.
 fn aggregate_source_rows(chunk_results: &[ChunkResultFile], expected_chunks: usize) -> Option<u64> {
     if chunk_results.len() < expected_chunks {
         return None;
@@ -116,7 +117,7 @@ fn aggregate_source_rows(chunk_results: &[ChunkResultFile], expected_chunks: usi
     chunk_results
         .iter()
         .map(|r| r.source_rows_in_chunk)
-        .try_fold(0u64, |acc, n| n.map(|x| acc + x))
+        .try_fold(0u64, |acc, n| n.and_then(|x| acc.checked_add(x)))
 }
 
 /// Maximum bytes to read for schema inference
@@ -366,26 +367,28 @@ impl Coordinator {
             .await
     }
 
-    /// Collect all chunk results from manifest storage
+    /// Collect all chunk results from manifest storage. Returns the
+    /// results plus the IDs of any missing chunks so the caller can
+    /// surface them as a hard failure rather than a silent drop.
     async fn collect_results(
         &self,
         job_id: &str,
         chunk_count: usize,
-    ) -> Result<Vec<ChunkResultFile>> {
+    ) -> Result<(Vec<ChunkResultFile>, Vec<u32>)> {
         let mut results = Vec::with_capacity(chunk_count);
+        let mut missing = Vec::new();
 
         for chunk_id in 0..chunk_count as u32 {
             match self.manifest_storage.read_result(job_id, chunk_id).await {
                 Ok(result) => results.push(result),
                 Err(_) => {
-                    // Chunk result may be missing if worker crashed before writing result file
-                    // This is tracked in failure metrics and doesn't require hard failure
                     warn!("Chunk {chunk_id} result missing");
+                    missing.push(chunk_id);
                 }
             }
         }
 
-        Ok(results)
+        Ok((results, missing))
     }
 
     /// Create chunks from the source file and return metadata
@@ -1074,10 +1077,24 @@ impl Coordinator {
         start_time: Instant,
     ) -> Result<LoadResult> {
         info!("Aggregating results...");
-        let chunk_results = self
+        let (chunk_results, missing) = self
             .collect_results(job_id, chunks.len())
             .await
             .context("Failed to collect results")?;
+
+        // A missing chunk result = worker crashed mid-load. Without this
+        // bail, records_failed stays 0 and source_rows demotes to None
+        // (SkippedNoExactSourceCount → exit 0): a silent drop the
+        // verification layer cannot catch. Fail hard so the operator
+        // resumes from the manifest instead of shipping green.
+        if !missing.is_empty() {
+            anyhow::bail!(
+                "Load incomplete: {n} chunk result(s) missing (likely worker crash). \
+                 Missing chunk IDs: {missing:?}. Re-run with --resume-job-id={job_id} \
+                 to retry the missing chunks.",
+                n = missing.len(),
+            );
+        }
 
         let total_records_loaded: u64 = chunk_results.iter().map(|r| r.records_loaded).sum();
         let total_records_failed: u64 = chunk_results.iter().map(|r| r.records_failed).sum();

--- a/src/coordination/coordinator.rs
+++ b/src/coordination/coordinator.rs
@@ -106,6 +106,19 @@ fn validate_conflict_columns_not_all_excluded(
     Ok(())
 }
 
+/// L1 source-row total across chunks. `None` if any chunk lacks a count
+/// (csv/tsv) or `chunk_results` is short of `expected_chunks` (worker crash) —
+/// forces classify() to SkippedNoExactSourceCount instead of a false Match.
+fn aggregate_source_rows(chunk_results: &[ChunkResultFile], expected_chunks: usize) -> Option<u64> {
+    if chunk_results.len() < expected_chunks {
+        return None;
+    }
+    chunk_results
+        .iter()
+        .map(|r| r.source_rows_in_chunk)
+        .try_fold(0u64, |acc, n| n.map(|x| acc + x))
+}
+
 /// Maximum bytes to read for schema inference
 ///
 /// Caps the amount of data read to prevent loading entire large files just for
@@ -1068,16 +1081,7 @@ impl Coordinator {
 
         let total_records_loaded: u64 = chunk_results.iter().map(|r| r.records_loaded).sum();
         let total_records_failed: u64 = chunk_results.iter().map(|r| r.records_failed).sum();
-        // A missing chunk-result file (worker crashed) shrinks records_loaded
-        // and source_rows together, so a naive fold would silently report Match.
-        let total_source_rows: Option<u64> = if chunk_results.len() < chunks.len() {
-            None
-        } else {
-            chunk_results
-                .iter()
-                .map(|r| r.source_rows_in_chunk)
-                .try_fold(0u64, |acc, n| n.map(|x| acc + x))
-        };
+        let total_source_rows = aggregate_source_rows(&chunk_results, chunks.len());
         let duration = start_time.elapsed();
 
         // Warn if significantly fewer records were processed than estimated
@@ -1110,6 +1114,56 @@ impl Coordinator {
             duration,
             chunk_results,
         })
+    }
+}
+
+#[cfg(test)]
+mod aggregate_tests {
+    use super::*;
+    use crate::coordination::manifest::ChunkStatus;
+
+    fn mk_chunk_result(id: u32, source_rows: Option<u64>) -> ChunkResultFile {
+        ChunkResultFile {
+            chunk_id: id,
+            worker_id: "w".into(),
+            status: ChunkStatus::Success,
+            records_loaded: source_rows.unwrap_or(0),
+            records_failed: 0,
+            bytes_processed: 0,
+            started_at: "1970-01-01T00:00:00Z".into(),
+            completed_at: "1970-01-01T00:00:00Z".into(),
+            duration_secs: 0,
+            errors: Vec::new(),
+            source_rows_in_chunk: source_rows,
+        }
+    }
+
+    #[test]
+    fn aggregate_source_rows_full_set_returns_sum() {
+        let results = vec![
+            mk_chunk_result(0, Some(7)),
+            mk_chunk_result(1, Some(3)),
+            mk_chunk_result(2, Some(10)),
+        ];
+        assert_eq!(aggregate_source_rows(&results, 3), Some(20));
+    }
+
+    #[test]
+    fn aggregate_source_rows_partial_results_returns_none() {
+        // Worker crashed: only 2 of 3 expected chunk results landed.
+        let results = vec![mk_chunk_result(0, Some(7)), mk_chunk_result(1, Some(3))];
+        assert_eq!(aggregate_source_rows(&results, 3), None);
+    }
+
+    #[test]
+    fn aggregate_source_rows_any_none_chunk_returns_none() {
+        // csv/tsv path: at least one chunk has no exact count.
+        let results = vec![
+            mk_chunk_result(0, Some(7)),
+            mk_chunk_result(1, None),
+            mk_chunk_result(2, Some(10)),
+        ];
+        assert_eq!(aggregate_source_rows(&results, 3), None);
     }
 }
 

--- a/src/coordination/coordinator.rs
+++ b/src/coordination/coordinator.rs
@@ -156,8 +156,7 @@ fn align_pgdump_schema_to_copy_columns(
 
     if copy_set != target_set {
         let target_names: Vec<&str> = resolved.columns.iter().map(|c| c.name.as_str()).collect();
-        // Sort the diff lists so the bail message is deterministic across runs
-        // (HashSet::difference iteration order is not stable).
+        // Sort for deterministic error output (HashSet iteration is unstable).
         let mut missing_in_target: Vec<&str> = copy_set.difference(&target_set).copied().collect();
         let mut missing_in_dump: Vec<&str> = target_set.difference(&copy_set).copied().collect();
         missing_in_target.sort_unstable();
@@ -274,10 +273,8 @@ pub struct LoadResult {
     /// Sum of per-chunk row estimates obtained by sampling the source bytes;
     /// used to flag a large delta vs records actually loaded.
     pub estimated_rows: Option<u64>,
-    /// Exact source-row count summed across all chunks. `Some` only when every
-    /// chunk reported a count (pgdump and parquet do; csv/tsv leave `None`),
-    /// so a single missing chunk count collapses the total to `None`. Drives
-    /// the L1 verification cross-check.
+    /// Exact source-row count summed across chunks. `None` if any
+    /// chunk lacks a count (csv/tsv) — drives L1.
     pub source_rows: Option<u64>,
     pub duration: Duration,
     /// Detailed results for each chunk (accessed in integration tests)
@@ -762,12 +759,9 @@ impl Coordinator {
             }
         }
 
-        // --exclude-columns on resume: the flag may be omitted (the manifest's list
-        // is authoritative), but if supplied it must match the manifest as a set.
-        // Avoids forcing operators to retype the list while still catching accidental
-        // drift. Compare as sets (sorted) because the manifest stores the list in
-        // schema order while the user-passed list is in CLI order — semantically
-        // equivalent lists should not trip the check.
+        // --exclude-columns on resume: optional, but if supplied must
+        // match the manifest as a set (manifest order is schema-order,
+        // CLI order is user-order — both are valid).
         if !config.exclude_columns.is_empty() {
             let mut requested = config.exclude_columns.clone();
             let mut stored = manifest.table.excluded_columns.clone();
@@ -1074,12 +1068,7 @@ impl Coordinator {
 
         let total_records_loaded: u64 = chunk_results.iter().map(|r| r.records_loaded).sum();
         let total_records_failed: u64 = chunk_results.iter().map(|r| r.records_failed).sum();
-        // Sum source-row counts only when every chunk reported one; a single
-        // missing count (e.g. csv/tsv reader, or a chunk-result file from a
-        // pre-verify run that had no field) collapses the whole total to
-        // `None` so the L1 verdict path skips cleanly with
-        // `SkippedNoExactSourceCount` instead of comparing against a
-        // partial sum.
+        // All-or-nothing fold: any missing chunk count → None.
         let total_source_rows: Option<u64> = chunk_results
             .iter()
             .map(|r| r.source_rows_in_chunk)

--- a/src/coordination/manifest.rs
+++ b/src/coordination/manifest.rs
@@ -194,6 +194,14 @@ pub struct ChunkResultFile {
     pub completed_at: String, // ISO 8601
     pub duration_secs: u64,
     pub errors: Vec<ErrorRecord>,
+    /// Exact source-row count for this chunk's byte range, computed by the
+    /// reader (parser-independent). `Some` for pgdump and parquet; `None` for
+    /// csv/tsv. Aggregated across chunks into `LoadResult.source_rows` and
+    /// drives the L1 verification cross-check. `skip_serializing_if` keeps
+    /// pre-verify manifests deserializable without rewriting their result
+    /// files (the field defaults to `None` on read).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_rows_in_chunk: Option<u64>,
 }
 
 /// Record of an error that occurred during processing.

--- a/src/coordination/manifest.rs
+++ b/src/coordination/manifest.rs
@@ -194,12 +194,9 @@ pub struct ChunkResultFile {
     pub completed_at: String, // ISO 8601
     pub duration_secs: u64,
     pub errors: Vec<ErrorRecord>,
-    /// Exact source-row count for this chunk's byte range, computed by the
-    /// reader (parser-independent). `Some` for pgdump and parquet; `None` for
-    /// csv/tsv. Aggregated across chunks into `LoadResult.source_rows` and
-    /// drives the L1 verification cross-check. `skip_serializing_if` keeps
-    /// pre-verify manifests deserializable without rewriting their result
-    /// files (the field defaults to `None` on read).
+    /// Exact source-row count for this chunk (pgdump/parquet only).
+    /// Optional+skip_serializing_if for backward compatibility with
+    /// manifests written before this field existed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_rows_in_chunk: Option<u64>,
 }

--- a/src/coordination/worker.rs
+++ b/src/coordination/worker.rs
@@ -457,6 +457,7 @@ impl Worker {
             completed_at: end_time.to_rfc3339(),
             duration_secs,
             errors,
+            source_rows_in_chunk: chunk_data.source_rows_in_chunk,
         };
 
         // Write result to manifest

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -228,13 +228,18 @@ impl Pool {
     /// Get a fully qualified table name for SQL statements
     /// - PostgreSQL: Returns "schema"."table" for non-public, or "table" for public
     /// - SQLite: Returns "table" (possibly prefixed like "sales_orders")
+    ///
+    /// Escapes embedded `"` per SQL identifier-quoting rules (defense in
+    /// depth — `validate_identifier`/`validate_pgdump_identifier` should
+    /// already have rejected such input upstream).
     pub fn qualified_table_name(&self, schema_name: &str, table_name: &str) -> String {
         let (schema, table) = self.table_identifier(schema_name, table_name);
+        let q = |s: &str| s.replace('"', "\"\"");
 
         if self.is_postgres() && schema != "public" {
-            format!("\"{}\".\"{}\"", schema, table)
+            format!("\"{}\".\"{}\"", q(&schema), q(&table))
         } else {
-            format!("\"{}\"", table)
+            format!("\"{}\"", q(&table))
         }
     }
 

--- a/src/formats/delimited/reader.rs
+++ b/src/formats/delimited/reader.rs
@@ -106,10 +106,18 @@ impl<R: ByteReader + 'static> FileReader for GenericDelimitedReader<R> {
             }
         }
 
+        // CSV/TSV: no exact source-row count — quote-aware row counting would
+        // require a second parse, and the cheap `\n` byte count would over-count
+        // any newline embedded inside a quoted field. Leave `None` so the L1
+        // verification path skips with `SkippedNoExactSourceCount`. The
+        // existing `estimated_rows` plumbing (from `metadata`) carries through
+        // unchanged for operator visibility. Quote-aware exact counting is the
+        // v2 follow-up.
         Ok(ChunkData {
             records,
             bytes_read: chunk.end_offset - chunk.start_offset,
             parse_errors,
+            source_rows_in_chunk: None,
         })
     }
 }

--- a/src/formats/delimited/reader.rs
+++ b/src/formats/delimited/reader.rs
@@ -106,13 +106,11 @@ impl<R: ByteReader + 'static> FileReader for GenericDelimitedReader<R> {
             }
         }
 
-        // CSV/TSV: no exact source-row count — quote-aware row counting would
-        // require a second parse, and the cheap `\n` byte count would over-count
-        // any newline embedded inside a quoted field. Leave `None` so the L1
-        // verification path skips with `SkippedNoExactSourceCount`. The
-        // existing `estimated_rows` plumbing (from `metadata`) carries through
-        // unchanged for operator visibility. Quote-aware exact counting is the
-        // v2 follow-up.
+        // CSV/TSV: source_rows is None — quote-aware row counting needs
+        // a second parse, and a cheap `\n` byte count would over-count
+        // any newline inside a quoted field. L1 short-circuits with
+        // `SkippedNoExactSourceCount`; `estimated_rows` from `metadata`
+        // still carries through.
         Ok(ChunkData {
             records,
             bytes_read: chunk.end_offset - chunk.start_offset,

--- a/src/formats/delimited/reader.rs
+++ b/src/formats/delimited/reader.rs
@@ -106,11 +106,9 @@ impl<R: ByteReader + 'static> FileReader for GenericDelimitedReader<R> {
             }
         }
 
-        // CSV/TSV: source_rows is None — quote-aware row counting needs
-        // a second parse, and a cheap `\n` byte count would over-count
-        // any newline inside a quoted field. L1 short-circuits with
-        // `SkippedNoExactSourceCount`; `estimated_rows` from `metadata`
-        // still carries through.
+        // CSV/TSV: no exact source-row count (a `\n` tally would
+        // over-count newlines inside quoted fields). `estimated_rows`
+        // from metadata still carries through.
         Ok(ChunkData {
             records,
             bytes_read: chunk.end_offset - chunk.start_offset,

--- a/src/formats/parquet/reader.rs
+++ b/src/formats/parquet/reader.rs
@@ -92,8 +92,7 @@ impl<R: ByteReader + Clone + 'static> GenericParquetReader<R> {
             all_records.extend(records);
         }
 
-        // Sum the parser-independent row count from the footer metadata
-        // captured at file open. Drives the L1 verification cross-check.
+        // L1 count from footer metadata.
         let source_rows: u64 = row_group_indices
             .iter()
             .filter_map(|&idx| self.row_groups.get(idx).map(|rg| rg.num_rows))

--- a/src/formats/parquet/reader.rs
+++ b/src/formats/parquet/reader.rs
@@ -92,10 +92,18 @@ impl<R: ByteReader + Clone + 'static> GenericParquetReader<R> {
             all_records.extend(records);
         }
 
+        // Sum the parser-independent row count from the footer metadata
+        // captured at file open. Drives the L1 verification cross-check.
+        let source_rows: u64 = row_group_indices
+            .iter()
+            .filter_map(|&idx| self.row_groups.get(idx).map(|rg| rg.num_rows))
+            .sum();
+
         Ok(ChunkData {
             records: all_records,
             bytes_read,
             parse_errors: 0,
+            source_rows_in_chunk: Some(source_rows),
         })
     }
 }

--- a/src/formats/pgdump/reader.rs
+++ b/src/formats/pgdump/reader.rs
@@ -155,6 +155,42 @@ mod tests {
         assert_eq!(chunk_data.parse_errors, 0);
     }
 
+    /// Multi-chunk invariant: per-chunk source_rows must sum to the
+    /// total record count. Pins the all-or-nothing fold in
+    /// `Coordinator::run_load`.
+    #[tokio::test]
+    async fn pgdump_source_rows_sum_across_chunks_equals_total() {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "COPY public.t (id, name) FROM stdin;").unwrap();
+        for i in 0..100 {
+            writeln!(f, "{i}\tname{i}").unwrap();
+        }
+        writeln!(f, "\\.").unwrap();
+        f.flush().unwrap();
+
+        let reader = LocalFileByteReader::new(f.path());
+        let block = find_copy_block(&reader, "public", "t").await.unwrap();
+        let pgdump = PgDumpReader::from_block(reader, block);
+        // Force multiple chunks: ~10 rows per chunk over 100 rows.
+        let chunks = pgdump.create_chunks(80).await.unwrap();
+        assert!(
+            chunks.len() > 1,
+            "test setup: expected multiple chunks, got {}",
+            chunks.len()
+        );
+
+        let mut total_source_rows = 0u64;
+        let mut total_records = 0usize;
+        for chunk in &chunks {
+            let cd = pgdump.read_chunk(chunk).await.unwrap();
+            total_source_rows += cd.source_rows_in_chunk.unwrap();
+            total_records += cd.records.len();
+            assert_eq!(cd.parse_errors, 0);
+        }
+        assert_eq!(total_source_rows, 100);
+        assert_eq!(total_records, 100);
+    }
+
     /// Empty-line invariant: every `\n` in a COPY block becomes a
     /// record OR a parse_error. Silent drops would break L1.
     #[tokio::test]

--- a/src/formats/pgdump/reader.rs
+++ b/src/formats/pgdump/reader.rs
@@ -74,6 +74,16 @@ impl<R: ByteReader + 'static> FileReader for PgDumpReader<R> {
             .await
             .context("Failed to read chunk data")?;
 
+        // Tee an exact source-row count off the raw bytes BEFORE parsing.
+        // pg_dump escapes embedded `\n` as the two literal bytes `\` `n`, so
+        // every byte-newline inside `[data_start, data_end)` corresponds to
+        // exactly one record. The `\.` terminator line is excluded by chunk
+        // construction (`data_end` stops at the start of `\.` — see
+        // scan.rs CopyBlock docs), so no end-of-block adjustment is needed.
+        // Drives the L1 verification cross-check against
+        // `records_loaded + records_failed`.
+        let source_rows = buffer.iter().filter(|&&b| b == b'\n').count() as u64;
+
         let expected_columns = self.block.columns.len();
         let mut records = Vec::new();
         let mut parse_errors = 0u64;
@@ -102,6 +112,7 @@ impl<R: ByteReader + 'static> FileReader for PgDumpReader<R> {
             records,
             bytes_read: chunk.end_offset - chunk.start_offset,
             parse_errors,
+            source_rows_in_chunk: Some(source_rows),
         })
     }
 }
@@ -113,4 +124,74 @@ fn split_lines(buf: &[u8]) -> impl Iterator<Item = &[u8]> {
     let buf = buf.strip_suffix(b"\n").unwrap_or(buf);
     buf.split(|&b| b == b'\n')
         .map(|line| line.strip_suffix(b"\r").unwrap_or(line))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::formats::pgdump::scan::find_copy_block;
+    use crate::io::LocalFileByteReader;
+    use std::io::Write;
+
+    /// Pin the L1 invariant: source_rows_in_chunk equals the exact source-row
+    /// count for the COPY block. Each `\n` in `[data_start, data_end)` is one
+    /// record, the `\.` terminator is excluded by chunk construction.
+    #[tokio::test]
+    async fn pgdump_read_chunk_source_rows_matches_record_count() {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "-- preamble").unwrap();
+        writeln!(f, "COPY public.t (id, name) FROM stdin;").unwrap();
+        for i in 0..10 {
+            writeln!(f, "{i}\tname{i}").unwrap();
+        }
+        writeln!(f, "\\.").unwrap();
+        f.flush().unwrap();
+
+        let reader = LocalFileByteReader::new(f.path());
+        let block = find_copy_block(&reader, "public", "t").await.unwrap();
+        let pgdump = PgDumpReader::from_block(reader, block);
+        let chunks = pgdump.create_chunks(1024 * 1024).await.unwrap();
+        let chunk_data = pgdump.read_chunk(&chunks[0]).await.unwrap();
+        assert_eq!(
+            chunk_data.source_rows_in_chunk,
+            Some(10),
+            "source_rows must equal the 10 data rows in the COPY block"
+        );
+        assert_eq!(chunk_data.records.len(), 10);
+        assert_eq!(chunk_data.parse_errors, 0);
+    }
+
+    /// Pin the empty-line invariant called out in the design doc: every
+    /// byte-newline in a pgdump COPY block corresponds to a record OR a
+    /// `parse_error`. A future change that drops empty lines silently would
+    /// break L1's source-vs-loader cross-check.
+    #[tokio::test]
+    async fn pgdump_empty_line_counts_as_parse_error_so_l1_holds() {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "COPY public.t (id, name) FROM stdin;").unwrap();
+        writeln!(f, "1\talpha").unwrap();
+        // Empty line in the middle of the COPY block — pg_dump never emits
+        // these, but a hand-edited or corrupted dump might. Must surface
+        // as a parse_error, not a silent drop.
+        writeln!(f).unwrap();
+        writeln!(f, "2\tbeta").unwrap();
+        writeln!(f, "\\.").unwrap();
+        f.flush().unwrap();
+
+        let reader = LocalFileByteReader::new(f.path());
+        let block = find_copy_block(&reader, "public", "t").await.unwrap();
+        let pgdump = PgDumpReader::from_block(reader, block);
+        let chunks = pgdump.create_chunks(1024 * 1024).await.unwrap();
+        let chunk_data = pgdump.read_chunk(&chunks[0]).await.unwrap();
+        assert_eq!(
+            chunk_data.source_rows_in_chunk,
+            Some(3),
+            "source_rows counts every \\n: 2 valid rows + 1 empty line"
+        );
+        assert_eq!(chunk_data.records.len(), 2);
+        assert_eq!(
+            chunk_data.parse_errors, 1,
+            "the empty line must surface as a parse_error so L1 cross-check stays in sync"
+        );
+    }
 }

--- a/src/formats/pgdump/reader.rs
+++ b/src/formats/pgdump/reader.rs
@@ -74,14 +74,9 @@ impl<R: ByteReader + 'static> FileReader for PgDumpReader<R> {
             .await
             .context("Failed to read chunk data")?;
 
-        // Tee an exact source-row count off the raw bytes BEFORE parsing.
-        // pg_dump escapes embedded `\n` as the two literal bytes `\` `n`, so
-        // every byte-newline inside `[data_start, data_end)` corresponds to
-        // exactly one record. The `\.` terminator line is excluded by chunk
-        // construction (`data_end` stops at the start of `\.` — see
-        // scan.rs CopyBlock docs), so no end-of-block adjustment is needed.
-        // Drives the L1 verification cross-check against
-        // `records_loaded + records_failed`.
+        // Exact L1 count: pg_dump escapes embedded `\n` as `\` + `n`,
+        // so every byte-newline in `[data_start, data_end)` is one
+        // record. `\.` is excluded by chunk construction.
         let source_rows = buffer.iter().filter(|&&b| b == b'\n').count() as u64;
 
         let expected_columns = self.block.columns.len();
@@ -133,9 +128,8 @@ mod tests {
     use crate::io::LocalFileByteReader;
     use std::io::Write;
 
-    /// Pin the L1 invariant: source_rows_in_chunk equals the exact source-row
-    /// count for the COPY block. Each `\n` in `[data_start, data_end)` is one
-    /// record, the `\.` terminator is excluded by chunk construction.
+    /// L1 invariant: source_rows_in_chunk == record count for a clean
+    /// single-chunk dump. `\.` is excluded by chunk construction.
     #[tokio::test]
     async fn pgdump_read_chunk_source_rows_matches_record_count() {
         let mut f = tempfile::NamedTempFile::new().unwrap();
@@ -161,18 +155,15 @@ mod tests {
         assert_eq!(chunk_data.parse_errors, 0);
     }
 
-    /// Pin the empty-line invariant called out in the design doc: every
-    /// byte-newline in a pgdump COPY block corresponds to a record OR a
-    /// `parse_error`. A future change that drops empty lines silently would
-    /// break L1's source-vs-loader cross-check.
+    /// Empty-line invariant: every `\n` in a COPY block becomes a
+    /// record OR a parse_error. Silent drops would break L1.
     #[tokio::test]
     async fn pgdump_empty_line_counts_as_parse_error_so_l1_holds() {
         let mut f = tempfile::NamedTempFile::new().unwrap();
         writeln!(f, "COPY public.t (id, name) FROM stdin;").unwrap();
         writeln!(f, "1\talpha").unwrap();
-        // Empty line in the middle of the COPY block — pg_dump never emits
-        // these, but a hand-edited or corrupted dump might. Must surface
-        // as a parse_error, not a silent drop.
+        // Hand-edited / corrupted dump: empty line mid-block. Must
+        // surface as parse_error, not a silent drop.
         writeln!(f).unwrap();
         writeln!(f, "2\tbeta").unwrap();
         writeln!(f, "\\.").unwrap();

--- a/src/formats/pgdump/reader.rs
+++ b/src/formats/pgdump/reader.rs
@@ -155,9 +155,8 @@ mod tests {
         assert_eq!(chunk_data.parse_errors, 0);
     }
 
-    /// Multi-chunk invariant: per-chunk source_rows must sum to the
-    /// total record count. Pins the all-or-nothing fold in
-    /// `Coordinator::run_load`.
+    /// Per-chunk source_rows must sum to the total source-row count.
+    /// Pins the reader-side invariant that `aggregate_source_rows` folds.
     #[tokio::test]
     async fn pgdump_source_rows_sum_across_chunks_equals_total() {
         let mut f = tempfile::NamedTempFile::new().unwrap();

--- a/src/formats/reader.rs
+++ b/src/formats/reader.rs
@@ -64,6 +64,15 @@ pub struct ChunkData {
     pub bytes_read: u64,
     /// Number of records that failed to parse
     pub parse_errors: u64,
+    /// Exact number of source rows present in this chunk's byte range, computed
+    /// by the reader before parsing. `Some` only for formats that can tally
+    /// rows independently of the parser (pgdump: `\n` byte count tee'd off the
+    /// raw read; parquet: footer row-group total). `None` for csv/tsv where
+    /// quote-aware exact counting would require a second parse — these formats
+    /// continue to surface the existing `estimated_rows` for operator
+    /// visibility instead. Drives the L1 verification cross-check against
+    /// `records_loaded + records_failed`.
+    pub source_rows_in_chunk: Option<u64>,
 }
 
 /// Build newline-aligned `Chunk`s over the byte range `[start, end)` from

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -1331,16 +1331,32 @@ mod tests {
             test_pool: Some(pool.clone()),
         };
 
-        let result1 = run_load(args1).await.unwrap();
-        let job_id = result1.job_id.clone();
-
-        // Verify first load had some successes and some failures
-        println!(
-            "First load: loaded={}, failed={}",
-            result1.records_loaded, result1.records_failed
+        // First load now fails hard when chunks are left without result
+        // files (single-worker exits on first batch failure → trailing
+        // chunks unprocessed). Pre-fix this returned a green LoadResult
+        // with silent drops; post-fix the operator gets a load-incomplete
+        // error pointing at --resume-job-id. Recover the job_id by
+        // listing the manifest dir.
+        let err = run_load(args1)
+            .await
+            .expect_err("first load must fail hard when worker exits with chunks unprocessed");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Load incomplete"),
+            "expected load-incomplete error, got: {msg}"
         );
-        assert!(result1.records_loaded < 40, "Should have some failures");
-        assert!(result1.records_failed > 0, "Should have failures");
+        let job_id = {
+            let jobs_dir = manifest_path.join("jobs");
+            let mut entries = fs::read_dir(&jobs_dir).await.unwrap();
+            let mut found = None;
+            while let Some(entry) = entries.next_entry().await.unwrap() {
+                if entry.file_type().await.unwrap().is_dir() {
+                    found = Some(entry.file_name().to_string_lossy().into_owned());
+                    break;
+                }
+            }
+            found.expect("jobs dir must contain a job subdir")
+        };
 
         // Count records after first load - should only have records with value <= 300
         let mut conn = pool.acquire().await.unwrap();
@@ -4603,15 +4619,14 @@ mod tests {
             assert_eq!(
                 v.verdict,
                 crate::runner::VerifyVerdict::Match,
-                "{}.{} expected Match, got {:?} (source_rows={:?}, loaded={}, failed={}, target_pre={:?}, target_post={:?})",
+                "{}.{} expected Match, got {:?} (source_rows={:?}, loaded={}, failed={}, target_counts={:?})",
                 t.schema,
                 t.table,
                 v.verdict,
                 v.source_rows,
                 v.records_loaded,
                 v.records_failed,
-                v.target_pre_count,
-                v.target_post_count,
+                v.target_counts,
             );
             assert!(
                 v.source_rows.is_some(),
@@ -4879,8 +4894,10 @@ mod tests {
         assert_eq!(result.records_failed, 0);
         let v = result.verify.as_ref().unwrap();
         assert_eq!(v.verdict, crate::verify::VerifyVerdict::Match);
-        assert_eq!(v.target_pre_count, Some(0));
-        assert_eq!(v.target_post_count, Some(10));
+        assert_eq!(
+            v.target_counts,
+            Some(crate::verify::L2Counts { pre: 0, post: 10 })
+        );
         Ok(())
     }
 
@@ -4934,8 +4951,10 @@ mod tests {
         assert_eq!(result.records_loaded, 50);
         let v = result.verify.as_ref().unwrap();
         assert_eq!(v.verdict, crate::verify::VerifyVerdict::Match);
-        assert_eq!(v.target_pre_count, Some(0));
-        assert_eq!(v.target_post_count, Some(50));
+        assert_eq!(
+            v.target_counts,
+            Some(crate::verify::L2Counts { pre: 0, post: 50 })
+        );
     }
 
     /// csv + verify=Count → SkippedNoExactSourceCount (no exact source count).
@@ -5041,8 +5060,7 @@ mod tests {
             .as_ref()
             .expect("verify=Count must produce a VerifyOutcome");
         // L2 skipped under --if-not-exists.
-        assert_eq!(v.target_pre_count, None);
-        assert_eq!(v.target_post_count, None);
+        assert_eq!(v.target_counts, None);
         // csv → L1 also skipped → SkippedNoExactSourceCount.
         assert_eq!(
             v.verdict,

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -23,7 +23,7 @@ mod tests {
             parquet::GenericParquetReader,
         },
         io::LocalFileByteReader,
-        runner::{Format, LoadArgs, MigrateArgs, run_load, run_migrate},
+        runner::{Format, LoadArgs, MigrateArgs, VerifyMode, run_load, run_migrate},
     };
     use arrow::array::*;
     use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
@@ -508,6 +508,7 @@ mod tests {
             quote: None,
             escape: None,
             has_header: Some(true),
+            verify: VerifyMode::Off,
             test_pool: Some(pool.clone()),
         };
 
@@ -596,6 +597,7 @@ mod tests {
             quote: None,
             escape: None,
             has_header: None,
+            verify: VerifyMode::Off,
             test_pool: Some(pool.clone()),
         };
 
@@ -737,6 +739,7 @@ mod tests {
             quote: None,
             escape: None,
             has_header: Some(true),
+            verify: VerifyMode::Off,
             test_pool: Some(pool),
         };
 
@@ -1007,6 +1010,7 @@ mod tests {
             quote: None,
             escape: None,
             has_header: Some(true),
+            verify: VerifyMode::Off,
             test_pool: Some(pool.clone()),
         };
 
@@ -1109,6 +1113,7 @@ mod tests {
             quote: None,
             escape: None,
             has_header: Some(true),
+            verify: VerifyMode::Off,
             test_pool: Some(pool.clone()),
         };
 
@@ -1199,6 +1204,7 @@ mod tests {
             quote: None,
             escape: None,
             has_header: Some(true),
+            verify: VerifyMode::Off,
             test_pool: Some(pool.clone()),
         };
 
@@ -1321,6 +1327,7 @@ mod tests {
             quote: None,
             escape: None,
             has_header: Some(true),
+            verify: VerifyMode::Off,
             test_pool: Some(pool.clone()),
         };
 
@@ -1417,6 +1424,7 @@ mod tests {
             quote: None,
             escape: None,
             has_header: Some(true),
+            verify: VerifyMode::Off,
             test_pool: Some(pool.clone()),
         };
 
@@ -1918,6 +1926,7 @@ mod tests {
             quote: Some("'".to_string()),
             escape: Some("\\".to_string()),
             has_header: Some(false),
+            verify: VerifyMode::Off,
             test_pool: Some(pool.clone()),
         };
 
@@ -2091,6 +2100,7 @@ mod tests {
             quote,
             escape,
             has_header,
+            verify: VerifyMode::Off,
             test_pool: Some(pool.clone()),
         };
         run_load(args).await.unwrap()
@@ -2216,6 +2226,7 @@ mod tests {
             quote: None,
             escape: None,
             has_header: None,
+            verify: VerifyMode::Off,
             test_pool: Some(pool.clone()),
         };
         let result = run_load(args).await.unwrap();
@@ -2265,6 +2276,7 @@ mod tests {
             quote: None,
             escape: None,
             has_header: Some(true),
+            verify: VerifyMode::Off,
             test_pool: Some(pool.clone()),
         };
         let result = run_load(args).await.unwrap();
@@ -2339,6 +2351,7 @@ mod tests {
             quote: None,
             escape: None,
             has_header: Some(true),
+            verify: VerifyMode::Off,
             test_pool: Some(pool),
         };
         let err = run_load(args).await.expect_err("must reject");
@@ -3994,6 +4007,7 @@ mod tests {
             column_mappings: HashMap::new(),
             resume_job_id: None,
             on_conflict: OnConflict::DoNothing,
+            verify: VerifyMode::Off,
             exclude_columns: Vec::new(),
             delimiter: None,
             quote: None,
@@ -4301,6 +4315,7 @@ mod tests {
             quote: None,
             escape: None,
             has_header: None,
+            verify: VerifyMode::Off,
             test_pool: Some(pool),
         };
 
@@ -4520,6 +4535,10 @@ mod tests {
             batch_concurrency: 1,
             chunk_size_bytes: 1024 * 1024,
             on_conflict: OnConflict::Error,
+            // Exercise the migrate default end-to-end: every loaded table
+            // gets a VerifyOutcome and the assertions below pin the verdict
+            // shape we promise (`Match` for both tables on a fresh cluster).
+            verify: VerifyMode::Count,
             quiet: true,
             debug: false,
             test_pool: None,
@@ -4570,6 +4589,39 @@ mod tests {
                 .build()?,
         )
         .await?;
+
+        // ── Stage 1.5: per-table verification verdict ───────────────────
+        // The migrate orchestrator runs verify=Count by default; assert
+        // every loaded table came back with Match. Catches a real-cluster
+        // regression where rows go missing between the loader and DSQL —
+        // which is exactly what L1+L2 was added to surface.
+        for t in &report.tables {
+            let v = t.verify.as_ref().unwrap_or_else(|| {
+                panic!(
+                    "verify must be Some on {}.{} under default migrate verify=Count",
+                    t.schema, t.table
+                )
+            });
+            assert_eq!(
+                v.verdict,
+                crate::runner::VerifyVerdict::Match,
+                "{}.{} expected Match, got {:?} (source_rows={:?}, loaded={}, failed={}, target_pre={:?}, target_post={:?})",
+                t.schema,
+                t.table,
+                v.verdict,
+                v.source_rows,
+                v.records_loaded,
+                v.records_failed,
+                v.target_pre_count,
+                v.target_post_count,
+            );
+            assert!(
+                v.source_rows.is_some(),
+                "pgdump must produce exact source_rows; got None for {}.{}",
+                t.schema,
+                t.table,
+            );
+        }
 
         // ── Stage 2: schema shape on the destination ───────────────────
         // SERIAL → identity on both PK columns.
@@ -4800,6 +4852,171 @@ mod tests {
             0,
             "column-set guard must reject before any rows are inserted"
         );
+        Ok(())
+    }
+
+    // ============ Verification (source_rows + LoadResult.verify) ============
+
+    /// `LoadResult.source_rows` reflects the exact pgdump source-row count
+    /// (one `\n` per record). Pin the pgdump leg of L1's input.
+    #[tokio::test]
+    async fn pgdump_load_populates_source_rows_exact_count() -> anyhow::Result<()> {
+        let mut f = tempfile::NamedTempFile::new()?;
+        writeln!(f, "COPY public.things (id, name) FROM stdin;")?;
+        for i in 0..10 {
+            writeln!(f, "{i}\titem{i}")?;
+        }
+        writeln!(f, "\\.")?;
+        f.flush()?;
+
+        let pool = setup_sqlite_table("things", "id INTEGER, name TEXT").await;
+        let args = pgdump_load_args(
+            f.path().to_string_lossy().into_owned(),
+            "things",
+            pool.clone(),
+        );
+        let result = run_load(args).await?;
+
+        assert_eq!(result.source_rows, Some(10));
+        assert_eq!(result.records_loaded, 10);
+        assert_eq!(result.records_failed, 0);
+        // verify=Off (the load default) → no VerifyOutcome.
+        assert!(result.verify.is_none());
+        Ok(())
+    }
+
+    /// `LoadResult.source_rows` for parquet equals the sum of the chunk's
+    /// row-group `num_rows`. Pin the parquet leg of L1's input.
+    #[tokio::test]
+    async fn parquet_load_populates_source_rows_exact_count() {
+        let temp_dir = TempDir::new().unwrap();
+        let parquet_path = temp_dir.path().join("verify.parquet");
+        let schema = ArrowSchema::new(vec![Field::new("id", DataType::Int32, false)]);
+        let file = std::fs::File::create(&parquet_path).unwrap();
+        let props = WriterProperties::builder()
+            .set_max_row_group_size(20)
+            .build();
+        let mut writer = ArrowWriter::try_new(file, Arc::new(schema.clone()), Some(props)).unwrap();
+        let id_array = Int32Array::from_iter_values(0..50);
+        let batch =
+            RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(id_array)]).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let pool = setup_sqlite_table("verify_pq", "id INTEGER").await;
+        let args = LoadArgs {
+            endpoint: "test".to_string(),
+            region: "us-west-2".to_string(),
+            username: "test".to_string(),
+            source_uri: parquet_path.to_str().unwrap().to_string(),
+            target_table: "verify_pq".to_string(),
+            schema: "public".to_string(),
+            format: Format::Parquet,
+            worker_count: 1,
+            chunk_size_bytes: 10_000_000,
+            batch_size: 100,
+            batch_concurrency: 1,
+            create_table_if_missing: false,
+            manifest_dir: None,
+            quiet: true,
+            debug: false,
+            column_mappings: HashMap::new(),
+            resume_job_id: None,
+            on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            verify: VerifyMode::Off,
+            exclude_columns: Vec::new(),
+            delimiter: None,
+            quote: None,
+            escape: None,
+            has_header: None,
+            test_pool: Some(pool.clone()),
+        };
+        let result = run_load(args).await.unwrap();
+        assert_eq!(result.source_rows, Some(50));
+        assert_eq!(result.records_loaded, 50);
+    }
+
+    /// CSV/TSV: `source_rows` is `None` (quote-aware exact counting is v2).
+    /// Pin the SkippedNoExactSourceCount path: with verify=Count and source
+    /// counts None, the verdict short-circuits.
+    #[tokio::test]
+    async fn csv_load_with_verify_count_yields_skipped_verdict() {
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path = create_test_csv(&temp_dir, "verify.csv", 10).await;
+        let pool =
+            setup_sqlite_table("verify_csv", "id TEXT, name TEXT, value TEXT, amount TEXT").await;
+        let args = LoadArgs {
+            endpoint: "test".to_string(),
+            region: "us-west-2".to_string(),
+            username: "test".to_string(),
+            source_uri: csv_path,
+            target_table: "verify_csv".to_string(),
+            schema: "public".to_string(),
+            format: Format::Csv,
+            worker_count: 1,
+            chunk_size_bytes: 10_000_000,
+            batch_size: 100,
+            batch_concurrency: 1,
+            create_table_if_missing: false,
+            manifest_dir: None,
+            quiet: true,
+            debug: false,
+            column_mappings: HashMap::new(),
+            resume_job_id: None,
+            on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            verify: VerifyMode::Count,
+            exclude_columns: Vec::new(),
+            delimiter: None,
+            quote: None,
+            escape: None,
+            has_header: Some(true),
+            test_pool: Some(pool.clone()),
+        };
+        let result = run_load(args).await.unwrap();
+        assert_eq!(
+            result.source_rows, None,
+            "csv must leave source_rows None in v1"
+        );
+        let v = result
+            .verify
+            .as_ref()
+            .expect("verify=Count must produce a VerifyOutcome");
+        assert_eq!(
+            v.verdict,
+            crate::verify::VerifyVerdict::SkippedNoExactSourceCount,
+            "csv with verify=Count must yield SkippedNoExactSourceCount"
+        );
+    }
+
+    /// run_load with verify=Count on a pgdump fixture produces
+    /// VerifyVerdict::Match. Pre-count is captured against the existing
+    /// (empty) target, post-count reflects the loaded rows.
+    #[tokio::test]
+    async fn pgdump_run_load_verify_count_matches() -> anyhow::Result<()> {
+        let mut f = tempfile::NamedTempFile::new()?;
+        writeln!(f, "COPY public.things (id, name) FROM stdin;")?;
+        for i in 0..5 {
+            writeln!(f, "{i}\tname{i}")?;
+        }
+        writeln!(f, "\\.")?;
+        f.flush()?;
+
+        let pool = setup_sqlite_table("things", "id INTEGER, name TEXT").await;
+        let mut args = pgdump_load_args(
+            f.path().to_string_lossy().into_owned(),
+            "things",
+            pool.clone(),
+        );
+        args.verify = VerifyMode::Count;
+        let result = run_load(args).await?;
+        let v = result
+            .verify
+            .as_ref()
+            .expect("verify=Count must produce a VerifyOutcome");
+        assert_eq!(v.verdict, crate::verify::VerifyVerdict::Match);
+        assert_eq!(v.source_rows, Some(5));
+        assert_eq!(v.target_pre_count, Some(0));
+        assert_eq!(v.target_post_count, Some(5));
         Ok(())
     }
 }

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -5019,4 +5019,105 @@ mod tests {
         assert_eq!(v.target_post_count, Some(5));
         Ok(())
     }
+
+    /// Regression: `--if-not-exists` + `--verify=count` against a table
+    /// that already exists with rows must NOT report `ExtraTarget`. The
+    /// flag is idempotent; an operator who runs the same load twice is
+    /// the canonical case. Earlier impl recorded `target_pre_count = 0`
+    /// unconditionally when create_table_if_missing was true, producing
+    /// a false `ExtraTarget(N)` on every re-run. Fix: skip L2 entirely
+    /// in this mode; report L1-only Match.
+    #[tokio::test]
+    async fn csv_load_with_if_not_exists_and_verify_count_skips_l2() {
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path = create_test_csv(&temp_dir, "verify.csv", 10).await;
+
+        // Pre-create the target with rows already present — simulates a
+        // prior run that loaded data, plus the operator re-running with
+        // --if-not-exists for idempotency.
+        let pool =
+            setup_sqlite_table("verify_idem", "id TEXT, name TEXT, value TEXT, amount TEXT").await;
+        if let Ok(mut conn) = pool.acquire().await
+            && let crate::db::pool::PoolConnection::Sqlite(ref mut c) = conn
+        {
+            sqlx::query("INSERT INTO verify_idem VALUES ('99', 'pre', '0.5', '0')")
+                .execute(&mut **c)
+                .await
+                .unwrap();
+        }
+
+        let args = LoadArgs {
+            endpoint: "test".to_string(),
+            region: "us-west-2".to_string(),
+            username: "test".to_string(),
+            source_uri: csv_path,
+            target_table: "verify_idem".to_string(),
+            schema: "public".to_string(),
+            format: Format::Csv,
+            worker_count: 1,
+            chunk_size_bytes: 10_000_000,
+            batch_size: 100,
+            batch_concurrency: 1,
+            // The flag under test: --if-not-exists path must NOT cause
+            // a bogus ExtraTarget verdict when the table is pre-populated.
+            create_table_if_missing: true,
+            manifest_dir: None,
+            quiet: true,
+            debug: false,
+            column_mappings: HashMap::new(),
+            resume_job_id: None,
+            on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            verify: VerifyMode::Count,
+            exclude_columns: Vec::new(),
+            delimiter: None,
+            quote: None,
+            escape: None,
+            has_header: Some(true),
+            test_pool: Some(pool.clone()),
+        };
+        let result = run_load(args).await.unwrap();
+        let v = result
+            .verify
+            .as_ref()
+            .expect("verify=Count must produce a VerifyOutcome");
+        // L2 must be skipped under --if-not-exists.
+        assert_eq!(v.target_pre_count, None);
+        assert_eq!(v.target_post_count, None);
+        // CSV has no exact source row count, so L1 also yields the
+        // skipped verdict (proves we routed through classify and didn't
+        // synthesise a bogus Match).
+        assert_eq!(
+            v.verdict,
+            crate::verify::VerifyVerdict::SkippedNoExactSourceCount,
+            "csv + --if-not-exists must yield SkippedNoExactSourceCount, not ExtraTarget"
+        );
+    }
+
+    /// Companion to the CSV test: pgdump under `--if-not-exists` +
+    /// `--verify=count` must reach L1 Match (source_rows is exact for
+    /// pgdump) and skip L2 (target_pre/post None) — never ExtraTarget.
+    /// Note: `validate_load_args` rejects `--if-not-exists` with pgdump
+    /// today, so the run won't even reach the verify path; this test
+    /// exists as a tripwire — if a future change relaxes the validation
+    /// (e.g. pgdump schema inference lands), the verify behavior under
+    /// `--if-not-exists` must still be correct.
+    #[tokio::test]
+    async fn pgdump_with_if_not_exists_is_rejected_at_validation() -> anyhow::Result<()> {
+        let mut f = tempfile::NamedTempFile::new()?;
+        writeln!(f, "COPY public.things (id, name) FROM stdin;")?;
+        writeln!(f, "1\twidget")?;
+        writeln!(f, "\\.")?;
+        f.flush()?;
+
+        let pool = setup_sqlite_table("things", "id INTEGER, name TEXT").await;
+        let mut args = pgdump_load_args(f.path().to_string_lossy().into_owned(), "things", pool);
+        args.create_table_if_missing = true;
+        args.verify = VerifyMode::Count;
+        let err = run_load(args).await.unwrap_err().to_string();
+        assert!(
+            err.contains("create_table_if_missing"),
+            "pgdump + --if-not-exists must be rejected at validation; got: {err}"
+        );
+        Ok(())
+    }
 }

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -4996,9 +4996,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let csv_path = create_test_csv(&temp_dir, "verify.csv", 10).await;
 
-        // Pre-create the target with rows already present — simulates a
-        // prior run that loaded data, plus the operator re-running with
-        // re-run with --if-not-exists for idempotency.
+        // Pre-populate: simulates a prior load + operator re-run under --if-not-exists.
         let pool =
             setup_sqlite_table("verify_idem", "id TEXT, name TEXT, value TEXT, amount TEXT").await;
         if let Ok(mut conn) = pool.acquire().await
@@ -5071,6 +5069,28 @@ mod tests {
         assert!(
             err.contains("create_table_if_missing"),
             "pgdump + --if-not-exists must be rejected at validation; got: {err}"
+        );
+        Ok(())
+    }
+
+    /// Symmetric to migrate's `run_migrate_rejects_dump_identifiers_with_embedded_quote`:
+    /// the load path must reject a COPY column name with `"` before INSERT runs.
+    #[tokio::test]
+    async fn pgdump_load_rejects_column_name_with_embedded_quote() -> anyhow::Result<()> {
+        let mut f = tempfile::NamedTempFile::new()?;
+        // `""` decodes to one `"` in the column name — would corrupt INSERT
+        // identifier quoting if validation is skipped.
+        writeln!(f, "COPY public.things (id, \"evil\"\"col\") FROM stdin;")?;
+        writeln!(f, "1\twidget")?;
+        writeln!(f, "\\.")?;
+        f.flush()?;
+
+        let pool = setup_sqlite_table("things", "id INTEGER, name TEXT").await;
+        let args = pgdump_load_args(f.path().to_string_lossy().into_owned(), "things", pool);
+        let err = run_load(args).await.unwrap_err().to_string();
+        assert!(
+            err.contains("pg_dump column identifier") && err.contains("unsafe character"),
+            "expected validation error naming the column field; got: {err}"
         );
         Ok(())
     }

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -4591,10 +4591,8 @@ mod tests {
         .await?;
 
         // ── Stage 1.5: per-table verification verdict ───────────────────
-        // The migrate orchestrator runs verify=Count by default; assert
-        // every loaded table came back with Match. Catches a real-cluster
-        // regression where rows go missing between the loader and DSQL —
-        // which is exactly what L1+L2 was added to surface.
+        // verify=Count is on by default; every loaded table must come
+        // back as Match.
         for t in &report.tables {
             let v = t.verify.as_ref().unwrap_or_else(|| {
                 panic!(
@@ -4975,7 +4973,7 @@ mod tests {
         let result = run_load(args).await.unwrap();
         assert_eq!(
             result.source_rows, None,
-            "csv must leave source_rows None in v1"
+            "csv has no exact source-row count, so source_rows must be None"
         );
         let v = result
             .verify

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -4007,7 +4007,7 @@ mod tests {
             column_mappings: HashMap::new(),
             resume_job_id: None,
             on_conflict: OnConflict::DoNothing,
-            verify: VerifyMode::Off,
+            verify: VerifyMode::Count,
             exclude_columns: Vec::new(),
             delimiter: None,
             quote: None,
@@ -4853,10 +4853,9 @@ mod tests {
         Ok(())
     }
 
-    // ============ Verification (source_rows + LoadResult.verify) ============
+    // ============ Verify (source_rows + LoadResult.verify) ============
 
-    /// `LoadResult.source_rows` reflects the exact pgdump source-row count
-    /// (one `\n` per record). Pin the pgdump leg of L1's input.
+    /// pgdump: source_rows == record count.
     #[tokio::test]
     async fn pgdump_load_populates_source_rows_exact_count() -> anyhow::Result<()> {
         let mut f = tempfile::NamedTempFile::new()?;
@@ -4878,13 +4877,14 @@ mod tests {
         assert_eq!(result.source_rows, Some(10));
         assert_eq!(result.records_loaded, 10);
         assert_eq!(result.records_failed, 0);
-        // verify=Off (the load default) → no VerifyOutcome.
-        assert!(result.verify.is_none());
+        let v = result.verify.as_ref().unwrap();
+        assert_eq!(v.verdict, crate::verify::VerifyVerdict::Match);
+        assert_eq!(v.target_pre_count, Some(0));
+        assert_eq!(v.target_post_count, Some(10));
         Ok(())
     }
 
-    /// `LoadResult.source_rows` for parquet equals the sum of the chunk's
-    /// row-group `num_rows`. Pin the parquet leg of L1's input.
+    /// parquet: source_rows == sum of row-group `num_rows`.
     #[tokio::test]
     async fn parquet_load_populates_source_rows_exact_count() {
         let temp_dir = TempDir::new().unwrap();
@@ -4921,7 +4921,7 @@ mod tests {
             column_mappings: HashMap::new(),
             resume_job_id: None,
             on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
-            verify: VerifyMode::Off,
+            verify: VerifyMode::Count,
             exclude_columns: Vec::new(),
             delimiter: None,
             quote: None,
@@ -4932,11 +4932,13 @@ mod tests {
         let result = run_load(args).await.unwrap();
         assert_eq!(result.source_rows, Some(50));
         assert_eq!(result.records_loaded, 50);
+        let v = result.verify.as_ref().unwrap();
+        assert_eq!(v.verdict, crate::verify::VerifyVerdict::Match);
+        assert_eq!(v.target_pre_count, Some(0));
+        assert_eq!(v.target_post_count, Some(50));
     }
 
-    /// CSV/TSV: `source_rows` is `None` (quote-aware exact counting is v2).
-    /// Pin the SkippedNoExactSourceCount path: with verify=Count and source
-    /// counts None, the verdict short-circuits.
+    /// csv + verify=Count → SkippedNoExactSourceCount (no exact source count).
     #[tokio::test]
     async fn csv_load_with_verify_count_yields_skipped_verdict() {
         let temp_dir = TempDir::new().unwrap();
@@ -4986,45 +4988,9 @@ mod tests {
         );
     }
 
-    /// run_load with verify=Count on a pgdump fixture produces
-    /// VerifyVerdict::Match. Pre-count is captured against the existing
-    /// (empty) target, post-count reflects the loaded rows.
-    #[tokio::test]
-    async fn pgdump_run_load_verify_count_matches() -> anyhow::Result<()> {
-        let mut f = tempfile::NamedTempFile::new()?;
-        writeln!(f, "COPY public.things (id, name) FROM stdin;")?;
-        for i in 0..5 {
-            writeln!(f, "{i}\tname{i}")?;
-        }
-        writeln!(f, "\\.")?;
-        f.flush()?;
-
-        let pool = setup_sqlite_table("things", "id INTEGER, name TEXT").await;
-        let mut args = pgdump_load_args(
-            f.path().to_string_lossy().into_owned(),
-            "things",
-            pool.clone(),
-        );
-        args.verify = VerifyMode::Count;
-        let result = run_load(args).await?;
-        let v = result
-            .verify
-            .as_ref()
-            .expect("verify=Count must produce a VerifyOutcome");
-        assert_eq!(v.verdict, crate::verify::VerifyVerdict::Match);
-        assert_eq!(v.source_rows, Some(5));
-        assert_eq!(v.target_pre_count, Some(0));
-        assert_eq!(v.target_post_count, Some(5));
-        Ok(())
-    }
-
-    /// Regression: `--if-not-exists` + `--verify=count` against a table
-    /// that already exists with rows must NOT report `ExtraTarget`. The
-    /// flag is idempotent; an operator who runs the same load twice is
-    /// the canonical case. Earlier impl recorded `target_pre_count = 0`
-    /// unconditionally when create_table_if_missing was true, producing
-    /// a false `ExtraTarget(N)` on every re-run. Fix: skip L2 entirely
-    /// in this mode; report L1-only Match.
+    /// `--if-not-exists` + verify=Count against a populated target
+    /// must skip L2 (else a re-run would report ExtraTarget). L1-only
+    /// path → SkippedNoExactSourceCount for csv.
     #[tokio::test]
     async fn csv_load_with_if_not_exists_and_verify_count_skips_l2() {
         let temp_dir = TempDir::new().unwrap();
@@ -5032,7 +4998,7 @@ mod tests {
 
         // Pre-create the target with rows already present — simulates a
         // prior run that loaded data, plus the operator re-running with
-        // --if-not-exists for idempotency.
+        // re-run with --if-not-exists for idempotency.
         let pool =
             setup_sqlite_table("verify_idem", "id TEXT, name TEXT, value TEXT, amount TEXT").await;
         if let Ok(mut conn) = pool.acquire().await
@@ -5056,8 +5022,6 @@ mod tests {
             chunk_size_bytes: 10_000_000,
             batch_size: 100,
             batch_concurrency: 1,
-            // The flag under test: --if-not-exists path must NOT cause
-            // a bogus ExtraTarget verdict when the table is pre-populated.
             create_table_if_missing: true,
             manifest_dir: None,
             quiet: true,
@@ -5078,12 +5042,10 @@ mod tests {
             .verify
             .as_ref()
             .expect("verify=Count must produce a VerifyOutcome");
-        // L2 must be skipped under --if-not-exists.
+        // L2 skipped under --if-not-exists.
         assert_eq!(v.target_pre_count, None);
         assert_eq!(v.target_post_count, None);
-        // CSV has no exact source row count, so L1 also yields the
-        // skipped verdict (proves we routed through classify and didn't
-        // synthesise a bogus Match).
+        // csv → L1 also skipped → SkippedNoExactSourceCount.
         assert_eq!(
             v.verdict,
             crate::verify::VerifyVerdict::SkippedNoExactSourceCount,
@@ -5091,14 +5053,8 @@ mod tests {
         );
     }
 
-    /// Companion to the CSV test: pgdump under `--if-not-exists` +
-    /// `--verify=count` must reach L1 Match (source_rows is exact for
-    /// pgdump) and skip L2 (target_pre/post None) — never ExtraTarget.
-    /// Note: `validate_load_args` rejects `--if-not-exists` with pgdump
-    /// today, so the run won't even reach the verify path; this test
-    /// exists as a tripwire — if a future change relaxes the validation
-    /// (e.g. pgdump schema inference lands), the verify behavior under
-    /// `--if-not-exists` must still be correct.
+    /// `validate_load_args` rejects `--if-not-exists` with pgdump
+    /// today; this is a tripwire if that ever relaxes.
     #[tokio::test]
     async fn pgdump_with_if_not_exists_is_rejected_at_validation() -> anyhow::Result<()> {
         let mut f = tempfile::NamedTempFile::new()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod formats;
 mod io;
 mod migrate;
 mod telemetry;
+mod verify;
 
 #[cfg(test)]
 mod integ_tests;

--- a/src/main.rs
+++ b/src/main.rs
@@ -497,7 +497,7 @@ async fn run_migrate_cli(args: MigrateCliArgs) -> anyhow::Result<()> {
                 println!("    Failed-row manifest: {}", path.display());
             }
             if let Some(v) = &t.verify {
-                print_verify_detail(v, "    ");
+                print_verify_detail(v, true);
             }
         }
         // The orchestrator halts on the first failed table. If the last
@@ -543,10 +543,11 @@ fn is_bad_verdict(v: &VerifyVerdict) -> bool {
     }
 }
 
-/// Print `Verify: <verdict>` and, on a non-clean verdict, the raw counts so
-/// the operator can size the gap without re-running. `indent` is prepended
-/// to both lines (`""` for single-table summary, `"    "` under `migrate`).
-fn print_verify_detail(v: &VerifyOutcome, indent: &str) {
+/// Print `Verify: <verdict>` and, on a non-clean verdict, the raw counts
+/// so the operator can size the gap without re-running. `nested` indents
+/// under a parent bullet (used for per-table rows in the `migrate` report).
+fn print_verify_detail(v: &VerifyOutcome, nested: bool) {
+    let indent = if nested { "    " } else { "" };
     println!("{indent}Verify: {}", format_verdict(&v.verdict));
     if matches!(
         v.verdict,
@@ -746,7 +747,7 @@ async fn run_loader(
         println!("Source rows: {src}");
     }
     if let Some(v) = &result.verify {
-        print_verify_detail(v, "");
+        print_verify_detail(v, false);
     }
 
     // Warn if significantly fewer records were loaded than estimated

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,11 @@ struct LoadParams {
     /// ExtraTarget / RowsConflictedAtTarget / SkippedNoExactSourceCount).
     /// Off by default on `load` to avoid the `count(*)` cost on a
     /// pre-existing target; on by default on `migrate` (fresh-cluster).
+    /// `count` assumes the loader is the sole writer of the target table
+    /// during the run — concurrent writers between pre-count and
+    /// post-count will skew the verdict. With `--if-not-exists` only the
+    /// L1 (source-vs-loader) cross-check is reported; L2 is skipped
+    /// because the table doesn't exist at pre-count time.
     #[arg(long, default_value = "off")]
     verify: String,
 
@@ -246,6 +251,9 @@ enum Command {
         /// and reports an L1+L2 verdict per table. Pre-counts on a fresh
         /// cluster are sub-ms; the `count(*)` cost on the loaded data is
         /// well within "no meaningful cost" for a migration window.
+        /// Assumes the loader is the sole writer of each target table
+        /// during the run — fresh-cluster `migrate` satisfies this by
+        /// construction.
         #[arg(long, default_value = "count")]
         verify: String,
 
@@ -501,6 +509,26 @@ async fn run_migrate_cli(args: MigrateCliArgs) -> anyhow::Result<()> {
             }
             if let Some(v) = &t.verify {
                 println!("    Verify: {}", format_verdict(&v.verdict));
+                // Print the underlying counts on a non-Match verdict so an
+                // operator can see the magnitudes in the summary without
+                // re-running with --debug or grepping the manifest.
+                if !matches!(
+                    v.verdict,
+                    VerifyVerdict::Match | VerifyVerdict::SkippedNoExactSourceCount
+                ) {
+                    println!(
+                        "      counts: source={src}, loaded={loaded}, failed={failed}, target_pre={pre}, target_post={post}",
+                        src = v.source_rows.map_or("n/a".to_string(), |n| n.to_string()),
+                        loaded = v.records_loaded,
+                        failed = v.records_failed,
+                        pre = v
+                            .target_pre_count
+                            .map_or("n/a".to_string(), |n| n.to_string()),
+                        post = v
+                            .target_post_count
+                            .map_or("n/a".to_string(), |n| n.to_string()),
+                    );
+                }
             }
         }
         // The orchestrator halts on the first failed table. If the last
@@ -725,6 +753,23 @@ async fn run_loader(
     }
     if let Some(v) = &result.verify {
         println!("Verify: {}", format_verdict(&v.verdict));
+        if !matches!(
+            v.verdict,
+            VerifyVerdict::Match | VerifyVerdict::SkippedNoExactSourceCount
+        ) {
+            println!(
+                "  counts: source={src}, loaded={loaded}, failed={failed}, target_pre={pre}, target_post={post}",
+                src = v.source_rows.map_or("n/a".to_string(), |n| n.to_string()),
+                loaded = v.records_loaded,
+                failed = v.records_failed,
+                pre = v
+                    .target_pre_count
+                    .map_or("n/a".to_string(), |n| n.to_string()),
+                post = v
+                    .target_post_count
+                    .map_or("n/a".to_string(), |n| n.to_string()),
+            );
+        }
     }
 
     // Warn if significantly fewer records were loaded than estimated

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use aurora_dsql_loader::runner::{
-    ApplyOutcome, Format, LoadArgs, MigrateArgs, OnConflict, run_load, run_migrate,
+    ApplyOutcome, Format, LoadArgs, MigrateArgs, OnConflict, VerifyMode, VerifyVerdict, run_load,
+    run_migrate,
 };
 use clap::{ArgGroup, Args as ClapArgs, Parser, Subcommand};
 use std::collections::HashMap;
@@ -106,6 +107,16 @@ struct LoadParams {
     /// Conflict resolution strategy (do-nothing, do-update, error)
     #[arg(long, default_value = "do-nothing")]
     on_conflict: String,
+
+    /// Post-load verification mode (`off`, `count`). Default `off`: the loader
+    /// emits per-chunk source-row counts but does not run target `count(*)`.
+    /// `count` adds a pre + post `count(*)` against the target table and
+    /// reports an `L1+L2` verdict (Match / LoaderDropped / MissingTarget /
+    /// ExtraTarget / RowsConflictedAtTarget / SkippedNoExactSourceCount).
+    /// Off by default on `load` to avoid the `count(*)` cost on a
+    /// pre-existing target; on by default on `migrate` (fresh-cluster).
+    #[arg(long, default_value = "off")]
+    verify: String,
 
     /// Columns to exclude from INSERT statements so the DB applies DEFAULT values
     /// (format: col1,col2). Source records must still contain these columns - the
@@ -230,6 +241,14 @@ enum Command {
         #[arg(long, default_value = "error")]
         on_conflict: String,
 
+        /// Post-load verification mode (`off`, `count`). Default `count`:
+        /// the orchestrator runs a pre + post `count(*)` per loaded table
+        /// and reports an L1+L2 verdict per table. Pre-counts on a fresh
+        /// cluster are sub-ms; the `count(*)` cost on the loaded data is
+        /// well within "no meaningful cost" for a migration window.
+        #[arg(long, default_value = "count")]
+        verify: String,
+
         /// Quiet mode - minimal output, only show summary.
         #[arg(short, long)]
         quiet: bool,
@@ -284,6 +303,7 @@ async fn main() -> anyhow::Result<()> {
             batch_size,
             batch_concurrency,
             on_conflict,
+            verify,
             quiet,
             debug,
         } => {
@@ -297,6 +317,7 @@ async fn main() -> anyhow::Result<()> {
                 batch_size,
                 batch_concurrency,
                 on_conflict,
+                verify,
                 quiet,
                 debug,
             })
@@ -322,6 +343,7 @@ struct MigrateCliArgs {
     batch_size: usize,
     batch_concurrency: usize,
     on_conflict: String,
+    verify: String,
     quiet: bool,
     debug: bool,
 }
@@ -369,6 +391,10 @@ async fn run_migrate_cli(args: MigrateCliArgs) -> anyhow::Result<()> {
         .on_conflict
         .parse::<OnConflict>()
         .map_err(|e| anyhow::anyhow!("Invalid --on-conflict value: {}", e))?;
+    let verify = args
+        .verify
+        .parse::<VerifyMode>()
+        .map_err(|e| anyhow::anyhow!("Invalid --verify value: {}", e))?;
 
     let migrate_args = MigrateArgs {
         endpoint: args.connection.endpoint,
@@ -382,6 +408,7 @@ async fn run_migrate_cli(args: MigrateCliArgs) -> anyhow::Result<()> {
         batch_concurrency: args.batch_concurrency,
         chunk_size_bytes,
         on_conflict,
+        verify,
         quiet: args.quiet,
         debug: args.debug,
     };
@@ -472,6 +499,9 @@ async fn run_migrate_cli(args: MigrateCliArgs) -> anyhow::Result<()> {
             if let Some(path) = &t.persisted_manifest_dir {
                 println!("    Failed-row manifest: {}", path.display());
             }
+            if let Some(v) = &t.verify {
+                println!("    Verify: {}", format_verdict(&v.verdict));
+            }
         }
         // The orchestrator halts on the first failed table. If the last
         // entry has failures, the operator needs to know the run was
@@ -490,12 +520,55 @@ async fn run_migrate_cli(args: MigrateCliArgs) -> anyhow::Result<()> {
 
     // Mirror `run_loader`: any per-table failures must surface as a
     // non-zero exit so a wrapping `migrate && deploy.sh` doesn't ship
-    // an app pointed at a partially-loaded cluster.
-    if report.tables.iter().any(|t| t.records_failed > 0) {
+    // an app pointed at a partially-loaded cluster. A non-Match verify
+    // verdict counts as a failure for the same reason — the report
+    // looks healthy without the verdict, and `migrate && deploy.sh`
+    // shouldn't ship against a cluster where rows went missing.
+    let any_failed_records = report.tables.iter().any(|t| t.records_failed > 0);
+    let any_bad_verdict = report.tables.iter().any(|t| {
+        t.verify.as_ref().is_some_and(|v| {
+            !matches!(
+                v.verdict,
+                VerifyVerdict::Match | VerifyVerdict::SkippedNoExactSourceCount
+            )
+        })
+    });
+    if any_failed_records || any_bad_verdict {
         std::process::exit(1);
     }
 
     Ok(())
+}
+
+/// One-line summary of a [`VerifyVerdict`] for the CLI's loaded-tables
+/// section. Match collapses to a short marker; the other variants surface
+/// the count payload so an operator can see the exact magnitude of the
+/// drop / shortfall / excess in the summary without grepping for it.
+fn format_verdict(v: &VerifyVerdict) -> String {
+    match v {
+        VerifyVerdict::Match => "OK (counts match)".to_string(),
+        VerifyVerdict::LoaderDropped(n) => {
+            format!(
+                "LOADER DROPPED {n} row(s) — source count exceeds loaded+failed; investigate parser/chunker"
+            )
+        }
+        VerifyVerdict::MissingTarget(n) => {
+            format!("MISSING TARGET {n} row(s) — INSERT count exceeds target growth")
+        }
+        VerifyVerdict::ExtraTarget(n) => {
+            format!(
+                "EXTRA TARGET {n} row(s) — target grew more than loader submitted (concurrent writer?)"
+            )
+        }
+        VerifyVerdict::RowsConflictedAtTarget(n) => {
+            format!(
+                "INFO: {n} row(s) conflict-resolved at target (expected under do-nothing/do-update)"
+            )
+        }
+        VerifyVerdict::SkippedNoExactSourceCount => {
+            "SKIPPED — no exact source-row count for this format (csv/tsv in v1)".to_string()
+        }
+    }
 }
 
 async fn run_loader(
@@ -559,6 +632,11 @@ async fn run_loader(
         .parse::<OnConflict>()
         .map_err(|e| anyhow::anyhow!("Invalid --on-conflict value: {}", e))?;
 
+    let verify = load
+        .verify
+        .parse::<VerifyMode>()
+        .map_err(|e| anyhow::anyhow!("Invalid --verify value: {}", e))?;
+
     // Parse chunk size
     let chunk_size_bytes = cli::parse_size_string(&load.chunk_size)
         .map_err(|e| anyhow::anyhow!("Invalid chunk size '{}': {}", load.chunk_size, e))?;
@@ -612,6 +690,7 @@ async fn run_loader(
         column_mappings,
         resume_job_id: output.resume_job_id.clone(),
         on_conflict,
+        verify,
         exclude_columns,
         delimiter: source.delimiter.clone(),
         quote: source.quote.clone(),
@@ -641,6 +720,12 @@ async fn run_loader(
         "Throughput: {:.2} records/sec",
         result.records_loaded as f64 / result.duration.as_secs_f64()
     );
+    if let Some(src) = result.source_rows {
+        println!("Source rows: {src}");
+    }
+    if let Some(v) = &result.verify {
+        println!("Verify: {}", format_verdict(&v.verdict));
+    }
 
     // Warn if significantly fewer records were loaded than estimated
     let mut row_count_mismatch = false;
@@ -687,7 +772,13 @@ async fn run_loader(
         println!("Manifest was stored in a temporary directory and has been cleaned up.");
     }
 
-    if result.records_failed > 0 || row_count_mismatch {
+    let bad_verdict = result.verify.as_ref().is_some_and(|v| {
+        !matches!(
+            v.verdict,
+            VerifyVerdict::Match | VerifyVerdict::SkippedNoExactSourceCount
+        )
+    });
+    if result.records_failed > 0 || row_count_mismatch || bad_verdict {
         std::process::exit(1);
     }
 
@@ -1138,6 +1229,7 @@ mod tests {
                 batch_size,
                 batch_concurrency,
                 on_conflict,
+                verify,
                 quiet,
                 debug,
             } => {
@@ -1152,6 +1244,7 @@ mod tests {
                 assert_eq!(batch_size, 2000);
                 assert_eq!(batch_concurrency, 32);
                 assert_eq!(on_conflict, "error");
+                assert_eq!(verify, "count");
                 assert!(!quiet);
                 assert!(!debug);
                 // The CLI default round-trips through `OnConflict::FromStr`
@@ -1162,6 +1255,14 @@ mod tests {
                     on_conflict.parse::<OnConflict>().unwrap(),
                     OnConflict::Error,
                     "migrate --on-conflict default must parse to OnConflict::Error",
+                );
+                // Same round-trip pin for --verify: the migrate default of
+                // "count" must parse to VerifyMode::Count. A future rename
+                // of the enum variant would surface here.
+                assert_eq!(
+                    verify.parse::<VerifyMode>().unwrap(),
+                    VerifyMode::Count,
+                    "migrate --verify default must parse to VerifyMode::Count",
                 );
             }
             _ => panic!("expected Migrate"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -538,18 +538,27 @@ async fn run_migrate_cli(args: MigrateCliArgs) -> anyhow::Result<()> {
     // ship against a partially-loaded cluster.
     let any_failed_records = report.tables.iter().any(|t| t.records_failed > 0);
     let any_bad_verdict = report.tables.iter().any(|t| {
-        t.verify.as_ref().is_some_and(|v| {
-            !matches!(
-                v.verdict,
-                VerifyVerdict::Match | VerifyVerdict::SkippedNoExactSourceCount
-            )
-        })
+        t.verify
+            .as_ref()
+            .is_some_and(|v| is_bad_verdict(&v.verdict))
     });
     if any_failed_records || any_bad_verdict {
         std::process::exit(1);
     }
 
     Ok(())
+}
+
+/// True for verdicts that should make the CLI exit non-zero. Exhaustive
+/// match so a future verdict variant fails compilation here.
+fn is_bad_verdict(v: &VerifyVerdict) -> bool {
+    match v {
+        VerifyVerdict::Match | VerifyVerdict::SkippedNoExactSourceCount => false,
+        VerifyVerdict::LoaderDropped(_)
+        | VerifyVerdict::MissingTarget(_)
+        | VerifyVerdict::ExtraTarget(_)
+        | VerifyVerdict::RowsConflictedAtTarget(_) => true,
+    }
 }
 
 /// One-line CLI summary per VerifyVerdict.
@@ -798,12 +807,10 @@ async fn run_loader(
         println!("Manifest was stored in a temporary directory and has been cleaned up.");
     }
 
-    let bad_verdict = result.verify.as_ref().is_some_and(|v| {
-        !matches!(
-            v.verdict,
-            VerifyVerdict::Match | VerifyVerdict::SkippedNoExactSourceCount
-        )
-    });
+    let bad_verdict = result
+        .verify
+        .as_ref()
+        .is_some_and(|v| is_bad_verdict(&v.verdict));
     if result.records_failed > 0 || row_count_mismatch || bad_verdict {
         std::process::exit(1);
     }
@@ -1006,6 +1013,19 @@ mod tests {
     use super::*;
     use clap::Parser;
     use std::collections::HashSet;
+
+    /// Pin the CLI exit-code policy: only `Match` and
+    /// `SkippedNoExactSourceCount` are clean. A future verdict variant
+    /// will fail compilation here (no `_ =>` arm).
+    #[test]
+    fn is_bad_verdict_classifies_every_variant() {
+        assert!(!is_bad_verdict(&VerifyVerdict::Match));
+        assert!(!is_bad_verdict(&VerifyVerdict::SkippedNoExactSourceCount));
+        assert!(is_bad_verdict(&VerifyVerdict::LoaderDropped(1)));
+        assert!(is_bad_verdict(&VerifyVerdict::MissingTarget(1)));
+        assert!(is_bad_verdict(&VerifyVerdict::ExtraTarget(1)));
+        assert!(is_bad_verdict(&VerifyVerdict::RowsConflictedAtTarget(1)));
+    }
 
     #[test]
     fn parse_exclude_columns_basic() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use aurora_dsql_loader::runner::{
-    ApplyOutcome, Format, LoadArgs, MigrateArgs, OnConflict, VerifyMode, VerifyVerdict, run_load,
-    run_migrate,
+    ApplyOutcome, Format, LoadArgs, MigrateArgs, OnConflict, VerifyMode, VerifyOutcome,
+    VerifyVerdict, run_load, run_migrate,
 };
 use clap::{ArgGroup, Args as ClapArgs, Parser, Subcommand};
 use std::collections::HashMap;
@@ -110,8 +110,9 @@ struct LoadParams {
 
     /// Post-load verification (`off` | `count`). `count` adds pre/post
     /// `count(*)` and reports an L1+L2 verdict per table. Assumes the
-    /// loader is the sole writer during the run. Skipped under
-    /// `--if-not-exists` (L2 needs a stable pre-count); L1 still runs.
+    /// loader is the sole writer during the run. L2 is skipped under
+    /// `--if-not-exists` (no stable pre-count) and on csv/tsv (no exact
+    /// source count); the per-table verdict still surfaces.
     #[arg(long, default_value = "off")]
     verify: String,
 
@@ -496,26 +497,7 @@ async fn run_migrate_cli(args: MigrateCliArgs) -> anyhow::Result<()> {
                 println!("    Failed-row manifest: {}", path.display());
             }
             if let Some(v) = &t.verify {
-                println!("    Verify: {}", format_verdict(&v.verdict));
-                // On a non-Match verdict, print the raw counts so the
-                // operator can size the gap without re-running.
-                if !matches!(
-                    v.verdict,
-                    VerifyVerdict::Match | VerifyVerdict::SkippedNoExactSourceCount
-                ) {
-                    println!(
-                        "      counts: source={src}, loaded={loaded}, failed={failed}, target_pre={pre}, target_post={post}",
-                        src = v.source_rows.map_or("n/a".to_string(), |n| n.to_string()),
-                        loaded = v.records_loaded,
-                        failed = v.records_failed,
-                        pre = v
-                            .target_pre_count
-                            .map_or("n/a".to_string(), |n| n.to_string()),
-                        post = v
-                            .target_post_count
-                            .map_or("n/a".to_string(), |n| n.to_string()),
-                    );
-                }
+                print_verify_detail(v, "    ");
             }
         }
         // The orchestrator halts on the first failed table. If the last
@@ -561,6 +543,28 @@ fn is_bad_verdict(v: &VerifyVerdict) -> bool {
     }
 }
 
+/// Print `Verify: <verdict>` and, on a non-clean verdict, the raw counts so
+/// the operator can size the gap without re-running. `indent` is prepended
+/// to both lines (`""` for single-table summary, `"    "` under `migrate`).
+fn print_verify_detail(v: &VerifyOutcome, indent: &str) {
+    println!("{indent}Verify: {}", format_verdict(&v.verdict));
+    if matches!(
+        v.verdict,
+        VerifyVerdict::Match | VerifyVerdict::SkippedNoExactSourceCount
+    ) {
+        return;
+    }
+    let fmt = |n: Option<u64>| n.map_or("n/a".to_string(), |n| n.to_string());
+    println!(
+        "{indent}  counts: source={src}, loaded={loaded}, failed={failed}, target_pre={pre}, target_post={post}",
+        src = fmt(v.source_rows),
+        loaded = v.records_loaded,
+        failed = v.records_failed,
+        pre = fmt(v.target_pre_count),
+        post = fmt(v.target_post_count),
+    );
+}
+
 /// One-line CLI summary per VerifyVerdict.
 fn format_verdict(v: &VerifyVerdict) -> String {
     match v {
@@ -580,7 +584,7 @@ fn format_verdict(v: &VerifyVerdict) -> String {
         }
         VerifyVerdict::RowsConflictedAtTarget(n) => {
             format!(
-                "INFO: {n} row(s) conflict-resolved at target (expected under do-nothing/do-update)"
+                "CONFLICT: {n} row(s) conflict-resolved at target (expected under do-nothing/do-update)"
             )
         }
         VerifyVerdict::SkippedNoExactSourceCount => {
@@ -742,24 +746,7 @@ async fn run_loader(
         println!("Source rows: {src}");
     }
     if let Some(v) = &result.verify {
-        println!("Verify: {}", format_verdict(&v.verdict));
-        if !matches!(
-            v.verdict,
-            VerifyVerdict::Match | VerifyVerdict::SkippedNoExactSourceCount
-        ) {
-            println!(
-                "  counts: source={src}, loaded={loaded}, failed={failed}, target_pre={pre}, target_post={post}",
-                src = v.source_rows.map_or("n/a".to_string(), |n| n.to_string()),
-                loaded = v.records_loaded,
-                failed = v.records_failed,
-                pre = v
-                    .target_pre_count
-                    .map_or("n/a".to_string(), |n| n.to_string()),
-                post = v
-                    .target_post_count
-                    .map_or("n/a".to_string(), |n| n.to_string()),
-            );
-        }
+        print_verify_detail(v, "");
     }
 
     // Warn if significantly fewer records were loaded than estimated

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,18 +108,10 @@ struct LoadParams {
     #[arg(long, default_value = "do-nothing")]
     on_conflict: String,
 
-    /// Post-load verification mode (`off`, `count`). Default `off`: the loader
-    /// emits per-chunk source-row counts but does not run target `count(*)`.
-    /// `count` adds a pre + post `count(*)` against the target table and
-    /// reports an `L1+L2` verdict (Match / LoaderDropped / MissingTarget /
-    /// ExtraTarget / RowsConflictedAtTarget / SkippedNoExactSourceCount).
-    /// Off by default on `load` to avoid the `count(*)` cost on a
-    /// pre-existing target; on by default on `migrate` (fresh-cluster).
-    /// `count` assumes the loader is the sole writer of the target table
-    /// during the run — concurrent writers between pre-count and
-    /// post-count will skew the verdict. With `--if-not-exists` only the
-    /// L1 (source-vs-loader) cross-check is reported; L2 is skipped
-    /// because the table doesn't exist at pre-count time.
+    /// Post-load verification (`off` | `count`). `count` adds pre/post
+    /// `count(*)` and reports an L1+L2 verdict per table. Assumes the
+    /// loader is the sole writer during the run. Skipped under
+    /// `--if-not-exists` (L2 needs a stable pre-count); L1 still runs.
     #[arg(long, default_value = "off")]
     verify: String,
 
@@ -246,14 +238,10 @@ enum Command {
         #[arg(long, default_value = "error")]
         on_conflict: String,
 
-        /// Post-load verification mode (`off`, `count`). Default `count`:
-        /// the orchestrator runs a pre + post `count(*)` per loaded table
-        /// and reports an L1+L2 verdict per table. Pre-counts on a fresh
-        /// cluster are sub-ms; the `count(*)` cost on the loaded data is
-        /// well within "no meaningful cost" for a migration window.
-        /// Assumes the loader is the sole writer of each target table
-        /// during the run — fresh-cluster `migrate` satisfies this by
-        /// construction.
+        /// Post-load verification (`off` | `count`). Default `count`:
+        /// pre/post `count(*)` per loaded table → L1+L2 verdict.
+        /// Fresh-cluster migrate makes the sole-writer assumption hold
+        /// trivially.
         #[arg(long, default_value = "count")]
         verify: String,
 
@@ -509,9 +497,8 @@ async fn run_migrate_cli(args: MigrateCliArgs) -> anyhow::Result<()> {
             }
             if let Some(v) = &t.verify {
                 println!("    Verify: {}", format_verdict(&v.verdict));
-                // Print the underlying counts on a non-Match verdict so an
-                // operator can see the magnitudes in the summary without
-                // re-running with --debug or grepping the manifest.
+                // On a non-Match verdict, print the raw counts so the
+                // operator can size the gap without re-running.
                 if !matches!(
                     v.verdict,
                     VerifyVerdict::Match | VerifyVerdict::SkippedNoExactSourceCount
@@ -565,10 +552,7 @@ async fn run_migrate_cli(args: MigrateCliArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// One-line summary of a [`VerifyVerdict`] for the CLI's loaded-tables
-/// section. Match collapses to a short marker; the other variants surface
-/// the count payload so an operator can see the exact magnitude of the
-/// drop / shortfall / excess in the summary without grepping for it.
+/// One-line CLI summary per VerifyVerdict.
 fn format_verdict(v: &VerifyVerdict) -> String {
     match v {
         VerifyVerdict::Match => "OK (counts match)".to_string(),
@@ -1298,9 +1282,7 @@ mod tests {
                     OnConflict::Error,
                     "migrate --on-conflict default must parse to OnConflict::Error",
                 );
-                // Same round-trip pin for --verify: the migrate default of
-                // "count" must parse to VerifyMode::Count. A future rename
-                // of the enum variant would surface here.
+                // CLI default "count" must round-trip to VerifyMode::Count.
                 assert_eq!(
                     verify.parse::<VerifyMode>().unwrap(),
                     VerifyMode::Count,

--- a/src/main.rs
+++ b/src/main.rs
@@ -493,46 +493,57 @@ async fn run_migrate_cli(args: MigrateCliArgs) -> anyhow::Result<()> {
                     String::new()
                 }
             );
+            if let Some(n) = t.source_rows {
+                println!("    Source rows: {n}");
+            }
             if let Some(path) = &t.persisted_manifest_dir {
                 println!("    Failed-row manifest: {}", path.display());
             }
             if let Some(v) = &t.verify {
                 print_verify_detail(v, true);
             }
+            if let Some(err) = &t.verify_error {
+                println!("    Verify: ERROR — {err}");
+            }
         }
-        // The orchestrator halts on the first failed table. If the last
-        // entry has failures, the operator needs to know the run was
-        // truncated — without FK enforcement on DSQL, continuing would
-        // silently load child rows against missing parents.
-        if report.tables.last().is_some_and(|t| t.records_failed > 0) {
+        // The orchestrator halts on the first table whose load failed
+        // OR whose post-count failed; in either case the report is
+        // truncated and re-running blind risks silent FK-less drift.
+        let last_halted = report
+            .tables
+            .last()
+            .is_some_and(|t| t.records_failed > 0 || t.verify_error.is_some());
+        if last_halted {
             let n = report.tables.len();
             let suffix = if n == 1 { "" } else { "s" };
             println!();
             println!(
-                "Halted after {n} table{suffix} due to load failures. \
-                 Inspect the manifest above before re-running."
+                "Halted after {n} table{suffix} due to load or verify failures. \
+                 Inspect the output above before re-running."
             );
         }
     }
 
-    // Mirror `run_loader`: per-table failures and non-Match verdicts
-    // both exit non-zero so a wrapping `migrate && deploy.sh` can't
-    // ship against a partially-loaded cluster.
+    // Mirror `run_loader`: per-table failures, non-Match verdicts, and
+    // post-count errors all exit non-zero so a wrapping
+    // `migrate && deploy.sh` can't ship against a partially-loaded cluster.
     let any_failed_records = report.tables.iter().any(|t| t.records_failed > 0);
     let any_bad_verdict = report.tables.iter().any(|t| {
         t.verify
             .as_ref()
             .is_some_and(|v| is_bad_verdict(&v.verdict))
     });
-    if any_failed_records || any_bad_verdict {
+    let any_verify_error = report.tables.iter().any(|t| t.verify_error.is_some());
+    if any_failed_records || any_bad_verdict || any_verify_error {
         std::process::exit(1);
     }
 
     Ok(())
 }
 
-/// True for verdicts that should make the CLI exit non-zero. Exhaustive
-/// match so a future verdict variant fails compilation here.
+/// True for verdicts that should make the CLI exit non-zero.
+/// `VerifyVerdict` is `#[non_exhaustive]`; unknown future variants
+/// default to non-zero so an unrecognised verdict can't ship green.
 fn is_bad_verdict(v: &VerifyVerdict) -> bool {
     match v {
         VerifyVerdict::Match | VerifyVerdict::SkippedNoExactSourceCount => false,
@@ -540,6 +551,7 @@ fn is_bad_verdict(v: &VerifyVerdict) -> bool {
         | VerifyVerdict::MissingTarget(_)
         | VerifyVerdict::ExtraTarget(_)
         | VerifyVerdict::RowsConflictedAtTarget(_) => true,
+        _ => true,
     }
 }
 
@@ -556,13 +568,15 @@ fn print_verify_detail(v: &VerifyOutcome, nested: bool) {
         return;
     }
     let fmt = |n: Option<u64>| n.map_or("n/a".to_string(), |n| n.to_string());
+    let (pre, post) = match v.target_counts {
+        Some(c) => (fmt(Some(c.pre)), fmt(Some(c.post))),
+        None => (fmt(None), fmt(None)),
+    };
     println!(
         "{indent}  counts: source={src}, loaded={loaded}, failed={failed}, target_pre={pre}, target_post={post}",
         src = fmt(v.source_rows),
         loaded = v.records_loaded,
         failed = v.records_failed,
-        pre = fmt(v.target_pre_count),
-        post = fmt(v.target_post_count),
     );
 }
 
@@ -576,21 +590,24 @@ fn format_verdict(v: &VerifyVerdict) -> String {
             )
         }
         VerifyVerdict::MissingTarget(n) => {
-            format!("MISSING TARGET {n} row(s) — INSERT count exceeds target growth")
+            format!(
+                "MISSING TARGET {n} row(s) — target grew less than loader submitted (concurrent DELETE? verify=count assumes sole writer)"
+            )
         }
         VerifyVerdict::ExtraTarget(n) => {
             format!(
-                "EXTRA TARGET {n} row(s) — target grew more than loader submitted (concurrent writer?)"
+                "EXTRA TARGET {n} row(s) — target grew more than loader submitted (concurrent INSERT? verify=count assumes sole writer)"
             )
         }
         VerifyVerdict::RowsConflictedAtTarget(n) => {
             format!(
-                "CONFLICT: {n} row(s) conflict-resolved at target (expected under do-nothing/do-update)"
+                "CONFLICT: {n} row(s) conflict-resolved at target under do-nothing/do-update; CLI exits 1 — re-run with verify=off if this is the intended idempotent re-apply"
             )
         }
         VerifyVerdict::SkippedNoExactSourceCount => {
             "SKIPPED — no exact source-row count for this format (csv/tsv)".to_string()
         }
+        _ => format!("UNKNOWN VERDICT: {v:?}"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -546,12 +546,9 @@ async fn run_migrate_cli(args: MigrateCliArgs) -> anyhow::Result<()> {
         }
     }
 
-    // Mirror `run_loader`: any per-table failures must surface as a
-    // non-zero exit so a wrapping `migrate && deploy.sh` doesn't ship
-    // an app pointed at a partially-loaded cluster. A non-Match verify
-    // verdict counts as a failure for the same reason — the report
-    // looks healthy without the verdict, and `migrate && deploy.sh`
-    // shouldn't ship against a cluster where rows went missing.
+    // Mirror `run_loader`: per-table failures and non-Match verdicts
+    // both exit non-zero so a wrapping `migrate && deploy.sh` can't
+    // ship against a partially-loaded cluster.
     let any_failed_records = report.tables.iter().any(|t| t.records_failed > 0);
     let any_bad_verdict = report.tables.iter().any(|t| {
         t.verify.as_ref().is_some_and(|v| {
@@ -594,7 +591,7 @@ fn format_verdict(v: &VerifyVerdict) -> String {
             )
         }
         VerifyVerdict::SkippedNoExactSourceCount => {
-            "SKIPPED — no exact source-row count for this format (csv/tsv in v1)".to_string()
+            "SKIPPED — no exact source-row count for this format (csv/tsv)".to_string()
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -704,7 +704,7 @@ async fn run_loader(
         delimiter: source.delimiter.clone(),
         quote: source.quote.clone(),
         escape: source.escape.clone(),
-        // `header_mode` ArgGroup makes --header/--no-header mutually exclusive at parse time.
+        // --header / --no-header are mutually exclusive (clap `conflicts_with`).
         has_header: if source.header {
             Some(true)
         } else if source.no_header {

--- a/src/migrate/orchestrator.rs
+++ b/src/migrate/orchestrator.rs
@@ -12,7 +12,7 @@ use crate::migrate::transform::{Diagnostic, TransformResult, transform_ddl};
 use crate::runner::{
     Format, LoadArgs, OnConflict, VerifyMode, run_load_with_pool_for_pgdump_block,
 };
-use crate::verify::{VerifyInputs, VerifyOutcome, classify, count_table_rows};
+use crate::verify::{VerifyInputs, VerifyOutcome, count_table_rows};
 use anyhow::{Context, Result};
 use aws_config::{BehaviorVersion, Region};
 use std::collections::HashMap;
@@ -199,8 +199,9 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
     // each load skips the dump rescan + credential-chain walk.
     let mut tables = Vec::with_capacity(blocks.len());
     for block in &blocks {
-        // L2 pre-count. Table exists (apply_ddl ran). L1 still runs
-        // when verify=Off because source_rows is parser-side.
+        // L2 pre-count. Table exists (apply_ddl ran). Source-row
+        // counting is parser-side and always free; classification only
+        // runs under verify=Count below.
         let target_pre_count = if args.verify == VerifyMode::Count {
             Some(
                 count_table_rows(&pool, &block.schema, &block.table)
@@ -246,25 +247,19 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
                         )
                     })?,
             );
-            let verdict = classify(VerifyInputs {
-                mode: args.verify,
-                on_conflict: args.on_conflict,
-                source_rows: r.source_rows,
-                records_loaded: r.records_loaded,
-                records_failed,
-                target_pre_count,
-                target_post_count,
-            });
-            Some(VerifyOutcome {
-                schema: block.schema.clone(),
-                table: block.table.clone(),
-                source_rows: r.source_rows,
-                records_loaded: r.records_loaded,
-                records_failed,
-                target_pre_count,
-                target_post_count,
-                verdict,
-            })
+            Some(VerifyOutcome::from_inputs(
+                block.schema.clone(),
+                block.table.clone(),
+                VerifyInputs {
+                    mode: args.verify,
+                    on_conflict: args.on_conflict,
+                    source_rows: r.source_rows,
+                    records_loaded: r.records_loaded,
+                    records_failed,
+                    target_pre_count,
+                    target_post_count,
+                },
+            ))
         } else {
             None
         };

--- a/src/migrate/orchestrator.rs
+++ b/src/migrate/orchestrator.rs
@@ -147,6 +147,19 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
         "migrate: scanned pg_dump for COPY blocks"
     );
 
+    // Defense in depth: the dump is untrusted input. Validate every
+    // schema / table / column identifier before they flow into
+    // `count(*)` SQL, worker INSERTs, or operator-facing stdout. CLI
+    // args go through `validate_load_args`; the dump path needs the
+    // same guard.
+    for block in &blocks {
+        crate::runner::validate_pgdump_identifier("schema", &block.schema)?;
+        crate::runner::validate_pgdump_identifier("table", &block.table)?;
+        for col in &block.columns {
+            crate::runner::validate_pgdump_identifier("column", col)?;
+        }
+    }
+
     let ddl = extract_ddl(&*reader, &blocks)
         .await
         .context("Failed to extract DDL from pg_dump")?;
@@ -403,6 +416,7 @@ fn collect_warnings(changes: &[Diagnostic]) -> Vec<String> {
 mod tests {
     use super::*;
     use crate::migrate::apply::ApplyOutcome;
+    use crate::verify::VerifyVerdict;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -865,7 +879,6 @@ COPY public.valid_first (id) FROM stdin;
     /// the L1+L2 contract end-to-end through the orchestrator.
     #[tokio::test]
     async fn run_migrate_verify_count_emits_match_per_table() {
-        use crate::verify::VerifyVerdict;
         let pool = Pool::sqlite_in_memory().await.unwrap();
         let dump = write_dump(
             "\
@@ -933,11 +946,9 @@ COPY public.t (id, x) FROM stdin;
 
     /// On_conflict=DoNothing with pre-existing duplicate rows in the
     /// target: L2 surfaces the gap as `RowsConflictedAtTarget(N)` rather
-    /// than `MissingTarget(N)`. Pins the per-OnConflict verdict shape
-    /// promised in the design doc.
+    /// than `MissingTarget(N)`. Pins the per-OnConflict verdict shape.
     #[tokio::test]
     async fn run_migrate_verify_count_classifies_pk_conflicts_under_skip() {
-        use crate::verify::VerifyVerdict;
         let pool = Pool::sqlite_in_memory().await.unwrap();
         // Pre-create the table with PK and seed two conflicting rows so
         // the dump's INSERTs hit ON CONFLICT DO NOTHING for those.
@@ -1016,10 +1027,7 @@ COPY public.t (id, x) FROM stdin;
 
     /// Symmetric to unfixable_does_not_build_pool with verify=Count
     /// requested: when transform_ddl surfaces unfixable, no tables load
-    /// and no verify outcomes get built. Pins that a future change which
-    /// runs verify before the unfixable short-circuit would surface
-    /// here — the design doc calls this out as a critical safety
-    /// invariant.
+    /// and no verify outcomes get built.
     #[tokio::test]
     async fn run_migrate_verify_unfixable_short_circuits_no_verify_outcome() {
         let pool = Pool::sqlite_in_memory().await.unwrap();
@@ -1037,6 +1045,46 @@ COPY public.events (id) FROM stdin;
         assert!(
             report.tables.is_empty(),
             "no per-table verify should be built on the unfixable path"
+        );
+    }
+
+    /// A crafted pg_dump COPY header carrying an embedded `"` in the
+    /// table identifier must be rejected before any pool query, DDL
+    /// apply, or per-table println — the dump is a second untrusted
+    /// input alongside CLI args, and `count(*)` SQL plus operator
+    /// stdout are both downstream of `block.table`.
+    #[tokio::test]
+    async fn run_migrate_rejects_dump_identifiers_with_embedded_quote() {
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        // The embedded `""` decodes via `read_identifier` to a single
+        // `"` inside the identifier. Without validation this lands in
+        // `format!("\"{name}\"")` and corrupts the SQL.
+        let dump = "\
+COPY public.\"evil\"\"name\" (id) FROM stdin;
+1
+\\.
+";
+        let f = write_dump(dump);
+        let args = args_with_pool(&file_uri(f.path()), pool.clone(), false);
+        let err = run_migrate(args)
+            .await
+            .expect_err("dump-parsed identifier with embedded quote must be rejected");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("pg_dump table identifier") && msg.contains("unsafe character"),
+            "error must name the offending identifier and field; got: {msg}"
+        );
+        // Side-effect free: the table must NOT have been created.
+        let rows: Vec<(i64,)> = pool
+            .fetch_all_with_binds::<(i64,)>(
+                "SELECT count(*) FROM sqlite_master WHERE type='table' AND name LIKE 'evil%'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            rows[0].0, 0,
+            "no DDL should run when identifier is rejected"
         );
     }
 }

--- a/src/migrate/orchestrator.rs
+++ b/src/migrate/orchestrator.rs
@@ -9,7 +9,10 @@ use crate::formats::pgdump::{extract_ddl, list_copy_blocks};
 use crate::io::{ByteReader, LocalFileByteReader, S3ByteReader, SourceUri};
 use crate::migrate::apply::{AppliedStatement, apply_ddl};
 use crate::migrate::transform::{Diagnostic, TransformResult, transform_ddl};
-use crate::runner::{Format, LoadArgs, OnConflict, run_load_with_pool_for_pgdump_block};
+use crate::runner::{
+    Format, LoadArgs, OnConflict, VerifyMode, run_load_with_pool_for_pgdump_block,
+};
+use crate::verify::{VerifyInputs, VerifyOutcome, classify, count_table_rows};
 use anyhow::{Context, Result};
 use aws_config::{BehaviorVersion, Region};
 use std::collections::HashMap;
@@ -50,6 +53,13 @@ pub struct MigrateArgs {
     /// `OnConflict::Error` — duplicate rows usually indicate a bug. The
     /// default mirrors what `run_load` accepts so this knob is opt-in.
     pub on_conflict: OnConflict,
+    /// Post-load verification mode. Default for migrate is
+    /// [`VerifyMode::Count`]: the orchestrator runs a pre + post `count(*)`
+    /// per loaded table, builds an L1+L2 [`VerifyOutcome`], and attaches it
+    /// to each [`TableLoadSummary`]. Set to [`VerifyMode::Off`] to skip
+    /// (and pay zero verify cost). The fresh-cluster posture makes
+    /// `Count`-on-by-default cheap: pre-count of an empty table is sub-ms.
+    pub verify: VerifyMode,
     /// Forwarded to `LoadArgs.quiet` for log-level control.
     pub quiet: bool,
     /// Forwarded to `LoadArgs.debug` for log-level control.
@@ -102,6 +112,12 @@ pub struct TableLoadSummary {
     /// it to inspect the failed-row chunks. `None` when the table loaded
     /// cleanly or when `--manifest-dir` was supplied (caller-owned).
     pub persisted_manifest_dir: Option<PathBuf>,
+    /// Verification outcome for this table. `Some` when
+    /// [`MigrateArgs::verify`] is [`VerifyMode::Count`] (the migrate
+    /// default); `None` only when explicitly disabled. Holds the L1
+    /// source-vs-loader cross-check and the L2 target pre/post counts in
+    /// a single verdict — see [`VerifyVerdict`].
+    pub verify: Option<VerifyOutcome>,
 }
 
 /// Drive the end-to-end migrate flow against a real (or test) cluster.
@@ -181,6 +197,26 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
     // each load skips the dump rescan + credential-chain walk.
     let mut tables = Vec::with_capacity(blocks.len());
     for block in &blocks {
+        // L2 pre-count BEFORE the load. apply_ddl ran above, so the table
+        // exists; counting an empty fresh-cluster table is sub-ms. When
+        // verify=Off we skip the call entirely (zero L2 cost), but L1
+        // still flows because source_rows is computed during the load.
+        let target_pre_count = if args.verify == VerifyMode::Count {
+            Some(
+                count_table_rows(&pool, &block.schema, &block.table)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "verify=count: failed to read pre-count for {schema}.{table}",
+                            schema = block.schema,
+                            table = block.table,
+                        )
+                    })?,
+            )
+        } else {
+            None
+        };
+
         let load_args = build_load_args(&args, &block.table, &block.schema);
         let r = run_load_with_pool_for_pgdump_block(
             pool.clone(),
@@ -197,12 +233,49 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
             )
         })?;
         let records_failed = r.records_failed;
+
+        let verify = if args.verify == VerifyMode::Count {
+            let target_post_count = Some(
+                count_table_rows(&pool, &block.schema, &block.table)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "verify=count: failed to read post-count for {schema}.{table}",
+                            schema = block.schema,
+                            table = block.table,
+                        )
+                    })?,
+            );
+            let verdict = classify(VerifyInputs {
+                mode: args.verify,
+                on_conflict: args.on_conflict,
+                source_rows: r.source_rows,
+                records_loaded: r.records_loaded,
+                records_failed,
+                target_pre_count,
+                target_post_count,
+            });
+            Some(VerifyOutcome {
+                schema: block.schema.clone(),
+                table: block.table.clone(),
+                source_rows: r.source_rows,
+                records_loaded: r.records_loaded,
+                records_failed,
+                target_pre_count,
+                target_post_count,
+                verdict,
+            })
+        } else {
+            None
+        };
+
         tables.push(TableLoadSummary {
             schema: block.schema.clone(),
             table: block.table.clone(),
             records_loaded: r.records_loaded,
             records_failed,
             persisted_manifest_dir: r.persisted_manifest_dir,
+            verify,
         });
         if records_failed > 0 {
             break;
@@ -291,6 +364,12 @@ fn build_load_args(args: &MigrateArgs, table: &str, schema: &str) -> LoadArgs {
         debug: args.debug,
         resume_job_id: None,
         on_conflict: args.on_conflict,
+        // The orchestrator drives L2 itself (it owns the per-table pre/post
+        // count loop) — so the inner `run_load_with_pool_for_pgdump_block`
+        // call must NOT also run verify. Pin to `Off` here regardless of
+        // `args.verify`; the orchestrator's verify decision lives in
+        // `run_migrate` below.
+        verify: VerifyMode::Off,
         exclude_columns: Vec::new(),
         delimiter: None,
         quote: None,
@@ -342,6 +421,10 @@ mod tests {
             batch_concurrency: 1,
             chunk_size_bytes: 1024 * 1024,
             on_conflict: OnConflict::Error,
+            // Off by default in test-helper because most tests focus on
+            // DDL apply / load shape; verify-specific tests opt in by
+            // overriding this field.
+            verify: VerifyMode::Off,
             quiet: true,
             debug: false,
             test_pool: Some(pool),
@@ -542,6 +625,7 @@ COPY public.t (id) FROM stdin;
             // Critically: NO test_pool. If the orchestrator tried to
             // build a real pool against the bogus endpoint, this would
             // fail. It must stay offline.
+            verify: VerifyMode::Off,
             test_pool: None,
         };
         let report = run_migrate(args).await.unwrap();
@@ -575,6 +659,7 @@ COPY public.t (id) FROM stdin;
             on_conflict: OnConflict::Error,
             quiet: true,
             debug: false,
+            verify: VerifyMode::Off,
             test_pool: None,
         };
         let report = run_migrate(args).await.unwrap();
@@ -692,6 +777,7 @@ COPY public.events (id) FROM stdin;
             debug: false,
             // Critically: NO test_pool. If the orchestrator tried to build
             // a real pool against the bogus endpoint, this would fail.
+            verify: VerifyMode::Off,
             test_pool: None,
         };
         let report = run_migrate(args).await.unwrap();
@@ -771,5 +857,192 @@ COPY public.valid_first (id) FROM stdin;
             .unwrap()[0]
             .0;
         assert_eq!(row_count, 0);
+    }
+
+    /// Migrate happy path with verify=Count: a clean fresh-cluster load
+    /// must produce `Match` for every table, with `source_rows == loaded`,
+    /// `target_pre_count == 0`, and `target_post_count == loaded`. Pins
+    /// the L1+L2 contract end-to-end through the orchestrator.
+    #[tokio::test]
+    async fn run_migrate_verify_count_emits_match_per_table() {
+        use crate::verify::VerifyVerdict;
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        let dump = write_dump(
+            "\
+CREATE TABLE users (id INTEGER, email TEXT);
+CREATE TABLE events (id INTEGER, label TEXT);
+COPY public.users (id, email) FROM stdin;
+1\ta@example.com
+2\tb@example.com
+3\tc@example.com
+\\.
+COPY public.events (id, label) FROM stdin;
+1\talpha
+2\tbeta
+\\.
+",
+        );
+        let mut args = args_with_pool(&file_uri(dump.path()), pool, false);
+        args.verify = VerifyMode::Count;
+
+        let report = run_migrate(args).await.unwrap();
+        assert_eq!(report.tables.len(), 2, "both COPY blocks should load");
+        for t in &report.tables {
+            let v = t
+                .verify
+                .as_ref()
+                .unwrap_or_else(|| panic!("verify must be Some on {table}", table = t.table));
+            assert_eq!(
+                v.verdict,
+                VerifyVerdict::Match,
+                "{table}: expected Match, got {verdict:?}",
+                table = t.table,
+                verdict = v.verdict
+            );
+            assert_eq!(v.target_pre_count, Some(0));
+            assert_eq!(v.target_post_count, Some(t.records_loaded));
+            assert_eq!(v.source_rows, Some(t.records_loaded));
+        }
+    }
+
+    /// Verify=Off: no `VerifyOutcome` is built and the orchestrator pays
+    /// zero `count(*)` cost. Pins the cost-control contract — operators
+    /// who explicitly opt out must not get hidden L2 traffic.
+    #[tokio::test]
+    async fn run_migrate_verify_off_leaves_summary_verify_none() {
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        let dump = write_dump(
+            "\
+CREATE TABLE t (id INTEGER, x TEXT);
+COPY public.t (id, x) FROM stdin;
+1\ta
+2\tb
+\\.
+",
+        );
+        let mut args = args_with_pool(&file_uri(dump.path()), pool, false);
+        args.verify = VerifyMode::Off;
+
+        let report = run_migrate(args).await.unwrap();
+        assert_eq!(report.tables.len(), 1);
+        assert!(
+            report.tables[0].verify.is_none(),
+            "verify=Off must leave TableLoadSummary.verify = None"
+        );
+    }
+
+    /// On_conflict=DoNothing with pre-existing duplicate rows in the
+    /// target: L2 surfaces the gap as `RowsConflictedAtTarget(N)` rather
+    /// than `MissingTarget(N)`. Pins the per-OnConflict verdict shape
+    /// promised in the design doc.
+    #[tokio::test]
+    async fn run_migrate_verify_count_classifies_pk_conflicts_under_skip() {
+        use crate::verify::VerifyVerdict;
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        // Pre-create the table with PK and seed two conflicting rows so
+        // the dump's INSERTs hit ON CONFLICT DO NOTHING for those.
+        pool.execute_query("CREATE TABLE t (id INTEGER PRIMARY KEY, x TEXT)")
+            .await
+            .unwrap();
+        pool.execute_query("INSERT INTO t VALUES (1, 'pre1'), (2, 'pre2')")
+            .await
+            .unwrap();
+
+        let dump = write_dump(
+            "\
+COPY public.t (id, x) FROM stdin;
+1\ta
+2\tb
+3\tc
+\\.
+",
+        );
+        let mut args = args_with_pool(&file_uri(dump.path()), pool, false);
+        args.verify = VerifyMode::Count;
+        args.on_conflict = OnConflict::DoNothing;
+
+        let report = run_migrate(args).await.unwrap();
+        let v = report.tables[0]
+            .verify
+            .as_ref()
+            .expect("verify must be Some under verify=Count");
+        // 3 rows submitted; 2 conflicted at target; only 1 new row landed.
+        // records_loaded counts the statement as successful (3) but
+        // target_delta is 1, so shortfall = 2.
+        assert_eq!(v.records_loaded, 3);
+        assert_eq!(v.target_pre_count, Some(2));
+        assert_eq!(v.target_post_count, Some(3));
+        assert_eq!(
+            v.verdict,
+            VerifyVerdict::RowsConflictedAtTarget(2),
+            "expected RowsConflictedAtTarget(2), got {:?}",
+            v.verdict
+        );
+    }
+
+    /// Symmetric to above but under `OnConflict::Error`: a duplicate row
+    /// makes the load FAIL outright (records_failed > 0), not silently
+    /// missing-target. The orchestrator halts on the first failed table,
+    /// so we don't reach the verify path under Error+conflict; this test
+    /// pins that the failure surfaces normally.
+    #[tokio::test]
+    async fn run_migrate_verify_count_under_error_with_conflict_halts() {
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        pool.execute_query("CREATE TABLE t (id INTEGER PRIMARY KEY, x TEXT)")
+            .await
+            .unwrap();
+        pool.execute_query("INSERT INTO t VALUES (1, 'pre1')")
+            .await
+            .unwrap();
+
+        let dump = write_dump(
+            "\
+COPY public.t (id, x) FROM stdin;
+1\ta
+\\.
+",
+        );
+        let mut args = args_with_pool(&file_uri(dump.path()), pool, false);
+        args.verify = VerifyMode::Count;
+        args.on_conflict = OnConflict::Error;
+
+        let report = run_migrate(args).await.unwrap();
+        assert_eq!(report.tables.len(), 1);
+        assert!(
+            report.tables[0].records_failed > 0,
+            "duplicate PK with OnConflict::Error must produce records_failed > 0"
+        );
+    }
+
+    /// L1 cross-check: a parser-injected drop must surface as
+    /// `LoaderDropped(N)` even when L2 looks clean (target_delta ==
+    /// records_loaded). We can't easily inject a parser drop into pgdump
+    /// inside this test (the reader is well-behaved on a fresh dump), so
+    /// this test validates the verdict shape via direct `classify()` —
+    /// the integration coverage for L1 lives at the unit-test level
+    /// already. The integration value here is that the orchestrator
+    /// would forward `source_rows: Some(...)` through to `classify`.
+    #[tokio::test]
+    async fn run_migrate_verify_unfixable_short_circuits_no_verify_outcome() {
+        // Symmetric to unfixable_does_not_build_pool: when
+        // transform_ddl surfaces unfixable, no tables load and no verify
+        // outcomes get built. Pins that a future change which runs
+        // verify before the unfixable short-circuit would surface here.
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        let dump = "\
+ALTER TABLE public.events ALTER COLUMN id SET DEFAULT nextval('public.events_id_seq'::regclass);
+COPY public.events (id) FROM stdin;
+1
+\\.
+";
+        let f = write_dump(dump);
+        let mut args = args_with_pool(&file_uri(f.path()), pool, false);
+        args.verify = VerifyMode::Count;
+        let report = run_migrate(args).await.unwrap();
+        assert!(!report.ddl_unfixable.is_empty());
+        assert!(
+            report.tables.is_empty(),
+            "no per-table verify should be built on the unfixable path"
+        );
     }
 }

--- a/src/migrate/orchestrator.rs
+++ b/src/migrate/orchestrator.rs
@@ -1014,20 +1014,14 @@ COPY public.t (id, x) FROM stdin;
         );
     }
 
-    /// L1 cross-check: a parser-injected drop must surface as
-    /// `LoaderDropped(N)` even when L2 looks clean (target_delta ==
-    /// records_loaded). We can't easily inject a parser drop into pgdump
-    /// inside this test (the reader is well-behaved on a fresh dump), so
-    /// this test validates the verdict shape via direct `classify()` —
-    /// the integration coverage for L1 lives at the unit-test level
-    /// already. The integration value here is that the orchestrator
-    /// would forward `source_rows: Some(...)` through to `classify`.
+    /// Symmetric to unfixable_does_not_build_pool with verify=Count
+    /// requested: when transform_ddl surfaces unfixable, no tables load
+    /// and no verify outcomes get built. Pins that a future change which
+    /// runs verify before the unfixable short-circuit would surface
+    /// here — the design doc calls this out as a critical safety
+    /// invariant.
     #[tokio::test]
     async fn run_migrate_verify_unfixable_short_circuits_no_verify_outcome() {
-        // Symmetric to unfixable_does_not_build_pool: when
-        // transform_ddl surfaces unfixable, no tables load and no verify
-        // outcomes get built. Pins that a future change which runs
-        // verify before the unfixable short-circuit would surface here.
         let pool = Pool::sqlite_in_memory().await.unwrap();
         let dump = "\
 ALTER TABLE public.events ALTER COLUMN id SET DEFAULT nextval('public.events_id_seq'::regclass);

--- a/src/migrate/orchestrator.rs
+++ b/src/migrate/orchestrator.rs
@@ -123,8 +123,8 @@ pub struct TableLoadSummary {
 /// 5. if any `unfixable` diagnostic surfaced — short-circuit and return
 ///    the report so the operator can edit the dump and re-run,
 /// 6. otherwise apply the fixed DDL one statement at a time, and
-/// 7. load each table's data via `run_load_with_pool` reusing the same
-///    `Pool` the apply stage used.
+/// 7. load each table's data via `run_load_with_pool_for_pgdump_block`,
+///    reusing the same `Pool`, the pre-resolved `CopyBlock`, and `aws_config`.
 ///
 /// When `args.dry_run` is set the function stops after step 4 (transform)
 /// — the operator gets the proposed DDL and the diagnostic split, no

--- a/src/migrate/orchestrator.rs
+++ b/src/migrate/orchestrator.rs
@@ -12,7 +12,7 @@ use crate::migrate::transform::{Diagnostic, TransformResult, transform_ddl};
 use crate::runner::{
     Format, LoadArgs, OnConflict, VerifyMode, run_load_with_pool_for_pgdump_block,
 };
-use crate::verify::{VerifyInputs, VerifyOutcome, count_table_rows};
+use crate::verify::{L2Counts, VerifyInputs, VerifyOutcome, count_table_rows};
 use anyhow::{Context, Result};
 use aws_config::{BehaviorVersion, Region};
 use std::collections::HashMap;
@@ -104,6 +104,10 @@ pub struct TableLoadSummary {
     pub table: String,
     pub records_loaded: u64,
     pub records_failed: u64,
+    /// Mirrors `LoadResult.source_rows` — exact for pgdump, `None` for
+    /// other formats. Surfaced even under `--verify=off` so operators
+    /// have a per-table source-side number without paying for L2.
+    pub source_rows: Option<u64>,
     /// Path to the persisted manifest dir when this table had failures.
     /// Mirrors `LoadResult.persisted_manifest_dir` — the operator needs
     /// it to inspect the failed-row chunks. `None` when the table loaded
@@ -111,6 +115,10 @@ pub struct TableLoadSummary {
     pub persisted_manifest_dir: Option<PathBuf>,
     /// `Some` under verify=Count, `None` otherwise.
     pub verify: Option<VerifyOutcome>,
+    /// Set when `count(*)` failed mid-run (transient pool/IAM/network);
+    /// the load itself succeeded but the verdict could not be computed.
+    /// Halts the loop so the operator sees the partial report.
+    pub verify_error: Option<String>,
 }
 
 /// Drive the end-to-end migrate flow against a real (or test) cluster.
@@ -199,23 +207,30 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
     // each load skips the dump rescan + credential-chain walk.
     let mut tables = Vec::with_capacity(blocks.len());
     for block in &blocks {
-        // L2 pre-count. Table exists (apply_ddl ran). Source-row
-        // counting is parser-side and always free; classification only
-        // runs under verify=Count below.
-        let target_pre_count = if args.verify == VerifyMode::Count {
-            Some(
-                count_table_rows(&pool, &block.schema, &block.table)
-                    .await
-                    .with_context(|| {
-                        format!(
-                            "verify=count: failed to read pre-count for {schema}.{table}",
-                            schema = block.schema,
-                            table = block.table,
-                        )
-                    })?,
-            )
-        } else {
-            None
+        // Pre-count failure here means the load hasn't started; record a
+        // verify_error against an empty TableLoadSummary so the report
+        // shows which table blocked. The cluster is unchanged for this
+        // block (`apply_ddl` already ran but no INSERTs hit yet).
+        let target_pre = match args.verify {
+            VerifyMode::Count => match count_table_rows(&pool, &block.schema, &block.table).await {
+                Ok(n) => Some(n),
+                Err(e) => {
+                    tables.push(TableLoadSummary {
+                        schema: block.schema.clone(),
+                        table: block.table.clone(),
+                        records_loaded: 0,
+                        records_failed: 0,
+                        source_rows: None,
+                        persisted_manifest_dir: None,
+                        verify: None,
+                        verify_error: Some(format!(
+                            "verify=count: pre-count failed (load not started): {e:#}"
+                        )),
+                    });
+                    break;
+                }
+            },
+            VerifyMode::Off => None,
         };
 
         let load_args = build_load_args(&args, &block.table, &block.schema);
@@ -235,44 +250,49 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
         })?;
         let records_failed = r.records_failed;
 
-        let verify = if args.verify == VerifyMode::Count {
-            let target_post_count = Some(
-                count_table_rows(&pool, &block.schema, &block.table)
-                    .await
-                    .with_context(|| {
-                        format!(
-                            "verify=count: failed to read post-count for {schema}.{table}",
-                            schema = block.schema,
-                            table = block.table,
-                        )
-                    })?,
-            );
-            Some(VerifyOutcome::from_inputs(
-                block.schema.clone(),
-                block.table.clone(),
-                VerifyInputs {
-                    mode: args.verify,
-                    on_conflict: args.on_conflict,
-                    source_rows: r.source_rows,
-                    records_loaded: r.records_loaded,
-                    records_failed,
-                    target_pre_count,
-                    target_post_count,
-                },
-            ))
-        } else {
-            None
+        // Post-count failure: load committed, count(*) failed. Surface
+        // the error against a populated summary so the operator sees what
+        // landed and which table needs manual verification.
+        let (verify, verify_error) = match args.verify {
+            VerifyMode::Count => match count_table_rows(&pool, &block.schema, &block.table).await {
+                Ok(post) => {
+                    let target_counts = target_pre.map(|pre| L2Counts { pre, post });
+                    let outcome = VerifyOutcome::from_inputs(
+                        block.schema.clone(),
+                        block.table.clone(),
+                        VerifyInputs {
+                            mode: args.verify,
+                            on_conflict: args.on_conflict,
+                            source_rows: r.source_rows,
+                            records_loaded: r.records_loaded,
+                            records_failed,
+                            target_counts,
+                        },
+                    );
+                    (Some(outcome), None)
+                }
+                Err(e) => (
+                    None,
+                    Some(format!(
+                        "verify=count: post-count failed (load completed): {e:#}"
+                    )),
+                ),
+            },
+            VerifyMode::Off => (None, None),
         };
 
+        let halt_on_post_count_error = verify_error.is_some();
         tables.push(TableLoadSummary {
             schema: block.schema.clone(),
             table: block.table.clone(),
             records_loaded: r.records_loaded,
             records_failed,
+            source_rows: r.source_rows,
             persisted_manifest_dir: r.persisted_manifest_dir,
             verify,
+            verify_error,
         });
-        if records_failed > 0 {
+        if records_failed > 0 || halt_on_post_count_error {
             break;
         }
     }
@@ -885,8 +905,13 @@ COPY public.events (id, label) FROM stdin;
                 table = t.table,
                 verdict = v.verdict
             );
-            assert_eq!(v.target_pre_count, Some(0));
-            assert_eq!(v.target_post_count, Some(t.records_loaded));
+            assert_eq!(
+                v.target_counts,
+                Some(L2Counts {
+                    pre: 0,
+                    post: t.records_loaded
+                })
+            );
             assert_eq!(v.source_rows, Some(t.records_loaded));
         }
     }
@@ -949,8 +974,7 @@ COPY public.t (id, x) FROM stdin;
             .expect("verify must be Some under verify=Count");
         // 3 submitted, 2 conflicted, 1 landed → shortfall = 2.
         assert_eq!(v.records_loaded, 3);
-        assert_eq!(v.target_pre_count, Some(2));
-        assert_eq!(v.target_post_count, Some(3));
+        assert_eq!(v.target_counts, Some(L2Counts { pre: 2, post: 3 }));
         assert_eq!(
             v.verdict,
             VerifyVerdict::RowsConflictedAtTarget(2),
@@ -988,6 +1012,55 @@ COPY public.t (id, x) FROM stdin;
             report.tables[0].records_failed > 0,
             "duplicate PK with OnConflict::Error must produce records_failed > 0"
         );
+    }
+
+    /// Halt-on-fail in the per-table loop: first table fails → second
+    /// table never runs. Pins the README's "halts on the first failed
+    /// table" contract; a refactor that drops the `break` would compile
+    /// and pass every other test.
+    #[tokio::test]
+    async fn run_migrate_halts_after_first_failed_table() {
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        // Pre-create t1 with PK + seed conflict; t2 is empty so its
+        // load would succeed if reached.
+        pool.execute_query("CREATE TABLE t1 (id INTEGER PRIMARY KEY)")
+            .await
+            .unwrap();
+        pool.execute_query("INSERT INTO t1 VALUES (1)")
+            .await
+            .unwrap();
+        pool.execute_query("CREATE TABLE t2 (id INTEGER)")
+            .await
+            .unwrap();
+
+        let dump = write_dump(
+            "\
+COPY public.t1 (id) FROM stdin;
+1
+\\.
+COPY public.t2 (id) FROM stdin;
+99
+\\.
+",
+        );
+        let mut args = args_with_pool(&file_uri(dump.path()), pool.clone(), false);
+        args.verify = VerifyMode::Off;
+        args.on_conflict = OnConflict::Error;
+
+        let report = run_migrate(args).await.unwrap();
+        assert_eq!(
+            report.tables.len(),
+            1,
+            "halt-on-fail must skip t2 when t1 reports records_failed > 0"
+        );
+        assert_eq!(report.tables[0].table, "t1");
+        assert!(report.tables[0].records_failed > 0);
+        // t2 must not have received any inserts.
+        let rows: Vec<(i64,)> = pool
+            .fetch_all_with_binds::<(i64,)>("SELECT count(*) FROM t2", &[])
+            .await
+            .unwrap();
+        assert_eq!(rows[0].0, 0, "t2 must be untouched after t1 halt");
     }
 
     /// verify=Count + unfixable: short-circuit still wins, no tables

--- a/src/migrate/orchestrator.rs
+++ b/src/migrate/orchestrator.rs
@@ -53,12 +53,9 @@ pub struct MigrateArgs {
     /// `OnConflict::Error` — duplicate rows usually indicate a bug. The
     /// default mirrors what `run_load` accepts so this knob is opt-in.
     pub on_conflict: OnConflict,
-    /// Post-load verification mode. Default for migrate is
-    /// [`VerifyMode::Count`]: the orchestrator runs a pre + post `count(*)`
-    /// per loaded table, builds an L1+L2 [`VerifyOutcome`], and attaches it
-    /// to each [`TableLoadSummary`]. Set to [`VerifyMode::Off`] to skip
-    /// (and pay zero verify cost). The fresh-cluster posture makes
-    /// `Count`-on-by-default cheap: pre-count of an empty table is sub-ms.
+    /// L2 verification toggle. Default `Count`: cheap on a fresh
+    /// cluster (pre-count is sub-ms) and the verdict closes the loop
+    /// on the load.
     pub verify: VerifyMode,
     /// Forwarded to `LoadArgs.quiet` for log-level control.
     pub quiet: bool,
@@ -112,11 +109,7 @@ pub struct TableLoadSummary {
     /// it to inspect the failed-row chunks. `None` when the table loaded
     /// cleanly or when `--manifest-dir` was supplied (caller-owned).
     pub persisted_manifest_dir: Option<PathBuf>,
-    /// Verification outcome for this table. `Some` when
-    /// [`MigrateArgs::verify`] is [`VerifyMode::Count`] (the migrate
-    /// default); `None` only when explicitly disabled. Holds the L1
-    /// source-vs-loader cross-check and the L2 target pre/post counts in
-    /// a single verdict — see [`VerifyVerdict`].
+    /// `Some` under verify=Count, `None` otherwise.
     pub verify: Option<VerifyOutcome>,
 }
 
@@ -147,11 +140,7 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
         "migrate: scanned pg_dump for COPY blocks"
     );
 
-    // Defense in depth: the dump is untrusted input. Validate every
-    // schema / table / column identifier before they flow into
-    // `count(*)` SQL, worker INSERTs, or operator-facing stdout. CLI
-    // args go through `validate_load_args`; the dump path needs the
-    // same guard.
+    // Validate dump-parsed identifiers before they reach SQL or stdout.
     for block in &blocks {
         crate::runner::validate_pgdump_identifier("schema", &block.schema)?;
         crate::runner::validate_pgdump_identifier("table", &block.table)?;
@@ -210,10 +199,8 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
     // each load skips the dump rescan + credential-chain walk.
     let mut tables = Vec::with_capacity(blocks.len());
     for block in &blocks {
-        // L2 pre-count BEFORE the load. apply_ddl ran above, so the table
-        // exists; counting an empty fresh-cluster table is sub-ms. When
-        // verify=Off we skip the call entirely (zero L2 cost), but L1
-        // still flows because source_rows is computed during the load.
+        // L2 pre-count. Table exists (apply_ddl ran). L1 still runs
+        // when verify=Off because source_rows is parser-side.
         let target_pre_count = if args.verify == VerifyMode::Count {
             Some(
                 count_table_rows(&pool, &block.schema, &block.table)
@@ -377,11 +364,7 @@ fn build_load_args(args: &MigrateArgs, table: &str, schema: &str) -> LoadArgs {
         debug: args.debug,
         resume_job_id: None,
         on_conflict: args.on_conflict,
-        // The orchestrator drives L2 itself (it owns the per-table pre/post
-        // count loop) — so the inner `run_load_with_pool_for_pgdump_block`
-        // call must NOT also run verify. Pin to `Off` here regardless of
-        // `args.verify`; the orchestrator's verify decision lives in
-        // `run_migrate` below.
+        // Orchestrator owns L2; the inner call must not double-verify.
         verify: VerifyMode::Off,
         exclude_columns: Vec::new(),
         delimiter: None,
@@ -435,10 +418,7 @@ mod tests {
             batch_concurrency: 1,
             chunk_size_bytes: 1024 * 1024,
             on_conflict: OnConflict::Error,
-            // Off by default in test-helper because most tests focus on
-            // DDL apply / load shape; verify-specific tests opt in by
-            // overriding this field.
-            verify: VerifyMode::Off,
+            verify: VerifyMode::Count,
             quiet: true,
             debug: false,
             test_pool: Some(pool),
@@ -873,10 +853,8 @@ COPY public.valid_first (id) FROM stdin;
         assert_eq!(row_count, 0);
     }
 
-    /// Migrate happy path with verify=Count: a clean fresh-cluster load
-    /// must produce `Match` for every table, with `source_rows == loaded`,
-    /// `target_pre_count == 0`, and `target_post_count == loaded`. Pins
-    /// the L1+L2 contract end-to-end through the orchestrator.
+    /// verify=Count happy path: every table → Match, source_rows ==
+    /// loaded, pre=0, post=loaded.
     #[tokio::test]
     async fn run_migrate_verify_count_emits_match_per_table() {
         let pool = Pool::sqlite_in_memory().await.unwrap();
@@ -918,9 +896,7 @@ COPY public.events (id, label) FROM stdin;
         }
     }
 
-    /// Verify=Off: no `VerifyOutcome` is built and the orchestrator pays
-    /// zero `count(*)` cost. Pins the cost-control contract — operators
-    /// who explicitly opt out must not get hidden L2 traffic.
+    /// verify=Off → TableLoadSummary.verify is None, no count(*) runs.
     #[tokio::test]
     async fn run_migrate_verify_off_leaves_summary_verify_none() {
         let pool = Pool::sqlite_in_memory().await.unwrap();
@@ -944,9 +920,8 @@ COPY public.t (id, x) FROM stdin;
         );
     }
 
-    /// On_conflict=DoNothing with pre-existing duplicate rows in the
-    /// target: L2 surfaces the gap as `RowsConflictedAtTarget(N)` rather
-    /// than `MissingTarget(N)`. Pins the per-OnConflict verdict shape.
+    /// DoNothing + pre-existing duplicates → RowsConflictedAtTarget(N),
+    /// not MissingTarget(N).
     #[tokio::test]
     async fn run_migrate_verify_count_classifies_pk_conflicts_under_skip() {
         let pool = Pool::sqlite_in_memory().await.unwrap();
@@ -977,9 +952,7 @@ COPY public.t (id, x) FROM stdin;
             .verify
             .as_ref()
             .expect("verify must be Some under verify=Count");
-        // 3 rows submitted; 2 conflicted at target; only 1 new row landed.
-        // records_loaded counts the statement as successful (3) but
-        // target_delta is 1, so shortfall = 2.
+        // 3 submitted, 2 conflicted, 1 landed → shortfall = 2.
         assert_eq!(v.records_loaded, 3);
         assert_eq!(v.target_pre_count, Some(2));
         assert_eq!(v.target_post_count, Some(3));
@@ -991,11 +964,8 @@ COPY public.t (id, x) FROM stdin;
         );
     }
 
-    /// Symmetric to above but under `OnConflict::Error`: a duplicate row
-    /// makes the load FAIL outright (records_failed > 0), not silently
-    /// missing-target. The orchestrator halts on the first failed table,
-    /// so we don't reach the verify path under Error+conflict; this test
-    /// pins that the failure surfaces normally.
+    /// OnConflict::Error + duplicate → records_failed > 0 (not a verify
+    /// shortfall). Orchestrator halts before the next table.
     #[tokio::test]
     async fn run_migrate_verify_count_under_error_with_conflict_halts() {
         let pool = Pool::sqlite_in_memory().await.unwrap();
@@ -1025,9 +995,8 @@ COPY public.t (id, x) FROM stdin;
         );
     }
 
-    /// Symmetric to unfixable_does_not_build_pool with verify=Count
-    /// requested: when transform_ddl surfaces unfixable, no tables load
-    /// and no verify outcomes get built.
+    /// verify=Count + unfixable: short-circuit still wins, no tables
+    /// load and no verify outcomes are built.
     #[tokio::test]
     async fn run_migrate_verify_unfixable_short_circuits_no_verify_outcome() {
         let pool = Pool::sqlite_in_memory().await.unwrap();
@@ -1048,17 +1017,13 @@ COPY public.events (id) FROM stdin;
         );
     }
 
-    /// A crafted pg_dump COPY header carrying an embedded `"` in the
-    /// table identifier must be rejected before any pool query, DDL
-    /// apply, or per-table println — the dump is a second untrusted
-    /// input alongside CLI args, and `count(*)` SQL plus operator
-    /// stdout are both downstream of `block.table`.
+    /// Embedded `"` in a dump-parsed table identifier is rejected
+    /// before any pool query or DDL apply.
     #[tokio::test]
     async fn run_migrate_rejects_dump_identifiers_with_embedded_quote() {
         let pool = Pool::sqlite_in_memory().await.unwrap();
-        // The embedded `""` decodes via `read_identifier` to a single
-        // `"` inside the identifier. Without validation this lands in
-        // `format!("\"{name}\"")` and corrupts the SQL.
+        // `""` decodes to a single `"` in the identifier — would
+        // corrupt `format!("\"{name}\"")` if validation is skipped.
         let dump = "\
 COPY public.\"evil\"\"name\" (id) FROM stdin;
 1

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -116,8 +116,9 @@ pub struct LoadArgs {
     // Conflict resolution strategy
     pub on_conflict: OnConflict,
 
-    /// L2 toggle. L1 always runs when the format gives an exact source
-    /// count. CLI default: `load`=Off, `migrate`=Count.
+    /// L2 toggle. Source-row counting runs parser-side regardless;
+    /// `Count` adds pre/post `count(*)` and a per-table verdict. CLI
+    /// default: `load`=Off, `migrate`=Count.
     pub verify: VerifyMode,
 
     // Columns to exclude from INSERT statements (DB applies DEFAULT values)
@@ -248,25 +249,19 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
         } else {
             None
         };
-        let verdict = crate::verify::classify(crate::verify::VerifyInputs {
-            mode: verify_mode,
-            on_conflict,
-            source_rows: result.source_rows,
-            records_loaded: result.records_loaded,
-            records_failed: result.records_failed,
-            target_pre_count,
-            target_post_count,
-        });
-        result.verify = Some(VerifyOutcome {
+        result.verify = Some(VerifyOutcome::from_inputs(
             schema,
-            table: target_table,
-            source_rows: result.source_rows,
-            records_loaded: result.records_loaded,
-            records_failed: result.records_failed,
-            target_pre_count,
-            target_post_count,
-            verdict,
-        });
+            target_table,
+            crate::verify::VerifyInputs {
+                mode: verify_mode,
+                on_conflict,
+                source_rows: result.source_rows,
+                records_loaded: result.records_loaded,
+                records_failed: result.records_failed,
+                target_pre_count,
+                target_post_count,
+            },
+        ));
     }
 
     Ok(result)

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -214,11 +214,13 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     validate_load_args(&args)?;
     let pool = build_pool(&args).await?;
 
-    // L2 needs a stable pre/post pair. `--if-not-exists` may create the
-    // table mid-load, so a pre-count would either error (table missing)
-    // or mis-classify a re-run against a populated target as
-    // `ExtraTarget`. Skip L2 in that case; L1 still runs via classify().
-    let l2_runs = args.verify == VerifyMode::Count && !args.create_table_if_missing;
+    // L2 needs a stable pre/post pair AND an exact source count to be
+    // meaningful. Skip on `--if-not-exists` (table may not exist yet, and a
+    // re-run would mis-classify as ExtraTarget) and on csv/tsv (classify()
+    // short-circuits to SkippedNoExactSourceCount, wasting two count(*)).
+    let l2_runs = args.verify == VerifyMode::Count
+        && !args.create_table_if_missing
+        && matches!(args.format, Format::PgDump | Format::Parquet);
     let target_pre_count = if l2_runs {
         Some(
             crate::verify::count_table_rows(&pool, &args.schema, &args.target_table)
@@ -270,11 +272,7 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     Ok(result)
 }
 
-/// Build the connection pool from `args`, with the `#[cfg(test)] test_pool`
-/// shortcut applied first so SQLite-backed tests skip the IAM path. Pulled
-/// out of [`run_load`] so the body of `run_load` becomes "build pool, hand
-/// off to `run_load_with_pool`" — the migrate orchestrator drives
-/// `run_load_with_pool` directly with its own already-built pool.
+/// Build the connection pool. Honors `args.test_pool` in `#[cfg(test)]`.
 async fn build_pool(args: &LoadArgs) -> Result<crate::db::Pool> {
     #[cfg(test)]
     if let Some(test_pool) = args.test_pool.clone() {
@@ -313,9 +311,14 @@ pub(crate) async fn run_load_with_pool(
     let reader_factory = ReaderFactory::new(&aws_config);
     let (file_reader, pgdump_columns) = match args.format {
         Format::PgDump => {
-            reader_factory
+            let (reader, columns) = reader_factory
                 .create_pgdump_reader(&parsed_uri, &args.schema, &args.target_table)
-                .await?
+                .await?;
+            // Symmetric to migrate's per-block validation — guards INSERT SQL.
+            for col in &columns {
+                validate_pgdump_identifier("column", col)?;
+            }
+            (reader, columns)
         }
         _ => {
             let reader = reader_factory

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -116,12 +116,8 @@ pub struct LoadArgs {
     // Conflict resolution strategy
     pub on_conflict: OnConflict,
 
-    /// Post-load verification mode (L2 target `count(*)`). L1 source-row
-    /// cross-check always runs when the format provides exact source rows
-    /// (pgdump, parquet); `Off` only suppresses L2.
-    /// Default per-entry-point: `migrate` runs `Count`; plain `load` runs
-    /// `Off` (the operator opts in via `--verify=count` to absorb the
-    /// `count(*)` cost on a pre-existing target).
+    /// L2 toggle. L1 always runs when the format gives an exact source
+    /// count. CLI default: `load`=Off, `migrate`=Count.
     pub verify: VerifyMode,
 
     // Columns to exclude from INSERT statements (DB applies DEFAULT values)
@@ -151,16 +147,12 @@ pub struct LoadResult {
     pub records_failed: u64,
     /// Estimated row count from file size (for mismatch detection)
     pub estimated_rows: Option<u64>,
-    /// Exact source-row count summed across chunks. `Some` for pgdump and
-    /// parquet (parser-independent counts); `None` for csv/tsv
-    /// (quote-aware exact counting not yet implemented).
+    /// Exact source-row count summed across chunks. `Some` for pgdump
+    /// and parquet; `None` for csv/tsv.
     pub source_rows: Option<u64>,
-    /// Verdict from the count-level verification layer for the
-    /// [`run_load`] entry point — `Some` when `--verify=count`, `None`
-    /// when `--verify=off`. The migrate orchestrator builds its own
-    /// per-table [`VerifyOutcome`] on `TableLoadSummary.verify` and
-    /// leaves this field `None` on the per-block `LoadResult` it
-    /// consumes internally.
+    /// `Some` under `--verify=count` on the `run_load` path. Migrate
+    /// builds its own outcome on `TableLoadSummary.verify` and leaves
+    /// this `None`.
     pub verify: Option<VerifyOutcome>,
     pub duration: Duration,
     /// Path to persisted manifest directory (if errors occurred and temp dir was used)
@@ -206,10 +198,6 @@ pub struct LoadResult {
 ///     delimiter: None,
 ///     quote: None,
 ///     escape: None,
-///     // The CSV in this example has a header row that names the destination
-///     // columns. With `create_table_if_missing: true`, leaving this as `None`
-///     // would name columns from row 1's data values (the new 3.0 default
-///     // treats every row as data). Set explicitly when loading a header-bearing file.
 ///     has_header: Some(true),
 ///     exclude_columns: Vec::new(),
 /// };
@@ -226,15 +214,10 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     validate_load_args(&args)?;
     let pool = build_pool(&args).await?;
 
-    // Capture the target pre-count BEFORE the load when L2 verify is on.
-    // L2 needs a stable pre/post comparison, but `--if-not-exists` lets
-    // the loader create the table mid-load; counting before creation
-    // would error, and assuming the table is fresh would mis-classify a
-    // re-run against an already-populated table as `ExtraTarget`. So
-    // when `--if-not-exists` is set we skip L2 entirely (`None` pre/post)
-    // and fall through to L1-only verdict via classify(). The operator
-    // still gets `LoaderDropped`/`Match` but loses target-side coverage —
-    // documented on the `--verify` flag in main.rs.
+    // L2 needs a stable pre/post pair. `--if-not-exists` may create the
+    // table mid-load, so a pre-count would either error (table missing)
+    // or mis-classify a re-run against a populated target as
+    // `ExtraTarget`. Skip L2 in that case; L1 still runs via classify().
     let l2_runs = args.verify == VerifyMode::Count && !args.create_table_if_missing;
     let target_pre_count = if l2_runs {
         Some(
@@ -459,12 +442,8 @@ async fn run_load_with_pool_and_reader(
         None
     };
 
-    // L2 verify (target pre/post counts) is the orchestrator's job — it
-    // runs the `count(*)` queries because it owns the per-table loop and
-    // can choose which tables to verify. `run_load_with_pool_and_reader`
-    // ships only the L1 inputs (`source_rows`); the orchestrator builds
-    // the `VerifyOutcome` later when it has the full picture, or skips
-    // verification entirely on the plain-load path with `--verify=off`.
+    // L1 inputs only — callers (run_load / migrate orchestrator) own
+    // L2 and the final VerifyOutcome.
     Ok(LoadResult {
         job_id: result.job_id,
         chunks_processed: result.chunks_processed,
@@ -523,12 +502,10 @@ fn validate_load_args(args: &LoadArgs) -> Result<()> {
     Ok(())
 }
 
-/// Reject SQL-identifier inputs (`--schema`, `--table`) that would break
-/// downstream identifier quoting. `Pool::qualified_table_name` interpolates
-/// the value into `format!("\"{}\"", …)` without escape-doubling embedded
-/// quotes, and the worker's INSERT generation does the same with column
-/// names. Rejecting embedded `"` and control bytes here closes the otherwise
-/// open path from CLI args into raw SQL.
+/// Reject CLI identifiers that would break SQL identifier quoting.
+/// `Pool::qualified_table_name` wraps the value in `"…"` without
+/// escape-doubling, so embedded `"` / control bytes / bidi-format
+/// codepoints are blocked here.
 fn validate_identifier(field: &'static str, value: &str) -> Result<()> {
     if value.is_empty() {
         anyhow::bail!("--{field} must not be empty");
@@ -544,13 +521,9 @@ fn validate_identifier(field: &'static str, value: &str) -> Result<()> {
     Ok(())
 }
 
-/// Reject SQL identifiers parsed out of an untrusted pg_dump file — the
-/// dump is a second untrusted input alongside CLI args. `block.schema` /
-/// `block.table` / `block.columns` from `list_copy_blocks` flow into the
-/// `count(*)` query, worker INSERTs, and operator stdout via the migrate
-/// summary; without this guard a crafted COPY header could smuggle SQL
-/// fragments, control bytes, or bidi codepoints. Reuses the same
-/// allowlist as the CLI surface; only the error wording differs.
+/// Same allowlist as `validate_identifier` but applied to identifiers
+/// parsed out of the dump (block.schema/table/columns). Distinct error
+/// wording so the operator knows the dump is at fault, not their CLI.
 pub(crate) fn validate_pgdump_identifier(field: &'static str, value: &str) -> Result<()> {
     if value.is_empty() {
         anyhow::bail!("pg_dump {field} identifier must not be empty");
@@ -567,14 +540,9 @@ pub(crate) fn validate_pgdump_identifier(field: &'static str, value: &str) -> Re
     Ok(())
 }
 
-/// Unicode bidi-control and zero-width / format codepoints that visually
-/// reorder or hide surrounding text in a terminal — RLM, LRM, RTL/LTR
-/// overrides, ZWSP/ZWNJ/ZWJ, BOM/ZWNBSP, line/paragraph separators, bidi
-/// isolates. A deceptive identifier carrying any of these would confuse an
-/// operator reading load logs even though it cannot escape SQL quoting.
-///
-/// Shared between `validate_identifier` (CLI `--schema` / `--table` inputs)
-/// and `main::is_unsafe_for_listing` (the `list-tables` TSV output guard).
+/// Unicode bidi/zero-width/format codepoints that visually reorder or
+/// hide surrounding text in a terminal. Shared between identifier
+/// validation and the `list-tables` TSV output guard.
 pub fn is_bidi_or_format_char(c: char) -> bool {
     matches!(
         c,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -16,6 +16,11 @@ pub use crate::migrate::{
     TableLoadSummary, run_migrate,
 };
 
+// Re-export the verification surface — `VerifyMode` is set by the CLI on
+// `LoadArgs`, and `VerifyOutcome` / `VerifyVerdict` ship as fields of
+// `LoadResult` and `TableLoadSummary`.
+pub use crate::verify::{VerifyMode, VerifyOutcome, VerifyVerdict};
+
 use anyhow::{Context, Result};
 use aws_config::{BehaviorVersion, Region};
 use std::collections::HashMap;
@@ -111,6 +116,14 @@ pub struct LoadArgs {
     // Conflict resolution strategy
     pub on_conflict: OnConflict,
 
+    /// Post-load verification mode (L2 target `count(*)`). L1 source-row
+    /// cross-check always runs when the format provides exact source rows
+    /// (pgdump, parquet); `Off` only suppresses L2.
+    /// Default per-entry-point: `migrate` runs `Count`; plain `load` runs
+    /// `Off` (the operator opts in via `--verify=count` to absorb the
+    /// `count(*)` cost on a pre-existing target).
+    pub verify: VerifyMode,
+
     // Columns to exclude from INSERT statements (DB applies DEFAULT values)
     pub exclude_columns: Vec<String>,
 
@@ -138,6 +151,16 @@ pub struct LoadResult {
     pub records_failed: u64,
     /// Estimated row count from file size (for mismatch detection)
     pub estimated_rows: Option<u64>,
+    /// Exact source-row count summed across chunks. `Some` for pgdump and
+    /// parquet (parser-independent counts); `None` for csv/tsv (no exact
+    /// count in v1 — the v2 sample-hash work covers the gap).
+    pub source_rows: Option<u64>,
+    /// Verdict from the count-level verification layer. `None` when verify
+    /// mode is `Off` AND the load wasn't routed through an entry point that
+    /// always builds a verdict (today: only the migrate orchestrator runs
+    /// verify automatically). When present, `verdict` holds the most
+    /// actionable signal — see [`VerifyVerdict`].
+    pub verify: Option<VerifyOutcome>,
     pub duration: Duration,
     /// Path to persisted manifest directory (if errors occurred and temp dir was used)
     pub persisted_manifest_dir: Option<PathBuf>,
@@ -155,7 +178,7 @@ pub struct LoadResult {
 /// # Example
 ///
 /// ```no_run
-/// use aurora_dsql_loader::runner::{LoadArgs, Format, OnConflict, run_load};
+/// use aurora_dsql_loader::runner::{LoadArgs, Format, OnConflict, VerifyMode, run_load};
 /// use std::collections::HashMap;
 ///
 /// # async fn example() -> anyhow::Result<()> {
@@ -178,6 +201,7 @@ pub struct LoadResult {
 ///     debug: false,
 ///     resume_job_id: None,
 ///     on_conflict: OnConflict::DoNothing,
+///     verify: VerifyMode::Off,
 ///     delimiter: None,
 ///     quote: None,
 ///     escape: None,
@@ -200,7 +224,62 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     // who skip `run_load` still get the same checks.
     validate_load_args(&args)?;
     let pool = build_pool(&args).await?;
-    run_load_with_pool(pool, args).await
+
+    // Capture the target pre-count BEFORE the load when L2 verify is on.
+    // With `--if-not-exists`, the table might not be created yet — in
+    // that case the run_load path will create it inside
+    // `run_load_with_pool` and the pre-count is 0 by construction.
+    // Without `--if-not-exists`, the table must already exist and we
+    // propagate any count failure.
+    let target_pre_count = if args.verify == VerifyMode::Count {
+        if args.create_table_if_missing {
+            Some(0)
+        } else {
+            Some(
+                crate::verify::count_table_rows(&pool, &args.schema, &args.target_table)
+                    .await
+                    .context("verify=count: failed to read target pre-count")?,
+            )
+        }
+    } else {
+        None
+    };
+
+    let schema = args.schema.clone();
+    let target_table = args.target_table.clone();
+    let on_conflict = args.on_conflict;
+    let verify_mode = args.verify;
+
+    let mut result = run_load_with_pool(pool.clone(), args).await?;
+
+    if verify_mode == VerifyMode::Count {
+        let target_post_count = Some(
+            crate::verify::count_table_rows(&pool, &schema, &target_table)
+                .await
+                .context("verify=count: failed to read target post-count")?,
+        );
+        let verdict = crate::verify::classify(crate::verify::VerifyInputs {
+            mode: verify_mode,
+            on_conflict,
+            source_rows: result.source_rows,
+            records_loaded: result.records_loaded,
+            records_failed: result.records_failed,
+            target_pre_count,
+            target_post_count,
+        });
+        result.verify = Some(VerifyOutcome {
+            schema,
+            table: target_table,
+            source_rows: result.source_rows,
+            records_loaded: result.records_loaded,
+            records_failed: result.records_failed,
+            target_pre_count,
+            target_post_count,
+            verdict,
+        });
+    }
+
+    Ok(result)
 }
 
 /// Build the connection pool from `args`, with the `#[cfg(test)] test_pool`
@@ -375,12 +454,20 @@ async fn run_load_with_pool_and_reader(
         None
     };
 
+    // L2 verify (target pre/post counts) is the orchestrator's job — it
+    // runs the `count(*)` queries because it owns the per-table loop and
+    // can choose which tables to verify. `run_load_with_pool_and_reader`
+    // ships only the L1 inputs (`source_rows`); the orchestrator builds
+    // the `VerifyOutcome` later when it has the full picture, or skips
+    // verification entirely on the plain-load path with `--verify=off`.
     Ok(LoadResult {
         job_id: result.job_id,
         chunks_processed: result.chunks_processed,
         records_loaded: result.records_loaded,
         records_failed: result.records_failed,
         estimated_rows: result.estimated_rows,
+        source_rows: result.source_rows,
+        verify: None,
         duration: result.duration,
         persisted_manifest_dir,
     })
@@ -679,6 +766,7 @@ mod tests {
             column_mappings: Default::default(),
             resume_job_id: None,
             on_conflict: OnConflict::DoNothing,
+            verify: VerifyMode::Off,
             exclude_columns: Vec::new(),
             delimiter: None,
             quote: None,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -19,7 +19,7 @@ pub use crate::migrate::{
 // Re-export the verification surface — `VerifyMode` is set by the CLI on
 // `LoadArgs`, and `VerifyOutcome` / `VerifyVerdict` ship as fields of
 // `LoadResult` and `TableLoadSummary`.
-pub use crate::verify::{VerifyMode, VerifyOutcome, VerifyVerdict};
+pub use crate::verify::{L2Counts, VerifyMode, VerifyOutcome, VerifyVerdict};
 
 use anyhow::{Context, Result};
 use aws_config::{BehaviorVersion, Region};
@@ -223,7 +223,7 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     let l2_runs = args.verify == VerifyMode::Count
         && !args.create_table_if_missing
         && matches!(args.format, Format::PgDump | Format::Parquet);
-    let target_pre_count = if l2_runs {
+    let target_pre = if l2_runs {
         Some(
             verify::count_table_rows(&pool, &args.schema, &args.target_table)
                 .await
@@ -233,6 +233,16 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
         None
     };
 
+    if args.verify == VerifyMode::Count && !l2_runs {
+        // Operator opted into count(*) but the gating conditions skipped
+        // L2; surface that instead of silently returning Match.
+        tracing::info!(
+            schema = %args.schema,
+            table = %args.target_table,
+            "verify=count: L2 skipped (--if-not-exists or csv/tsv); L1 only"
+        );
+    }
+
     let schema = args.schema.clone();
     let target_table = args.target_table.clone();
     let on_conflict = args.on_conflict;
@@ -241,7 +251,7 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     let mut result = run_load_with_pool(pool.clone(), args).await?;
 
     if verify_mode == VerifyMode::Count {
-        let target_post_count = if l2_runs {
+        let target_post = if l2_runs {
             Some(
                 verify::count_table_rows(&pool, &schema, &target_table)
                     .await
@@ -250,6 +260,9 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
         } else {
             None
         };
+        let target_counts = target_pre
+            .zip(target_post)
+            .map(|(pre, post)| L2Counts { pre, post });
         result.verify = Some(VerifyOutcome::from_inputs(
             schema,
             target_table,
@@ -259,8 +272,7 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
                 source_rows: result.source_rows,
                 records_loaded: result.records_loaded,
                 records_failed: result.records_failed,
-                target_pre_count,
-                target_post_count,
+                target_counts,
             },
         ));
     }
@@ -348,6 +360,8 @@ pub(crate) async fn run_load_with_pool_for_pgdump_block(
     aws_config: Option<&aws_config::SdkConfig>,
 ) -> Result<LoadResult> {
     validate_load_args(&args)?;
+    debug_assert_eq!(args.target_table, block.table);
+    debug_assert_eq!(args.schema, block.schema);
 
     let delimited_config = maybe_delimited_config(&args);
     let parsed_uri = SourceUri::parse(&args.source_uri)?;
@@ -498,13 +512,24 @@ fn validate_load_args(args: &LoadArgs) -> Result<()> {
             );
         }
     }
+
+    // verify=count's L2 needs target_pre sampled at the start of the
+    // load; on resume the manifest already holds rows from the original
+    // run, so post-pre would be < records_loaded and classify produces a
+    // false MissingTarget/RowsConflictedAtTarget.
+    if args.resume_job_id.is_some() && args.verify == VerifyMode::Count {
+        anyhow::bail!(
+            "--verify=count cannot be combined with --resume-job-id: pre-count \
+             would not include rows from the original run. Re-run with --verify=off."
+        );
+    }
     Ok(())
 }
 
-/// Reject CLI identifiers that would break SQL identifier quoting.
-/// `Pool::qualified_table_name` wraps the value in `"…"` without
-/// escape-doubling, so embedded `"` / control bytes / bidi-format
-/// codepoints are blocked here.
+/// Reject CLI identifiers that would break SQL identifier quoting or
+/// deceive an operator reading logs. `Pool::qualified_table_name`
+/// escape-doubles `"` defensively, but control bytes and bidi/format
+/// codepoints are blocked here so they never reach SQL or terminals.
 fn validate_identifier(field: &'static str, value: &str) -> Result<()> {
     if value.is_empty() {
         anyhow::bail!("--{field} must not be empty");
@@ -705,6 +730,19 @@ mod tests {
         args.create_table_if_missing = true;
         let err = validate_load_args(&args).unwrap_err().to_string();
         assert!(err.contains("create_table_if_missing"), "{err}");
+    }
+
+    /// Resume + verify=count would mis-classify: pre-count is sampled
+    /// at resume start but records_loaded sums the entire manifest, so
+    /// post − pre < records_loaded → false MissingTarget.
+    #[test]
+    fn resume_with_verify_count_is_rejected_at_validation() {
+        let mut args = sample_pgdump_args();
+        args.resume_job_id = Some("abc-123".into());
+        args.verify = VerifyMode::Count;
+        let err = validate_load_args(&args).unwrap_err().to_string();
+        assert!(err.contains("--verify=count"), "{err}");
+        assert!(err.contains("--resume-job-id"), "{err}");
     }
 
     #[tokio::test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -36,6 +36,7 @@ use crate::db::{self as db_pool, SchemaInferrer};
 use crate::formats::pgdump::{CopyBlock, PgDumpReader, list_copy_blocks};
 use crate::formats::{DelimitedConfig, ReaderFactory};
 use crate::io::{LocalFileByteReader, S3ByteReader, SourceUri};
+use crate::verify::{self, VerifyInputs};
 
 /// File format for the source data
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -224,7 +225,7 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
         && matches!(args.format, Format::PgDump | Format::Parquet);
     let target_pre_count = if l2_runs {
         Some(
-            crate::verify::count_table_rows(&pool, &args.schema, &args.target_table)
+            verify::count_table_rows(&pool, &args.schema, &args.target_table)
                 .await
                 .context("verify=count: failed to read target pre-count")?,
         )
@@ -242,7 +243,7 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     if verify_mode == VerifyMode::Count {
         let target_post_count = if l2_runs {
             Some(
-                crate::verify::count_table_rows(&pool, &schema, &target_table)
+                verify::count_table_rows(&pool, &schema, &target_table)
                     .await
                     .context("verify=count: failed to read target post-count")?,
             )
@@ -252,7 +253,7 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
         result.verify = Some(VerifyOutcome::from_inputs(
             schema,
             target_table,
-            crate::verify::VerifyInputs {
+            VerifyInputs {
                 mode: verify_mode,
                 on_conflict,
                 source_rows: result.source_rows,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -155,11 +155,12 @@ pub struct LoadResult {
     /// parquet (parser-independent counts); `None` for csv/tsv (no exact
     /// count in v1 — the v2 sample-hash work covers the gap).
     pub source_rows: Option<u64>,
-    /// Verdict from the count-level verification layer. `None` when verify
-    /// mode is `Off` AND the load wasn't routed through an entry point that
-    /// always builds a verdict (today: only the migrate orchestrator runs
-    /// verify automatically). When present, `verdict` holds the most
-    /// actionable signal — see [`VerifyVerdict`].
+    /// Verdict from the count-level verification layer for the
+    /// [`run_load`] entry point — `Some` when `--verify=count`, `None`
+    /// when `--verify=off`. The migrate orchestrator builds its own
+    /// per-table [`VerifyOutcome`] on `TableLoadSummary.verify` and
+    /// leaves this field `None` on the per-block `LoadResult` it
+    /// consumes internally.
     pub verify: Option<VerifyOutcome>,
     pub duration: Duration,
     /// Path to persisted manifest directory (if errors occurred and temp dir was used)
@@ -226,21 +227,21 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     let pool = build_pool(&args).await?;
 
     // Capture the target pre-count BEFORE the load when L2 verify is on.
-    // With `--if-not-exists`, the table might not be created yet — in
-    // that case the run_load path will create it inside
-    // `run_load_with_pool` and the pre-count is 0 by construction.
-    // Without `--if-not-exists`, the table must already exist and we
-    // propagate any count failure.
-    let target_pre_count = if args.verify == VerifyMode::Count {
-        if args.create_table_if_missing {
-            Some(0)
-        } else {
-            Some(
-                crate::verify::count_table_rows(&pool, &args.schema, &args.target_table)
-                    .await
-                    .context("verify=count: failed to read target pre-count")?,
-            )
-        }
+    // L2 needs a stable pre/post comparison, but `--if-not-exists` lets
+    // the loader create the table mid-load; counting before creation
+    // would error, and assuming the table is fresh would mis-classify a
+    // re-run against an already-populated table as `ExtraTarget`. So
+    // when `--if-not-exists` is set we skip L2 entirely (`None` pre/post)
+    // and fall through to L1-only verdict via classify(). The operator
+    // still gets `LoaderDropped`/`Match` but loses target-side coverage —
+    // documented on the `--verify` flag in main.rs.
+    let l2_runs = args.verify == VerifyMode::Count && !args.create_table_if_missing;
+    let target_pre_count = if l2_runs {
+        Some(
+            crate::verify::count_table_rows(&pool, &args.schema, &args.target_table)
+                .await
+                .context("verify=count: failed to read target pre-count")?,
+        )
     } else {
         None
     };
@@ -253,11 +254,15 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     let mut result = run_load_with_pool(pool.clone(), args).await?;
 
     if verify_mode == VerifyMode::Count {
-        let target_post_count = Some(
-            crate::verify::count_table_rows(&pool, &schema, &target_table)
-                .await
-                .context("verify=count: failed to read target post-count")?,
-        );
+        let target_post_count = if l2_runs {
+            Some(
+                crate::verify::count_table_rows(&pool, &schema, &target_table)
+                    .await
+                    .context("verify=count: failed to read target post-count")?,
+            )
+        } else {
+            None
+        };
         let verdict = crate::verify::classify(crate::verify::VerifyInputs {
             mode: verify_mode,
             on_conflict,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -152,8 +152,8 @@ pub struct LoadResult {
     /// Estimated row count from file size (for mismatch detection)
     pub estimated_rows: Option<u64>,
     /// Exact source-row count summed across chunks. `Some` for pgdump and
-    /// parquet (parser-independent counts); `None` for csv/tsv (no exact
-    /// count in v1 — the v2 sample-hash work covers the gap).
+    /// parquet (parser-independent counts); `None` for csv/tsv
+    /// (quote-aware exact counting not yet implemented).
     pub source_rows: Option<u64>,
     /// Verdict from the count-level verification layer for the
     /// [`run_load`] entry point — `Some` when `--verify=count`, `None`
@@ -539,6 +539,29 @@ fn validate_identifier(field: &'static str, value: &str) -> Result<()> {
              backslash, double-quote, or Unicode bidi/format codepoint) that would \
              corrupt SQL identifier quoting or visually deceive an operator reading \
              logs. Rename the table or use a quoted identifier in your DB instead."
+        );
+    }
+    Ok(())
+}
+
+/// Reject SQL identifiers parsed out of an untrusted pg_dump file — the
+/// dump is a second untrusted input alongside CLI args. `block.schema` /
+/// `block.table` / `block.columns` from `list_copy_blocks` flow into the
+/// `count(*)` query, worker INSERTs, and operator stdout via the migrate
+/// summary; without this guard a crafted COPY header could smuggle SQL
+/// fragments, control bytes, or bidi codepoints. Reuses the same
+/// allowlist as the CLI surface; only the error wording differs.
+pub(crate) fn validate_pgdump_identifier(field: &'static str, value: &str) -> Result<()> {
+    if value.is_empty() {
+        anyhow::bail!("pg_dump {field} identifier must not be empty");
+    }
+    if value.chars().any(is_unsafe_identifier_char) {
+        anyhow::bail!(
+            "pg_dump {field} identifier {value:?} contains an unsafe character \
+             (control byte, backslash, double-quote, or Unicode bidi/format \
+             codepoint) that would corrupt SQL identifier quoting or visually \
+             deceive an operator reading logs. Edit the dump to rename the \
+             offending identifier."
         );
     }
     Ok(())

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,48 +1,27 @@
-//! Loader verification: count-level cross-checks on completed loads.
+//! Count-level load verification.
 //!
-//! Two layers, both in [`VerifyOutcome`]:
+//! - **L1**: source `source_rows` vs `loaded + failed`. Catches drops
+//!   between source bytes and the DB layer (parser/chunker bugs).
+//! - **L2**: target `post - pre` vs `loaded`. Catches drops between
+//!   INSERT and table contents. Shortfall is `MissingTarget` under
+//!   `Error`, `RowsConflictedAtTarget` under `Skip`/`Update`.
 //!
-//! - **L1 — source vs loader.** Compares the parser-independent
-//!   `source_rows` count (pgdump `\n` byte tally; parquet footer total) to
-//!   `records_loaded + records_failed`. Catches drops between the source
-//!   bytes and the DB-input layer (parser regressions, chunk-data
-//!   mis-handling, lost record vector pushes). Naturally `ON CONFLICT`-aware
-//!   — neither side moves when conflict resolution skips a row.
-//!
-//! - **L2 — loader vs target.** Compares `target_delta = post_count -
-//!   pre_count` against `records_loaded`. Catches drops between INSERT
-//!   submission and the table contents. Verdict shape depends on
-//!   [`OnConflict`]: under `Error` a shortfall is `MissingTarget` (real bug);
-//!   under `Skip`/`Update` it's `RowsConflictedAtTarget` (informational —
-//!   conflict resolution discarded N rows).
-//!
-//! Out of scope: value-level fidelity (column-swap bugs, `\N`-vs-`""`
-//! mistranslation, encoding mishandling, type coercion). A count match
-//! proves completeness, not fidelity.
+//! Counts only — no value-level fidelity check.
 
 use crate::coordination::manifest::OnConflict;
 use crate::db::Pool;
 use anyhow::{Context, Result};
 
-/// Whether to run L2 (target pre/post `count(*)`). L1 always runs when
-/// `LoadResult.source_rows == Some` regardless of mode — its cost is
-/// negligible (the source-row tally is computed during parsing) and its
-/// signal is high.
+/// L2 toggle. L1 always runs when `source_rows` is exact (cost: free,
+/// computed during parsing).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum VerifyMode {
-    /// L2 is off. L1 still runs when source rows are exact.
     #[default]
     Off,
-    /// L2 is on: pre/post `count(*)` per loaded table.
-    ///
-    /// **Sole-writer assumption.** L2 compares `target_post -
-    /// target_pre` against `records_loaded`. If anyone else writes to
-    /// the same target table between pre-count and post-count the
-    /// verdict reflects the combined delta — concurrent inserts surface
-    /// as `ExtraTarget`, concurrent deletes as `MissingTarget`. The
-    /// operator owns ensuring no other writer touches the target during
-    /// the load window. `migrate` against a fresh cluster satisfies
-    /// this by construction.
+    /// Pre/post `count(*)` per loaded table. Assumes the load is the
+    /// sole writer to the target during the load window — concurrent
+    /// writes surface as `ExtraTarget` (insert) or `MissingTarget`
+    /// (delete). `migrate` against a fresh cluster satisfies this.
     Count,
 }
 
@@ -75,57 +54,36 @@ impl std::fmt::Display for VerifyMode {
 pub struct VerifyOutcome {
     pub schema: String,
     pub table: String,
-    /// Mirrored from `LoadResult.source_rows`. `None` for csv/tsv (no
-    /// exact source-row count) — short-circuits L1 to
-    /// [`VerifyVerdict::SkippedNoExactSourceCount`].
+    /// `None` for csv/tsv — L1 short-circuits to `SkippedNoExactSourceCount`.
     pub source_rows: Option<u64>,
     pub records_loaded: u64,
     pub records_failed: u64,
-    /// Target row count immediately before the load. `None` when L2 was not
-    /// run (verify mode `Off`).
+    /// Both `Some` when L2 ran, both `None` otherwise.
     pub target_pre_count: Option<u64>,
-    /// Target row count immediately after the load. `None` when L2 was not
-    /// run.
     pub target_post_count: Option<u64>,
     pub verdict: VerifyVerdict,
 }
 
-/// Single verdict per table, summarising both L1 and L2 with the most
-/// actionable signal first. The verdict variant captures the magnitude
-/// (`u64` payload) so callers don't need to recompute deltas from the raw
-/// counts.
+/// Most actionable verdict per table; payload is the magnitude.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VerifyVerdict {
-    /// Both layers cleared. L1: `source_rows == loaded + failed`. When L2
-    /// ran: `target_delta == records_loaded` (or `≤` under non-Error
-    /// `OnConflict` modes — see [`RowsConflictedAtTarget`]).
+    /// L1 clean, and L2 (if run) clean.
     Match,
-    /// L1: `source_rows > loaded + failed`. Rows entered the chunk buffer
-    /// and disappeared before reaching the DB layer — parser regression or
-    /// chunk-data mis-handling. Payload is `source_rows - (loaded + failed)`.
+    /// L1 shortfall: rows lost between source bytes and the DB layer.
     LoaderDropped(u64),
-    /// L2 under `OnConflict::Error`: `target_delta < records_loaded`.
-    /// INSERTs reported success but the target row count grew by less than
-    /// the loader claims — a real bug.
+    /// L2 shortfall under `OnConflict::Error` — INSERT reported success
+    /// but target grew by less than `records_loaded`. Real bug.
     MissingTarget(u64),
-    /// L2: `target_delta > records_loaded`. The target gained rows the
-    /// loader did not submit — concurrent writer or duplicate accounting
-    /// bug. Surfaced under all `OnConflict` modes.
+    /// L2 excess: target grew more than `records_loaded`. Concurrent
+    /// writer or duplicate accounting.
     ExtraTarget(u64),
-    /// L2 informational under `OnConflict::Skip`/`DoUpdate`:
-    /// `target_delta < records_loaded`. The shortfall is exactly the
-    /// number of submitted rows that conflict resolution discarded — not a
-    /// bug per se, but the operator should know.
+    /// L2 shortfall under `Skip`/`DoUpdate` — exactly N rows lost to
+    /// conflict resolution. Informational, not a bug.
     RowsConflictedAtTarget(u64),
-    /// `LoadResult.source_rows == None` (csv/tsv). L1 cannot run; L2
-    /// may still have run, but its standalone interpretation is weak
-    /// without L1, so we surface this single verdict and leave
-    /// fine-grained L2 verdicts to the count-bearing formats.
+    /// csv/tsv: no exact source count, so L1 can't run.
     SkippedNoExactSourceCount,
 }
 
-/// Inputs to [`classify`]. Grouped to keep the call site readable when
-/// orchestrator-level code wires the values up.
 #[derive(Debug, Clone, Copy)]
 pub struct VerifyInputs {
     pub mode: VerifyMode,
@@ -133,23 +91,16 @@ pub struct VerifyInputs {
     pub source_rows: Option<u64>,
     pub records_loaded: u64,
     pub records_failed: u64,
-    /// `Some` only when L2 ran. Required to pair with `target_post_count`.
+    /// Both `Some` when L2 ran, both `None` otherwise.
     pub target_pre_count: Option<u64>,
     pub target_post_count: Option<u64>,
 }
 
-/// Pure verdict classifier: takes the count layer's inputs and returns the
-/// most actionable verdict. No I/O, no allocation — the entire verification
-/// surface lives here so it can be exhaustively unit-tested without a DB.
+/// Pure verdict classifier — no I/O, exhaustively unit-tested.
 ///
-/// Decision order:
-/// 1. If `source_rows == None` → [`VerifyVerdict::SkippedNoExactSourceCount`].
-/// 2. L1 cross-check (`source` vs `loaded + failed`): a shortfall is
-///    [`VerifyVerdict::LoaderDropped`] regardless of `OnConflict` (both sides
-///    are insensitive to conflict resolution).
-/// 3. L2 cross-check (only when `mode == Count` AND both pre/post counts
-///    present): see [`VerifyVerdict`] variants for shape per `OnConflict`.
-/// 4. Both clean → [`VerifyVerdict::Match`].
+/// Order: source `None` → `SkippedNoExactSourceCount`; L1 shortfall →
+/// `LoaderDropped`; L2 (if mode=Count and pre/post present) → see
+/// variants; otherwise `Match`.
 pub fn classify(inputs: VerifyInputs) -> VerifyVerdict {
     let Some(source_rows) = inputs.source_rows else {
         return VerifyVerdict::SkippedNoExactSourceCount;
@@ -159,22 +110,16 @@ pub fn classify(inputs: VerifyInputs) -> VerifyVerdict {
     if source_rows > processed {
         return VerifyVerdict::LoaderDropped(source_rows - processed);
     }
-
-    // L1 over-count (`processed > source_rows`) is treated as a Match: it
-    // cannot happen for the formats covered today (pgdump `\n` count is
-    // exact; parquet footer total is exact), and turning it into a verdict
-    // would require a new variant the operator can't act on. If a future
-    // format introduces uncertainty, add a verdict then.
+    // Over-count (processed > source) cannot happen for pgdump or
+    // parquet (counts are exact); collapse to Match. Add a variant when
+    // a future format introduces uncertainty.
 
     if inputs.mode == VerifyMode::Count
         && let (Some(pre), Some(post)) = (inputs.target_pre_count, inputs.target_post_count)
     {
-        // saturating_sub rather than `if post >= pre` so a concurrent
-        // delete on the table during the load doesn't yield a negative
-        // delta and crash the verdict path. The post < pre case still
-        // surfaces — it just gets normalised to a delta of 0 (i.e. nothing
-        // landed), which then maps to a `MissingTarget` / conflict verdict
-        // depending on `on_conflict`.
+        // saturating_sub: a concurrent DELETE (post < pre) normalises to
+        // delta=0 → MissingTarget/RowsConflictedAtTarget, instead of
+        // panicking on underflow.
         let target_delta = post.saturating_sub(pre);
 
         if target_delta > inputs.records_loaded {
@@ -195,12 +140,9 @@ pub fn classify(inputs: VerifyInputs) -> VerifyVerdict {
     VerifyVerdict::Match
 }
 
-/// Run `SELECT COUNT(*) FROM <schema>.<table>` and return the result.
-///
-/// The orchestrator and `run_load` use this both for L2's pre-count (before
-/// the load) and post-count (after the load). Reuses `Pool::qualified_table_name`
-/// so identifier quoting matches what the rest of the loader emits — keeps
-/// SQLite (test) and Postgres (prod) on a single code path.
+/// `SELECT COUNT(*)` for L2 pre/post. Reuses
+/// `Pool::qualified_table_name` so identifier quoting matches the rest
+/// of the loader.
 pub async fn count_table_rows(pool: &Pool, schema: &str, table: &str) -> Result<u64> {
     let qualified = pool.qualified_table_name(schema, table);
     let sql = format!("SELECT COUNT(*) FROM {qualified}");
@@ -212,9 +154,7 @@ pub async fn count_table_rows(pool: &Pool, schema: &str, table: &str) -> Result<
         .first()
         .map(|(c,)| *c)
         .context("count(*) returned no rows")?;
-    // `COUNT(*)` is non-negative on every backend we ship; a negative value
-    // would imply a backend bug worth surfacing rather than silently
-    // wrapping into a u64.
+    // Negative count = backend bug; surface it rather than wrap into u64.
     if count < 0 {
         anyhow::bail!("count(*) on {schema}.{table} returned negative {count}");
     }
@@ -261,7 +201,7 @@ mod tests {
 
     #[test]
     fn l1_drop_under_error_is_loader_dropped() {
-        // source=100, loaded=90, failed=0 → 10 dropped before DB layer.
+        // source > loaded+failed → 10 dropped before DB layer.
         let v = classify(inputs(
             VerifyMode::Count,
             OnConflict::Error,
@@ -276,12 +216,9 @@ mod tests {
 
     #[test]
     fn l1_drop_takes_precedence_over_l2_missing_target() {
-        // Both layers see a problem: L1 sees 10 rows dropped before the
-        // DB layer (source=100 vs loaded=90), L2 sees 10 rows missing
-        // at the target (delta=80 vs loaded=90 under Error). L1 is the
-        // root cause — without it the L2 shortfall has no explanation —
-        // so its verdict wins. A regression that returns `MissingTarget`
-        // here would hide the L1 signal behind a downstream symptom.
+        // L1 short by 10 AND L2 short by 10 — L1 is the root cause and
+        // wins. A regression returning MissingTarget would hide the L1
+        // signal behind a downstream symptom.
         let v = classify(inputs(
             VerifyMode::Count,
             OnConflict::Error,
@@ -296,7 +233,7 @@ mod tests {
 
     #[test]
     fn parse_failures_are_not_drops() {
-        // source=100, loaded=70, failed=30 → 70+30 == 100, no drop.
+        // loaded+failed == source → no L1 drop.
         let v = classify(inputs(
             VerifyMode::Count,
             OnConflict::Error,
@@ -311,7 +248,7 @@ mod tests {
 
     #[test]
     fn l2_shortfall_under_error_is_missing_target() {
-        // L1 clean (source == loaded), L2 short (target_delta < loaded).
+        // L1 clean, L2 short → MissingTarget.
         let v = classify(inputs(
             VerifyMode::Count,
             OnConflict::Error,
@@ -354,8 +291,7 @@ mod tests {
 
     #[test]
     fn l2_excess_is_extra_target_under_all_modes() {
-        // target_delta > records_loaded — concurrent writer or duplicate
-        // accounting. Same verdict regardless of OnConflict.
+        // target_delta > loaded → ExtraTarget regardless of OnConflict.
         for mode in [
             OnConflict::Error,
             OnConflict::DoNothing,
@@ -376,9 +312,7 @@ mod tests {
 
     #[test]
     fn l2_skipped_when_mode_off() {
-        // mode=Off → L2 not consulted even with pre/post present (defensive
-        // — the orchestrator wouldn't supply them in that mode, but the
-        // classifier must not silently use them either).
+        // mode=Off must not consult L2 even if pre/post leak in.
         let v = classify(inputs(
             VerifyMode::Off,
             OnConflict::Error,
@@ -393,8 +327,7 @@ mod tests {
 
     #[test]
     fn l2_skipped_when_pre_post_missing() {
-        // mode=Count but counts unavailable (e.g. count query failed and
-        // we synthesised None) — fall back to L1-only Match.
+        // mode=Count but pre/post are None → fall back to L1-only Match.
         let v = classify(inputs(
             VerifyMode::Count,
             OnConflict::Error,
@@ -409,10 +342,8 @@ mod tests {
 
     #[test]
     fn pre_greater_than_post_does_not_panic() {
-        // Concurrent delete during the load would invert pre/post —
-        // saturating_sub keeps the verdict path safe; it surfaces as
-        // MissingTarget under Error (or RowsConflicted under non-Error)
-        // because target_delta resolves to 0.
+        // Concurrent delete (post < pre): saturating_sub → delta=0 →
+        // MissingTarget under Error. No panic.
         let v = classify(inputs(
             VerifyMode::Count,
             OnConflict::Error,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,0 +1,428 @@
+//! Loader verification: count-level cross-checks on completed loads.
+//!
+//! Two layers, both in [`VerifyOutcome`]:
+//!
+//! - **L1 — source vs loader.** Compares the parser-independent
+//!   `source_rows` count (pgdump `\n` byte tally; parquet footer total) to
+//!   `records_loaded + records_failed`. Catches drops between the source
+//!   bytes and the DB-input layer (parser regressions, chunk-data
+//!   mis-handling, lost record vector pushes). Naturally `ON CONFLICT`-aware
+//!   — neither side moves when conflict resolution skips a row.
+//!
+//! - **L2 — loader vs target.** Compares `target_delta = post_count -
+//!   pre_count` against `records_loaded`. Catches drops between INSERT
+//!   submission and the table contents. Verdict shape depends on
+//!   [`OnConflict`]: under `Error` a shortfall is `MissingTarget` (real bug);
+//!   under `Skip`/`Update` it's `RowsConflictedAtTarget` (informational —
+//!   conflict resolution discarded N rows).
+//!
+//! Out of scope for v1: value-level fidelity (column-swap bugs,
+//! `\N`-vs-`""` mistranslation, encoding mishandling, type coercion). A
+//! count match proves completeness, not fidelity.
+
+use crate::coordination::manifest::OnConflict;
+use crate::db::Pool;
+use anyhow::{Context, Result};
+
+/// Whether to run L2 (target pre/post `count(*)`). L1 always runs when
+/// `LoadResult.source_rows == Some` regardless of mode — its cost is
+/// negligible (the source-row tally is computed during parsing) and its
+/// signal is high.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum VerifyMode {
+    /// L2 is off. L1 still runs when source rows are exact.
+    #[default]
+    Off,
+    /// L2 is on: pre/post `count(*)` per loaded table.
+    Count,
+}
+
+impl std::str::FromStr for VerifyMode {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "off" => Ok(VerifyMode::Off),
+            "count" => Ok(VerifyMode::Count),
+            _ => Err(anyhow::anyhow!(
+                "Invalid --verify value '{}'. Must be one of: off, count",
+                s
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for VerifyMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VerifyMode::Off => write!(f, "off"),
+            VerifyMode::Count => write!(f, "count"),
+        }
+    }
+}
+
+/// One verification outcome per loaded table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifyOutcome {
+    pub schema: String,
+    pub table: String,
+    /// Mirrored from `LoadResult.source_rows`. `None` for csv/tsv (no exact
+    /// source-row count in v1) — short-circuits L1 to
+    /// [`VerifyVerdict::SkippedNoExactSourceCount`].
+    pub source_rows: Option<u64>,
+    pub records_loaded: u64,
+    pub records_failed: u64,
+    /// Target row count immediately before the load. `None` when L2 was not
+    /// run (verify mode `Off`).
+    pub target_pre_count: Option<u64>,
+    /// Target row count immediately after the load. `None` when L2 was not
+    /// run.
+    pub target_post_count: Option<u64>,
+    pub verdict: VerifyVerdict,
+}
+
+/// Single verdict per table, summarising both L1 and L2 with the most
+/// actionable signal first. The verdict variant captures the magnitude
+/// (`u64` payload) so callers don't need to recompute deltas from the raw
+/// counts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerifyVerdict {
+    /// Both layers cleared. L1: `source_rows == loaded + failed`. When L2
+    /// ran: `target_delta == records_loaded` (or `≤` under non-Error
+    /// `OnConflict` modes — see [`RowsConflictedAtTarget`]).
+    Match,
+    /// L1: `source_rows > loaded + failed`. Rows entered the chunk buffer
+    /// and disappeared before reaching the DB layer — parser regression or
+    /// chunk-data mis-handling. Payload is `source_rows - (loaded + failed)`.
+    LoaderDropped(u64),
+    /// L2 under `OnConflict::Error`: `target_delta < records_loaded`.
+    /// INSERTs reported success but the target row count grew by less than
+    /// the loader claims — a real bug.
+    MissingTarget(u64),
+    /// L2: `target_delta > records_loaded`. The target gained rows the
+    /// loader did not submit — concurrent writer or duplicate accounting
+    /// bug. Surfaced under all `OnConflict` modes.
+    ExtraTarget(u64),
+    /// L2 informational under `OnConflict::Skip`/`DoUpdate`:
+    /// `target_delta < records_loaded`. The shortfall is exactly the
+    /// number of submitted rows that conflict resolution discarded — not a
+    /// bug per se, but the operator should know.
+    RowsConflictedAtTarget(u64),
+    /// `LoadResult.source_rows == None` (csv/tsv in v1). L1 cannot run; L2
+    /// may still have run, but its standalone interpretation is weak
+    /// without L1, so we surface this single verdict and leave fine-grained
+    /// L2 verdicts to the count-bearing formats. Quote-aware exact counting
+    /// for csv/tsv is the v2 follow-up.
+    SkippedNoExactSourceCount,
+}
+
+/// Inputs to [`classify`]. Grouped to keep the call site readable when
+/// orchestrator-level code wires the values up.
+#[derive(Debug, Clone, Copy)]
+pub struct VerifyInputs {
+    pub mode: VerifyMode,
+    pub on_conflict: OnConflict,
+    pub source_rows: Option<u64>,
+    pub records_loaded: u64,
+    pub records_failed: u64,
+    /// `Some` only when L2 ran. Required to pair with `target_post_count`.
+    pub target_pre_count: Option<u64>,
+    pub target_post_count: Option<u64>,
+}
+
+/// Pure verdict classifier: takes the count layer's inputs and returns the
+/// most actionable verdict. No I/O, no allocation — the entire verification
+/// surface lives here so it can be exhaustively unit-tested without a DB.
+///
+/// Decision order:
+/// 1. If `source_rows == None` → [`VerifyVerdict::SkippedNoExactSourceCount`].
+/// 2. L1 cross-check (`source` vs `loaded + failed`): a shortfall is
+///    [`VerifyVerdict::LoaderDropped`] regardless of `OnConflict` (both sides
+///    are insensitive to conflict resolution).
+/// 3. L2 cross-check (only when `mode == Count` AND both pre/post counts
+///    present): see [`VerifyVerdict`] variants for shape per `OnConflict`.
+/// 4. Both clean → [`VerifyVerdict::Match`].
+pub fn classify(inputs: VerifyInputs) -> VerifyVerdict {
+    let Some(source_rows) = inputs.source_rows else {
+        return VerifyVerdict::SkippedNoExactSourceCount;
+    };
+
+    let processed = inputs.records_loaded + inputs.records_failed;
+    if source_rows > processed {
+        return VerifyVerdict::LoaderDropped(source_rows - processed);
+    }
+
+    // L1 over-count (`processed > source_rows`) is treated as a Match: it
+    // cannot happen for the formats covered today (pgdump `\n` count is
+    // exact; parquet footer total is exact), and turning it into a verdict
+    // would require a new variant the operator can't act on. If a future
+    // format introduces uncertainty, add a verdict then.
+
+    if inputs.mode == VerifyMode::Count
+        && let (Some(pre), Some(post)) = (inputs.target_pre_count, inputs.target_post_count)
+    {
+        // saturating_sub rather than `if post >= pre` so a concurrent
+        // delete on the table during the load doesn't yield a negative
+        // delta and crash the verdict path. The post < pre case still
+        // surfaces — it just gets normalised to a delta of 0 (i.e. nothing
+        // landed), which then maps to a `MissingTarget` / conflict verdict
+        // depending on `on_conflict`.
+        let target_delta = post.saturating_sub(pre);
+
+        if target_delta > inputs.records_loaded {
+            return VerifyVerdict::ExtraTarget(target_delta - inputs.records_loaded);
+        }
+
+        if target_delta < inputs.records_loaded {
+            let shortfall = inputs.records_loaded - target_delta;
+            return match inputs.on_conflict {
+                OnConflict::Error => VerifyVerdict::MissingTarget(shortfall),
+                OnConflict::DoNothing | OnConflict::DoUpdate => {
+                    VerifyVerdict::RowsConflictedAtTarget(shortfall)
+                }
+            };
+        }
+    }
+
+    VerifyVerdict::Match
+}
+
+/// Run `SELECT COUNT(*) FROM <schema>.<table>` and return the result.
+///
+/// The orchestrator and `run_load` use this both for L2's pre-count (before
+/// the load) and post-count (after the load). Reuses `Pool::qualified_table_name`
+/// so identifier quoting matches what the rest of the loader emits — keeps
+/// SQLite (test) and Postgres (prod) on a single code path.
+pub async fn count_table_rows(pool: &Pool, schema: &str, table: &str) -> Result<u64> {
+    let qualified = pool.qualified_table_name(schema, table);
+    let sql = format!("SELECT COUNT(*) FROM {qualified}");
+    let rows: Vec<(i64,)> = pool
+        .fetch_all_with_binds::<(i64,)>(&sql, &[])
+        .await
+        .with_context(|| format!("Failed to count rows in {schema}.{table}"))?;
+    let count = rows
+        .first()
+        .map(|(c,)| *c)
+        .context("count(*) returned no rows")?;
+    // `COUNT(*)` is non-negative on every backend we ship; a negative value
+    // would imply a backend bug worth surfacing rather than silently
+    // wrapping into a u64.
+    if count < 0 {
+        anyhow::bail!("count(*) on {schema}.{table} returned negative {count}");
+    }
+    Ok(count as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inputs(
+        mode: VerifyMode,
+        on_conflict: OnConflict,
+        source_rows: Option<u64>,
+        loaded: u64,
+        failed: u64,
+        pre: Option<u64>,
+        post: Option<u64>,
+    ) -> VerifyInputs {
+        VerifyInputs {
+            mode,
+            on_conflict,
+            source_rows,
+            records_loaded: loaded,
+            records_failed: failed,
+            target_pre_count: pre,
+            target_post_count: post,
+        }
+    }
+
+    #[test]
+    fn none_source_short_circuits_to_skipped() {
+        let v = classify(inputs(
+            VerifyMode::Count,
+            OnConflict::Error,
+            None,
+            10,
+            0,
+            Some(0),
+            Some(10),
+        ));
+        assert_eq!(v, VerifyVerdict::SkippedNoExactSourceCount);
+    }
+
+    #[test]
+    fn l1_drop_under_error_is_loader_dropped() {
+        // source=100, loaded=90, failed=0 → 10 dropped before DB layer.
+        let v = classify(inputs(
+            VerifyMode::Count,
+            OnConflict::Error,
+            Some(100),
+            90,
+            0,
+            Some(0),
+            Some(90),
+        ));
+        assert_eq!(v, VerifyVerdict::LoaderDropped(10));
+    }
+
+    #[test]
+    fn l1_drop_takes_precedence_over_l2_match() {
+        // L2 looks fine in isolation (delta == loaded) but L1 sees a drop.
+        // The drop is the more actionable signal, so it wins.
+        let v = classify(inputs(
+            VerifyMode::Count,
+            OnConflict::Error,
+            Some(100),
+            90,
+            0,
+            Some(0),
+            Some(90),
+        ));
+        assert_eq!(v, VerifyVerdict::LoaderDropped(10));
+    }
+
+    #[test]
+    fn parse_failures_are_not_drops() {
+        // source=100, loaded=70, failed=30 → 70+30 == 100, no drop.
+        let v = classify(inputs(
+            VerifyMode::Count,
+            OnConflict::Error,
+            Some(100),
+            70,
+            30,
+            Some(0),
+            Some(70),
+        ));
+        assert_eq!(v, VerifyVerdict::Match);
+    }
+
+    #[test]
+    fn l2_shortfall_under_error_is_missing_target() {
+        // L1 clean (source == loaded), L2 short (target_delta < loaded).
+        let v = classify(inputs(
+            VerifyMode::Count,
+            OnConflict::Error,
+            Some(100),
+            100,
+            0,
+            Some(0),
+            Some(95),
+        ));
+        assert_eq!(v, VerifyVerdict::MissingTarget(5));
+    }
+
+    #[test]
+    fn l2_shortfall_under_skip_is_rows_conflicted() {
+        let v = classify(inputs(
+            VerifyMode::Count,
+            OnConflict::DoNothing,
+            Some(100),
+            100,
+            0,
+            Some(0),
+            Some(95),
+        ));
+        assert_eq!(v, VerifyVerdict::RowsConflictedAtTarget(5));
+    }
+
+    #[test]
+    fn l2_shortfall_under_update_is_rows_conflicted() {
+        let v = classify(inputs(
+            VerifyMode::Count,
+            OnConflict::DoUpdate,
+            Some(100),
+            100,
+            0,
+            Some(0),
+            Some(95),
+        ));
+        assert_eq!(v, VerifyVerdict::RowsConflictedAtTarget(5));
+    }
+
+    #[test]
+    fn l2_excess_is_extra_target_under_all_modes() {
+        // target_delta > records_loaded — concurrent writer or duplicate
+        // accounting. Same verdict regardless of OnConflict.
+        for mode in [
+            OnConflict::Error,
+            OnConflict::DoNothing,
+            OnConflict::DoUpdate,
+        ] {
+            let v = classify(inputs(
+                VerifyMode::Count,
+                mode,
+                Some(100),
+                100,
+                0,
+                Some(0),
+                Some(105),
+            ));
+            assert_eq!(v, VerifyVerdict::ExtraTarget(5), "mode {mode:?}");
+        }
+    }
+
+    #[test]
+    fn l2_skipped_when_mode_off() {
+        // mode=Off → L2 not consulted even with pre/post present (defensive
+        // — the orchestrator wouldn't supply them in that mode, but the
+        // classifier must not silently use them either).
+        let v = classify(inputs(
+            VerifyMode::Off,
+            OnConflict::Error,
+            Some(100),
+            100,
+            0,
+            Some(0),
+            Some(95),
+        ));
+        assert_eq!(v, VerifyVerdict::Match);
+    }
+
+    #[test]
+    fn l2_skipped_when_pre_post_missing() {
+        // mode=Count but counts unavailable (e.g. count query failed and
+        // we synthesised None) — fall back to L1-only Match.
+        let v = classify(inputs(
+            VerifyMode::Count,
+            OnConflict::Error,
+            Some(100),
+            100,
+            0,
+            None,
+            None,
+        ));
+        assert_eq!(v, VerifyVerdict::Match);
+    }
+
+    #[test]
+    fn pre_greater_than_post_does_not_panic() {
+        // Concurrent delete during the load would invert pre/post —
+        // saturating_sub keeps the verdict path safe; it surfaces as
+        // MissingTarget under Error (or RowsConflicted under non-Error)
+        // because target_delta resolves to 0.
+        let v = classify(inputs(
+            VerifyMode::Count,
+            OnConflict::Error,
+            Some(10),
+            10,
+            0,
+            Some(20),
+            Some(15),
+        ));
+        assert_eq!(v, VerifyVerdict::MissingTarget(10));
+    }
+
+    #[test]
+    fn verify_mode_round_trips_through_str() {
+        for m in [VerifyMode::Off, VerifyMode::Count] {
+            let s = m.to_string();
+            assert_eq!(s.parse::<VerifyMode>().unwrap(), m);
+        }
+    }
+
+    #[test]
+    fn verify_mode_rejects_unknown() {
+        assert!("strict".parse::<VerifyMode>().is_err());
+    }
+}

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -16,9 +16,9 @@
 //!   under `Skip`/`Update` it's `RowsConflictedAtTarget` (informational —
 //!   conflict resolution discarded N rows).
 //!
-//! Out of scope for v1: value-level fidelity (column-swap bugs,
-//! `\N`-vs-`""` mistranslation, encoding mishandling, type coercion). A
-//! count match proves completeness, not fidelity.
+//! Out of scope: value-level fidelity (column-swap bugs, `\N`-vs-`""`
+//! mistranslation, encoding mishandling, type coercion). A count match
+//! proves completeness, not fidelity.
 
 use crate::coordination::manifest::OnConflict;
 use crate::db::Pool;
@@ -75,8 +75,8 @@ impl std::fmt::Display for VerifyMode {
 pub struct VerifyOutcome {
     pub schema: String,
     pub table: String,
-    /// Mirrored from `LoadResult.source_rows`. `None` for csv/tsv (no exact
-    /// source-row count in v1) — short-circuits L1 to
+    /// Mirrored from `LoadResult.source_rows`. `None` for csv/tsv (no
+    /// exact source-row count) — short-circuits L1 to
     /// [`VerifyVerdict::SkippedNoExactSourceCount`].
     pub source_rows: Option<u64>,
     pub records_loaded: u64,
@@ -117,11 +117,10 @@ pub enum VerifyVerdict {
     /// number of submitted rows that conflict resolution discarded — not a
     /// bug per se, but the operator should know.
     RowsConflictedAtTarget(u64),
-    /// `LoadResult.source_rows == None` (csv/tsv in v1). L1 cannot run; L2
+    /// `LoadResult.source_rows == None` (csv/tsv). L1 cannot run; L2
     /// may still have run, but its standalone interpretation is weak
-    /// without L1, so we surface this single verdict and leave fine-grained
-    /// L2 verdicts to the count-bearing formats. Quote-aware exact counting
-    /// for csv/tsv is the v2 follow-up.
+    /// without L1, so we surface this single verdict and leave
+    /// fine-grained L2 verdicts to the count-bearing formats.
     SkippedNoExactSourceCount,
 }
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -77,8 +77,10 @@ pub enum VerifyVerdict {
     /// L2 excess: target grew more than `records_loaded`. Concurrent
     /// writer or duplicate accounting.
     ExtraTarget(u64),
-    /// L2 shortfall under `Skip`/`DoUpdate` — exactly N rows lost to
-    /// conflict resolution. Informational, not a bug.
+    /// L2 shortfall under `Skip`/`DoUpdate` — N rows resolved by ON CONFLICT.
+    /// Expected under conflict-tolerant modes; CLI still exits 1 so a chained
+    /// `migrate && deploy.sh` does not ship a partially-loaded cluster without
+    /// operator review.
     RowsConflictedAtTarget(u64),
     /// csv/tsv: no exact source count, so L1 can't run.
     SkippedNoExactSourceCount,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -34,6 +34,15 @@ pub enum VerifyMode {
     #[default]
     Off,
     /// L2 is on: pre/post `count(*)` per loaded table.
+    ///
+    /// **Sole-writer assumption.** L2 compares `target_post -
+    /// target_pre` against `records_loaded`. If anyone else writes to
+    /// the same target table between pre-count and post-count the
+    /// verdict reflects the combined delta — concurrent inserts surface
+    /// as `ExtraTarget`, concurrent deletes as `MissingTarget`. The
+    /// operator owns ensuring no other writer touches the target during
+    /// the load window. `migrate` against a fresh cluster satisfies
+    /// this by construction.
     Count,
 }
 
@@ -267,9 +276,13 @@ mod tests {
     }
 
     #[test]
-    fn l1_drop_takes_precedence_over_l2_match() {
-        // L2 looks fine in isolation (delta == loaded) but L1 sees a drop.
-        // The drop is the more actionable signal, so it wins.
+    fn l1_drop_takes_precedence_over_l2_missing_target() {
+        // Both layers see a problem: L1 sees 10 rows dropped before the
+        // DB layer (source=100 vs loaded=90), L2 sees 10 rows missing
+        // at the target (delta=80 vs loaded=90 under Error). L1 is the
+        // root cause — without it the L2 shortfall has no explanation —
+        // so its verdict wins. A regression that returns `MissingTarget`
+        // here would hide the L1 signal behind a downstream symptom.
         let v = classify(inputs(
             VerifyMode::Count,
             OnConflict::Error,
@@ -277,7 +290,7 @@ mod tests {
             90,
             0,
             Some(0),
-            Some(90),
+            Some(80),
         ));
         assert_eq!(v, VerifyVerdict::LoaderDropped(10));
     }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -4,7 +4,7 @@
 //!   between source bytes and the DB layer (parser/chunker bugs).
 //! - **L2**: target `post - pre` vs `loaded`. Catches drops between
 //!   INSERT and table contents. Shortfall is `MissingTarget` under
-//!   `Error`, `RowsConflictedAtTarget` under `Skip`/`Update`.
+//!   `Error`, `RowsConflictedAtTarget` under `DoNothing`/`DoUpdate`.
 //!
 //! Counts only — no value-level fidelity check.
 
@@ -12,8 +12,9 @@ use crate::coordination::manifest::OnConflict;
 use crate::db::Pool;
 use anyhow::{Context, Result};
 
-/// L2 toggle. L1 always runs when `source_rows` is exact (cost: free,
-/// computed during parsing).
+/// L2 toggle. Source-row counting happens parser-side regardless;
+/// `Count` adds pre/post `count(*)` and produces a `VerifyOutcome` per
+/// loaded table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum VerifyMode {
     #[default]
@@ -77,7 +78,7 @@ pub enum VerifyVerdict {
     /// L2 excess: target grew more than `records_loaded`. Concurrent
     /// writer or duplicate accounting.
     ExtraTarget(u64),
-    /// L2 shortfall under `Skip`/`DoUpdate` — N rows resolved by ON CONFLICT.
+    /// L2 shortfall under `DoNothing`/`DoUpdate` — N rows resolved by ON CONFLICT.
     /// Expected under conflict-tolerant modes; CLI still exits 1 so a chained
     /// `migrate && deploy.sh` does not ship a partially-loaded cluster without
     /// operator review.
@@ -96,6 +97,23 @@ pub struct VerifyInputs {
     /// Both `Some` when L2 ran, both `None` otherwise.
     pub target_pre_count: Option<u64>,
     pub target_post_count: Option<u64>,
+}
+
+impl VerifyOutcome {
+    /// Classify `inputs` and bind the verdict to `(schema, table)`.
+    pub fn from_inputs(schema: String, table: String, inputs: VerifyInputs) -> Self {
+        let verdict = classify(inputs);
+        VerifyOutcome {
+            schema,
+            table,
+            source_rows: inputs.source_rows,
+            records_loaded: inputs.records_loaded,
+            records_failed: inputs.records_failed,
+            target_pre_count: inputs.target_pre_count,
+            target_post_count: inputs.target_post_count,
+            verdict,
+        }
+    }
 }
 
 /// Pure verdict classifier — no I/O, exhaustively unit-tested.

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -16,6 +16,7 @@ use anyhow::{Context, Result};
 /// `Count` adds pre/post `count(*)` and produces a `VerifyOutcome` per
 /// loaded table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum VerifyMode {
     #[default]
     Off,
@@ -50,8 +51,18 @@ impl std::fmt::Display for VerifyMode {
     }
 }
 
+/// L2 pre/post pair. `Some` exactly when L2 ran; the `(pre, post)`
+/// invariant — both present together — is enforced by construction
+/// rather than by convention on two parallel `Option` fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct L2Counts {
+    pub pre: u64,
+    pub post: u64,
+}
+
 /// One verification outcome per loaded table.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct VerifyOutcome {
     pub schema: String,
     pub table: String,
@@ -59,49 +70,48 @@ pub struct VerifyOutcome {
     pub source_rows: Option<u64>,
     pub records_loaded: u64,
     pub records_failed: u64,
-    /// Both `Some` when L2 ran, both `None` otherwise.
-    pub target_pre_count: Option<u64>,
-    pub target_post_count: Option<u64>,
+    /// `Some` when L2 ran, `None` otherwise.
+    pub target_counts: Option<L2Counts>,
     pub verdict: VerifyVerdict,
 }
 
 /// Most actionable verdict per table; payload is the magnitude.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum VerifyVerdict {
     /// L1 clean, and L2 (if run) clean.
     Match,
     /// L1 shortfall: rows lost between source bytes and the DB layer.
     LoaderDropped(u64),
     /// L2 shortfall under `OnConflict::Error` — INSERT reported success
-    /// but target grew by less than `records_loaded`. Real bug.
+    /// but target grew by less than `records_loaded`. Concurrent DELETE
+    /// or rolled-back INSERT (verify=count assumes sole writer).
     MissingTarget(u64),
     /// L2 excess: target grew more than `records_loaded`. Concurrent
-    /// writer or duplicate accounting.
+    /// INSERT (verify=count assumes sole writer) or duplicate accounting.
     ExtraTarget(u64),
-    /// L2 shortfall under `DoNothing`/`DoUpdate` — N rows resolved by ON CONFLICT.
-    /// Expected under conflict-tolerant modes; CLI still exits 1 so a chained
-    /// `migrate && deploy.sh` does not ship a partially-loaded cluster without
-    /// operator review.
+    /// L2 shortfall under `DoNothing`/`DoUpdate` — N rows resolved by
+    /// ON CONFLICT. CLI exits 1 so chained `migrate && deploy.sh` does
+    /// not ship a partially-loaded cluster without operator review.
     RowsConflictedAtTarget(u64),
     /// csv/tsv: no exact source count, so L1 can't run.
     SkippedNoExactSourceCount,
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct VerifyInputs {
+pub(crate) struct VerifyInputs {
     pub mode: VerifyMode,
     pub on_conflict: OnConflict,
     pub source_rows: Option<u64>,
     pub records_loaded: u64,
     pub records_failed: u64,
-    /// Both `Some` when L2 ran, both `None` otherwise.
-    pub target_pre_count: Option<u64>,
-    pub target_post_count: Option<u64>,
+    /// `Some` when L2 ran, `None` otherwise.
+    pub target_counts: Option<L2Counts>,
 }
 
 impl VerifyOutcome {
     /// Classify `inputs` and bind the verdict to `(schema, table)`.
-    pub fn from_inputs(schema: String, table: String, inputs: VerifyInputs) -> Self {
+    pub(crate) fn from_inputs(schema: String, table: String, inputs: VerifyInputs) -> Self {
         let verdict = classify(inputs);
         VerifyOutcome {
             schema,
@@ -109,8 +119,7 @@ impl VerifyOutcome {
             source_rows: inputs.source_rows,
             records_loaded: inputs.records_loaded,
             records_failed: inputs.records_failed,
-            target_pre_count: inputs.target_pre_count,
-            target_post_count: inputs.target_post_count,
+            target_counts: inputs.target_counts,
             verdict,
         }
     }
@@ -119,9 +128,9 @@ impl VerifyOutcome {
 /// Pure verdict classifier — no I/O, exhaustively unit-tested.
 ///
 /// Order: source `None` → `SkippedNoExactSourceCount`; L1 shortfall →
-/// `LoaderDropped`; L2 (if mode=Count and pre/post present) → see
+/// `LoaderDropped`; L2 (if mode=Count and counts present) → see
 /// variants; otherwise `Match`.
-pub fn classify(inputs: VerifyInputs) -> VerifyVerdict {
+pub(crate) fn classify(inputs: VerifyInputs) -> VerifyVerdict {
     let Some(source_rows) = inputs.source_rows else {
         return VerifyVerdict::SkippedNoExactSourceCount;
     };
@@ -135,7 +144,7 @@ pub fn classify(inputs: VerifyInputs) -> VerifyVerdict {
     // a future format introduces uncertainty.
 
     if inputs.mode == VerifyMode::Count
-        && let (Some(pre), Some(post)) = (inputs.target_pre_count, inputs.target_post_count)
+        && let Some(L2Counts { pre, post }) = inputs.target_counts
     {
         // saturating_sub: a concurrent DELETE (post < pre) normalises to
         // delta=0 → MissingTarget/RowsConflictedAtTarget, instead of
@@ -163,7 +172,7 @@ pub fn classify(inputs: VerifyInputs) -> VerifyVerdict {
 /// `SELECT COUNT(*)` for L2 pre/post. Reuses
 /// `Pool::qualified_table_name` so identifier quoting matches the rest
 /// of the loader.
-pub async fn count_table_rows(pool: &Pool, schema: &str, table: &str) -> Result<u64> {
+pub(crate) async fn count_table_rows(pool: &Pool, schema: &str, table: &str) -> Result<u64> {
     let qualified = pool.qualified_table_name(schema, table);
     let sql = format!("SELECT COUNT(*) FROM {qualified}");
     let rows: Vec<(i64,)> = pool
@@ -194,14 +203,18 @@ mod tests {
         pre: Option<u64>,
         post: Option<u64>,
     ) -> VerifyInputs {
+        let target_counts = match (pre, post) {
+            (Some(pre), Some(post)) => Some(L2Counts { pre, post }),
+            (None, None) => None,
+            _ => panic!("test helper: pre/post must both be Some or both None"),
+        };
         VerifyInputs {
             mode,
             on_conflict,
             source_rows,
             records_loaded: loaded,
             records_failed: failed,
-            target_pre_count: pre,
-            target_post_count: post,
+            target_counts,
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds an opt-in count-level verification layer that catches **silent row drops** in the loader (chunk-boundary bugs, parser regressions, coordinator quirks). Today, `records_loaded` reports what was *sent* to the DB, not what the source actually contained — a clean-looking report can mask missing rows.
- **L1** (parser-independent, always populated when format supports it): pgdump tees a `\n` byte count off the raw chunk read; parquet sums footer row-group totals; csv/tsv stay `None` (quote-aware exact counting is the v2 follow-up). The L1 verdict ships only under `--verify=count`; under `--verify=off` operators see a raw `source_rows` number on `LoadResult` with no built-in cross-check.
- **L2** (opt-in via `--verify=count`): pre + post `count(*)` per loaded table, classified into a single verdict per `OnConflict`: `Match | LoaderDropped(N) | MissingTarget(N) | ExtraTarget(N) | RowsConflictedAtTarget(N) | SkippedNoExactSourceCount`.
- New CLI flag `--verify <off|count>` on both `load` and `migrate`. Defaults: `load=Off` (avoid `count(*)` on big targets), `migrate=Count` (fresh-cluster, sub-ms pre-counts).
- Implementation in `src/verify.rs` — two enums (`VerifyMode`, `VerifyVerdict`), two structs (`VerifyOutcome`, `VerifyInputs`), one pure `classify()` function + integration helpers. The classifier has no I/O so the verdict matrix is exhaustively unit-tested.
- **Drive-by hardening:** every schema/table/column identifier parsed out of the dump is now passed through `validate_pgdump_identifier` before reaching SQL or `list-tables` stdout — closes an injection seam where a crafted COPY clause with embedded `"` / `\` / control bytes / Unicode bidi codepoints could corrupt identifier quoting.

## Caveats

- **Sole-writer assumption** for `--verify=count`: a concurrent INSERT during the load surfaces as `ExtraTarget`; a concurrent DELETE saturates to `MissingTarget`. `migrate` against a fresh cluster satisfies this trivially; `load --verify=count` against a live target should be paired with the operator's own quiescence guarantee.
- **`--if-not-exists` skips L2:** the table may not exist at pre-count time, and a re-run against an already-populated target would mis-classify as `ExtraTarget`. The verdict falls back to L1-only (`Match` if pgdump/parquet, `SkippedNoExactSourceCount` if csv/tsv).

## Test plan

- [x] 32 new tests pass (13 unit tests in `src/verify.rs`, 6 orchestrator integration tests, 6 reader/runner integration tests, 3 pgdump invariant pins, 3 aggregate-source-rows unit tests, 1 exit-code policy unit test).
- [x] All 271 lib tests + 25 main tests + 1 doctest pass.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] Real-DSQL E2E (`pgdump_migrate_real_full_dump_collapses_serial_strips_fk`, run under `--features e2e-dsql` in CI's `e2e-dsql` job) extended to assert `VerifyVerdict::Match` and `source_rows.is_some()` for every loaded table — closes the loop end-to-end against a real cluster.
- [x] Empty-line invariant pinned: a corrupted COPY block with an empty line surfaces as a `parse_error` (not a silent drop), so L1's `source == loaded + failed` cross-check stays in sync.