### PR TITLE
feat(progress): align migrate progress monitoring with load

### DIFF
--- a/src/coordination/coordinator.rs
+++ b/src/coordination/coordinator.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use chrono::Utc;
 use derive_builder::Builder;
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use indicatif::MultiProgress;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -12,12 +12,13 @@ use uuid::Uuid;
 use super::manifest::{
     ChunkInfo, ChunkResultFile, DsqlConfig, FileFormat, ManifestFile, ManifestStorage, OnConflict,
 };
+use super::progress::LoadProgress;
 use super::worker::Worker;
 use crate::db::schema::{Schema, query_table_schema, validate_schema_exists};
 use crate::db::{Pool, SchemaInferrer};
 use crate::formats::FileReader;
 use crate::formats::reader::{Chunk, FileMetadata};
-use crate::telemetry::{ProgressStats, TelemetryEvent};
+use crate::telemetry::TelemetryEvent;
 
 /// Validate that every excluded name exists in the schema and that at least
 /// one column would remain after exclusion.
@@ -262,6 +263,12 @@ pub struct LoadConfig {
     on_conflict: OnConflict,
     #[builder(default)]
     exclude_columns: Vec<String>,
+    /// When `Some`, the load attaches its 4 progress bars to the
+    /// caller's `MultiProgress` (migrate path). When `None`, it
+    /// builds its own (standalone-load path). `quiet=true` suppresses
+    /// bars in either case.
+    #[builder(default)]
+    parent_multi: Option<Arc<MultiProgress>>,
 }
 
 /// Result of a completed data load operation
@@ -323,15 +330,39 @@ impl Coordinator {
         // Drop the coordinator's copy of the sender so the channel closes when workers finish
         drop(telemetry_tx);
 
-        // Setup progress tracking
-        let prog_jh = Self::setup_progress_tracking(config, &file_metadata, &chunks, telemetry_rx);
+        // Setup progress tracking. Three cases by (quiet, parent_multi):
+        //   quiet=true             → no bars at all (skip LoadProgress).
+        //   quiet=false, parent=Some → migrate path: add bars under the
+        //                              caller's persistent dump bars,
+        //                              clear them when this table finishes.
+        //   quiet=false, parent=None → standalone path: own MultiProgress,
+        //                              leave bars visible at the end.
+        let load_progress = if config.quiet {
+            None
+        } else {
+            let total_chunks = chunks.len() as u64;
+            Some(match &config.parent_multi {
+                Some(parent) => {
+                    LoadProgress::within(parent, &file_metadata, total_chunks, telemetry_rx)
+                }
+                None => LoadProgress::new(&file_metadata, total_chunks, telemetry_rx),
+            })
+        };
 
         // Wait for all workers to complete
         let worker_results = futures::future::join_all(worker_handles).await;
 
-        // Wait for the progress bar to finish so we don't collide output
-        if let Some(jh) = prog_jh {
-            let _ = jh.await;
+        // Drain and finalize bars. Per-iteration ordering invariant:
+        // workers finished → channel closed → pump drains → bars finalize.
+        // `finish_clean` clears per-table bars (migrate); `finish_standalone`
+        // leaves them visible (load command). The clear path is selected by
+        // parent_multi presence — same matrix as construction above.
+        if let Some(lp) = load_progress {
+            if config.parent_multi.is_some() {
+                lp.finish_clean().await;
+            } else {
+                lp.finish_standalone().await;
+            }
         }
 
         // Check for any worker errors
@@ -963,95 +994,6 @@ impl Coordinator {
         }
 
         worker_handles
-    }
-
-    /// Setup progress tracking with progress bars
-    fn setup_progress_tracking(
-        config: &LoadConfig,
-        file_metadata: &FileMetadata,
-        chunks: &[Chunk],
-        mut telemetry_rx: mpsc::UnboundedReceiver<TelemetryEvent>,
-    ) -> Option<tokio::task::JoinHandle<()>> {
-        if config.quiet {
-            return None;
-        }
-
-        // Create progress bars with MultiProgress
-        let multi_progress = MultiProgress::new();
-        let total_chunks = chunks.len() as u64;
-        let estimated_total_rows = file_metadata.estimated_rows.unwrap_or(0);
-
-        let chunk_bar = multi_progress.add(ProgressBar::new(total_chunks));
-        chunk_bar.set_style(
-            ProgressStyle::default_bar()
-                .template(
-                    "[{elapsed_precise}] Chunks: [{bar:30.cyan/blue}] {pos}/{len} ({percent}%)",
-                )
-                .unwrap()
-                .progress_chars("=>-"),
-        );
-
-        let rows_bar = if estimated_total_rows > 0 {
-            let bar = multi_progress.add(ProgressBar::new(estimated_total_rows));
-            bar.set_style(
-                ProgressStyle::default_bar()
-                    .template("[{elapsed_precise}] Rows:       [{bar:30.green/blue}] {human_pos}/{human_len} ({percent}%) | {per_sec}")
-                    .unwrap()
-                    .progress_chars("=>-")
-            );
-            Some(bar)
-        } else {
-            None
-        };
-
-        let bytes_bar = multi_progress.add(ProgressBar::new(file_metadata.file_size_bytes));
-        bytes_bar.set_style(
-            ProgressStyle::default_bar()
-                .template("[{elapsed_precise}] Bytes:      [{bar:30.yellow/blue}] {bytes}/{total_bytes} ({percent}%) | {bytes_per_sec}")
-                .unwrap()
-                .progress_chars("=>-")
-        );
-
-        let stats_bar = multi_progress.add(ProgressBar::new(0));
-        stats_bar.set_style(
-            ProgressStyle::default_bar()
-                .template("[{elapsed_precise}] Batch Time: {msg}")
-                .unwrap(),
-        );
-
-        Some(tokio::spawn(async move {
-            let mut stats = ProgressStats::new();
-
-            while let Some(event) = telemetry_rx.recv().await {
-                stats.update(&event);
-
-                chunk_bar.set_position(stats.chunks_completed as u64);
-                if let Some(ref bar) = rows_bar {
-                    bar.set_position(stats.records_loaded);
-                }
-                bytes_bar.set_position(stats.bytes_processed);
-
-                let (p50, p90, p99) = stats.get_percentiles();
-                if let (Some(p50), Some(p90), Some(p99)) = (p50, p90, p99) {
-                    stats_bar
-                        .set_message(format!("p50: {}ms, p90: {}ms, p99: {}ms", p50, p90, p99));
-                }
-            }
-
-            chunk_bar.finish_with_message("All chunks completed");
-            if let Some(bar) = rows_bar {
-                bar.finish();
-            }
-            bytes_bar.finish();
-
-            let (p50, p90, p99) = stats.get_percentiles();
-            if let (Some(p50), Some(p90), Some(p99)) = (p50, p90, p99) {
-                stats_bar
-                    .finish_with_message(format!("p50: {}ms, p90: {}ms, p99: {}ms", p50, p90, p99));
-            } else {
-                stats_bar.finish();
-            }
-        }))
     }
 
     /// Aggregate the final results from all chunk result files

--- a/src/coordination/coordinator.rs
+++ b/src/coordination/coordinator.rs
@@ -264,7 +264,7 @@ pub struct LoadConfig {
     #[builder(default)]
     exclude_columns: Vec<String>,
     /// `Some` attaches bars to the caller's `MultiProgress`; `None`
-    /// builds an own one. `quiet` overrides both to no bars.
+    /// builds its own. `quiet` overrides both to no bars.
     #[builder(default)]
     parent_multi: Option<Arc<MultiProgress>>,
 }

--- a/src/coordination/coordinator.rs
+++ b/src/coordination/coordinator.rs
@@ -263,10 +263,8 @@ pub struct LoadConfig {
     on_conflict: OnConflict,
     #[builder(default)]
     exclude_columns: Vec<String>,
-    /// When `Some`, the load attaches its 4 progress bars to the
-    /// caller's `MultiProgress` (migrate path). When `None`, it
-    /// builds its own (standalone-load path). `quiet=true` suppresses
-    /// bars in either case.
+    /// `Some` attaches bars to the caller's `MultiProgress`; `None`
+    /// builds an own one. `quiet` overrides both to no bars.
     #[builder(default)]
     parent_multi: Option<Arc<MultiProgress>>,
 }
@@ -330,13 +328,8 @@ impl Coordinator {
         // Drop the coordinator's copy of the sender so the channel closes when workers finish
         drop(telemetry_tx);
 
-        // Setup progress tracking. Three cases by (quiet, parent_multi):
-        //   quiet=true             → no bars at all (skip LoadProgress).
-        //   quiet=false, parent=Some → migrate path: add bars under the
-        //                              caller's persistent dump bars,
-        //                              clear them when this table finishes.
-        //   quiet=false, parent=None → standalone path: own MultiProgress,
-        //                              leave bars visible at the end.
+        // `quiet` short-circuits bar construction; otherwise `parent_multi`
+        // selects attached (migrate) vs. own MultiProgress (standalone).
         let load_progress = if config.quiet {
             None
         } else {
@@ -352,11 +345,8 @@ impl Coordinator {
         // Wait for all workers to complete
         let worker_results = futures::future::join_all(worker_handles).await;
 
-        // Drain and finalize bars. Per-iteration ordering invariant:
+        // Ordering invariant (reordering corrupts the live render):
         // workers finished → channel closed → pump drains → bars finalize.
-        // `finish_clean` clears per-table bars (migrate); `finish_standalone`
-        // leaves them visible (load command). The clear path is selected by
-        // parent_multi presence — same matrix as construction above.
         if let Some(lp) = load_progress {
             if config.parent_multi.is_some() {
                 lp.finish_clean().await;

--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -7,4 +7,4 @@ pub mod worker;
 
 pub use coordinator::{Coordinator, LoadConfigBuilder};
 pub use manifest::{DsqlConfig, FileFormat};
-pub use progress::MigrateProgress;
+pub(crate) use progress::MigrateProgress;

--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -2,7 +2,9 @@
 
 pub mod coordinator;
 pub mod manifest;
+pub mod progress;
 pub mod worker;
 
 pub use coordinator::{Coordinator, LoadConfigBuilder};
 pub use manifest::{DsqlConfig, FileFormat};
+pub use progress::MigrateProgress;

--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -7,4 +7,4 @@ pub mod worker;
 
 pub use coordinator::{Coordinator, LoadConfigBuilder};
 pub use manifest::{DsqlConfig, FileFormat};
-pub(crate) use progress::MigrateProgress;
+pub use progress::MigrateProgress;

--- a/src/coordination/progress.rs
+++ b/src/coordination/progress.rs
@@ -229,7 +229,6 @@ impl LoadProgress {
         self.bytes_bar.finish();
         self.stats_bar.finish();
     }
-
 }
 
 /// Add the four per-load bars to `multi` and return them. Shared
@@ -381,5 +380,4 @@ mod tests {
 
         lp.finish_clean().await;
     }
-
 }

--- a/src/coordination/progress.rs
+++ b/src/coordination/progress.rs
@@ -1,0 +1,385 @@
+//! Progress bar construction and lifecycle for both load and migrate flows.
+//!
+//! Two consumers:
+//! - `Coordinator::run_load` builds a [`LoadProgress`] either standalone
+//!   (its own `MultiProgress`) or `within` a parent `MultiProgress`
+//!   supplied by the migrate orchestrator.
+//! - `migrate::orchestrator::run_migrate` builds one [`MigrateProgress`]
+//!   for the whole-dump view and threads its `multi` handle into each
+//!   per-table load via `LoadConfig.parent_multi`.
+//!
+//! Bar layout during migrate (top → bottom):
+//! ```text
+//! [elapsed] Tables:     [bar] N/M (P%)              ← MigrateProgress, persistent
+//! [elapsed] Bytes:      [bar] X/Y (P%) | rate ETA Z ← MigrateProgress, persistent
+//! [elapsed] Chunks:     [bar] n/m (P%)              ← LoadProgress, per-table
+//! [elapsed] Rows:       [bar] r/total (P%) | rate   ← LoadProgress, per-table (parquet only)
+//! [elapsed] Bytes:      [bar] b/size (P%) | rate    ← LoadProgress, per-table
+//! [elapsed] Batch Time: p50/p90/p99                 ← LoadProgress, per-table
+//! ```
+//!
+//! Bar lifecycle (per table):
+//! 1. `LoadProgress::within` adds 4 bars below the 2 persistent ones.
+//! 2. Workers send `TelemetryEvent`s; the pump task updates the bars.
+//! 3. After the load returns, the channel is closed; the pump exits.
+//! 4. `LoadProgress::finish_clean` / `finish_halted` awaits the pump,
+//!    then either clears the per-table bars (clean) or freezes them
+//!    in place (halt) — see method docs for the ordering invariant.
+
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+use crate::formats::pgdump::CopyBlock;
+use crate::formats::reader::FileMetadata;
+use crate::telemetry::{ProgressStats, TelemetryEvent};
+
+/// Whole-dump progress view used by the migrate orchestrator.
+///
+/// Holds two persistent bars (Tables, Bytes) plus a shared
+/// `MultiProgress` handle that per-table [`LoadProgress`] instances
+/// attach to. Constructed once at the top of `run_migrate` and lives
+/// for the duration of the per-table loop.
+pub struct MigrateProgress {
+    multi: Arc<MultiProgress>,
+    tables_bar: ProgressBar,
+    bytes_bar: ProgressBar,
+}
+
+impl MigrateProgress {
+    /// Build the migrate-wide progress view from the resolved
+    /// `CopyBlock` list. `total_bytes` sums each block's data payload
+    /// (`data_end - data_start`) — already produced by `list_copy_blocks`.
+    pub fn new(blocks: &[CopyBlock]) -> Self {
+        Self::with_multi(blocks, MultiProgress::new())
+    }
+
+    /// Test/internal constructor: callers can supply a `MultiProgress`
+    /// with `ProgressDrawTarget::hidden()` so `cargo test` doesn't
+    /// stream bars to stderr.
+    pub fn with_multi(blocks: &[CopyBlock], multi: MultiProgress) -> Self {
+        let total_tables = blocks.len() as u64;
+        let total_bytes: u64 = blocks.iter().map(|b| b.data_end - b.data_start).sum();
+
+        let tables_bar = multi.add(ProgressBar::new(total_tables));
+        tables_bar.set_style(
+            ProgressStyle::default_bar()
+                .template(
+                    "[{elapsed_precise}] Tables:     [{bar:30.magenta/blue}] {pos}/{len} ({percent}%)",
+                )
+                .unwrap()
+                .progress_chars("=>-"),
+        );
+
+        let bytes_bar = multi.add(ProgressBar::new(total_bytes));
+        bytes_bar.set_style(
+            ProgressStyle::default_bar()
+                .template(
+                    "[{elapsed_precise}] Dump Bytes: [{bar:30.yellow/blue}] {bytes}/{total_bytes} ({percent}%) | {bytes_per_sec} ETA {eta}",
+                )
+                .unwrap()
+                .progress_chars("=>-"),
+        );
+
+        Self {
+            multi: Arc::new(multi),
+            tables_bar,
+            bytes_bar,
+        }
+    }
+
+    /// Shared `MultiProgress` handle for per-table [`LoadProgress`]
+    /// instances to attach to via [`LoadProgress::within`].
+    pub fn multi(&self) -> Arc<MultiProgress> {
+        Arc::clone(&self.multi)
+    }
+
+    /// Advance the persistent bars after a clean per-table load.
+    pub fn record_table_loaded(&self, block_bytes: u64) {
+        self.tables_bar.inc(1);
+        self.bytes_bar.inc(block_bytes);
+    }
+
+    /// Close the run cleanly: finish both persistent bars at full
+    /// position so the live render is closed before the orchestrator's
+    /// caller (e.g. `main.rs`'s "Loaded tables:" summary) prints.
+    pub fn finish_clean(&self) {
+        self.tables_bar.finish_with_message("done");
+        self.bytes_bar.finish_with_message("done");
+    }
+
+    /// Close the run on a halting iteration: freeze both persistent
+    /// bars at their current position with a "halted" message. The
+    /// per-table `LoadProgress` for the halting table is finalized
+    /// independently via [`LoadProgress::finish_halted`].
+    pub fn finish_halted(&self, reason: &str) {
+        self.tables_bar
+            .abandon_with_message(format!("halted: {reason}"));
+        self.bytes_bar
+            .abandon_with_message(format!("halted: {reason}"));
+    }
+}
+
+/// Per-load progress: 4 bars (chunks / rows / bytes / batch-time) plus
+/// the telemetry pump task that drives them. Constructed by
+/// `Coordinator::run_load` either standalone or attached to a parent
+/// `MultiProgress` from [`MigrateProgress`].
+pub struct LoadProgress {
+    chunk_bar: ProgressBar,
+    rows_bar: Option<ProgressBar>,
+    bytes_bar: ProgressBar,
+    stats_bar: ProgressBar,
+    pump: tokio::task::JoinHandle<()>,
+}
+
+impl LoadProgress {
+    /// Standalone-load path: build a fresh `MultiProgress` and 4 bars,
+    /// spawn the pump task. Equivalent to the previous
+    /// `setup_progress_tracking` body.
+    pub fn new(
+        file_metadata: &FileMetadata,
+        total_chunks: u64,
+        telemetry_rx: mpsc::UnboundedReceiver<TelemetryEvent>,
+    ) -> Self {
+        Self::with_multi(
+            &MultiProgress::new(),
+            file_metadata,
+            total_chunks,
+            telemetry_rx,
+        )
+    }
+
+    /// Migrate path: attach 4 bars to the caller's `MultiProgress` so
+    /// they render below the persistent dump-wide bars.
+    pub fn within(
+        parent: &MultiProgress,
+        file_metadata: &FileMetadata,
+        total_chunks: u64,
+        telemetry_rx: mpsc::UnboundedReceiver<TelemetryEvent>,
+    ) -> Self {
+        Self::with_multi(parent, file_metadata, total_chunks, telemetry_rx)
+    }
+
+    fn with_multi(
+        multi: &MultiProgress,
+        file_metadata: &FileMetadata,
+        total_chunks: u64,
+        mut telemetry_rx: mpsc::UnboundedReceiver<TelemetryEvent>,
+    ) -> Self {
+        let (chunk_bar, rows_bar, bytes_bar, stats_bar) =
+            build_load_bars(multi, file_metadata, total_chunks);
+
+        let chunk_bar_pump = chunk_bar.clone();
+        let rows_bar_pump = rows_bar.clone();
+        let bytes_bar_pump = bytes_bar.clone();
+        let stats_bar_pump = stats_bar.clone();
+
+        let pump = tokio::spawn(async move {
+            let mut stats = ProgressStats::new();
+            while let Some(event) = telemetry_rx.recv().await {
+                stats.update(&event);
+                chunk_bar_pump.set_position(stats.chunks_completed as u64);
+                if let Some(ref bar) = rows_bar_pump {
+                    bar.set_position(stats.records_loaded);
+                }
+                bytes_bar_pump.set_position(stats.bytes_processed);
+                let (p50, p90, p99) = stats.get_percentiles();
+                if let (Some(p50), Some(p90), Some(p99)) = (p50, p90, p99) {
+                    stats_bar_pump
+                        .set_message(format!("p50: {}ms, p90: {}ms, p99: {}ms", p50, p90, p99));
+                }
+            }
+        });
+
+        Self {
+            chunk_bar,
+            rows_bar,
+            bytes_bar,
+            stats_bar,
+            pump,
+        }
+    }
+
+    /// Migrate clean path: await the pump (channel must already be
+    /// closed by the caller dropping its `telemetry_tx`), then
+    /// `finish_and_clear` the per-table bars so the next iteration's
+    /// bars render in the same screen position. Bars must NOT be
+    /// finalized while the pump is still writing to them — corrupts
+    /// the next bar's render.
+    pub async fn finish_clean(self) {
+        let _ = self.pump.await;
+        self.chunk_bar.finish_and_clear();
+        if let Some(bar) = self.rows_bar {
+            bar.finish_and_clear();
+        }
+        self.bytes_bar.finish_and_clear();
+        self.stats_bar.finish_and_clear();
+    }
+
+    /// Standalone-load termination: same pump-wait ordering as
+    /// `finish_clean`, but leave the bars visible (not cleared) so
+    /// the operator keeps the final state on screen. This is the
+    /// historical behavior of `setup_progress_tracking`'s pump exit.
+    pub async fn finish_standalone(self) {
+        let _ = self.pump.await;
+        self.chunk_bar.finish_with_message("All chunks completed");
+        if let Some(bar) = self.rows_bar {
+            bar.finish();
+        }
+        self.bytes_bar.finish();
+        self.stats_bar.finish();
+    }
+
+}
+
+/// Add the four per-load bars to `multi` and return them. Shared
+/// between [`LoadProgress::new`] and [`LoadProgress::within`] so the
+/// templates live in one place.
+fn build_load_bars(
+    multi: &MultiProgress,
+    file_metadata: &FileMetadata,
+    total_chunks: u64,
+) -> (ProgressBar, Option<ProgressBar>, ProgressBar, ProgressBar) {
+    let estimated_total_rows = file_metadata.estimated_rows.unwrap_or(0);
+
+    let chunk_bar = multi.add(ProgressBar::new(total_chunks));
+    chunk_bar.set_style(
+        ProgressStyle::default_bar()
+            .template(
+                "[{elapsed_precise}] Chunks:     [{bar:30.cyan/blue}] {pos}/{len} ({percent}%)",
+            )
+            .unwrap()
+            .progress_chars("=>-"),
+    );
+
+    let rows_bar = if estimated_total_rows > 0 {
+        let bar = multi.add(ProgressBar::new(estimated_total_rows));
+        bar.set_style(
+            ProgressStyle::default_bar()
+                .template(
+                    "[{elapsed_precise}] Rows:       [{bar:30.green/blue}] {human_pos}/{human_len} ({percent}%) | {per_sec}",
+                )
+                .unwrap()
+                .progress_chars("=>-"),
+        );
+        Some(bar)
+    } else {
+        None
+    };
+
+    let bytes_bar = multi.add(ProgressBar::new(file_metadata.file_size_bytes));
+    bytes_bar.set_style(
+        ProgressStyle::default_bar()
+            .template(
+                "[{elapsed_precise}] Bytes:      [{bar:30.yellow/blue}] {bytes}/{total_bytes} ({percent}%) | {bytes_per_sec}",
+            )
+            .unwrap()
+            .progress_chars("=>-"),
+    );
+
+    let stats_bar = multi.add(ProgressBar::new(0));
+    stats_bar.set_style(
+        ProgressStyle::default_bar()
+            .template("[{elapsed_precise}] Batch Time: {msg}")
+            .unwrap(),
+    );
+
+    (chunk_bar, rows_bar, bytes_bar, stats_bar)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indicatif::ProgressDrawTarget;
+
+    fn mk_block(schema: &str, table: &str, data_start: u64, data_end: u64) -> CopyBlock {
+        CopyBlock {
+            schema: schema.into(),
+            table: table.into(),
+            header_start: data_start.saturating_sub(1),
+            data_start,
+            data_end,
+            block_end: data_end + 2,
+            columns: vec!["id".into()],
+        }
+    }
+
+    /// `MigrateProgress::new` derives the dump totals straight from the
+    /// `CopyBlock` list — total tables = blocks.len(), total bytes =
+    /// sum of (data_end - data_start). Pinning so a future refactor of
+    /// `CopyBlock` field semantics surfaces here.
+    #[test]
+    fn migrate_progress_totals_from_blocks() {
+        let blocks = vec![
+            mk_block("public", "a", 100, 200),
+            mk_block("public", "b", 300, 1300),
+            mk_block("public", "c", 1400, 1450),
+        ];
+        let multi = MultiProgress::with_draw_target(ProgressDrawTarget::hidden());
+        let mp = MigrateProgress::with_multi(&blocks, multi);
+        assert_eq!(mp.tables_bar.length(), Some(3));
+        assert_eq!(mp.bytes_bar.length(), Some(100 + 1000 + 50));
+    }
+
+    /// `record_table_loaded` advances both persistent bars in lockstep.
+    #[test]
+    fn migrate_progress_records_advance_both_bars() {
+        let blocks = vec![
+            mk_block("public", "a", 0, 100),
+            mk_block("public", "b", 100, 300),
+        ];
+        let multi = MultiProgress::with_draw_target(ProgressDrawTarget::hidden());
+        let mp = MigrateProgress::with_multi(&blocks, multi);
+        mp.record_table_loaded(100);
+        assert_eq!(mp.tables_bar.position(), 1);
+        assert_eq!(mp.bytes_bar.position(), 100);
+        mp.record_table_loaded(200);
+        assert_eq!(mp.tables_bar.position(), 2);
+        assert_eq!(mp.bytes_bar.position(), 300);
+    }
+
+    /// `finish_halted` does NOT advance the bars — they freeze at the
+    /// last `record_table_loaded` position. Pin so a future "set to
+    /// total on halt" refactor surfaces.
+    #[test]
+    fn migrate_progress_finish_halted_freezes_position() {
+        let blocks = vec![
+            mk_block("public", "a", 0, 100),
+            mk_block("public", "b", 100, 300),
+        ];
+        let multi = MultiProgress::with_draw_target(ProgressDrawTarget::hidden());
+        let mp = MigrateProgress::with_multi(&blocks, multi);
+        mp.record_table_loaded(100);
+        mp.finish_halted("1 row failed");
+        assert_eq!(mp.tables_bar.position(), 1);
+        assert_eq!(mp.bytes_bar.position(), 100);
+    }
+
+    /// `LoadProgress::within` smoke: build, send one telemetry event,
+    /// drop the channel, await `finish_clean`. Exercises the full
+    /// lifecycle (insert → pump → drop → finalize) without any real
+    /// load. Pinned so a future change to the pump's drain semantics
+    /// or finish ordering surfaces.
+    #[tokio::test]
+    async fn load_progress_within_lifecycle_finishes_cleanly() {
+        let multi = MultiProgress::with_draw_target(ProgressDrawTarget::hidden());
+        let metadata = FileMetadata {
+            file_size_bytes: 1000,
+            estimated_rows: Some(50),
+        };
+        let (tx, rx) = mpsc::unbounded_channel();
+        let lp = LoadProgress::within(&multi, &metadata, 5, rx);
+
+        tx.send(TelemetryEvent::ChunkStarted).unwrap();
+        tx.send(TelemetryEvent::BatchLoaded {
+            records_loaded: 10,
+            bytes_processed: 200,
+            duration_ms: 42,
+        })
+        .unwrap();
+        drop(tx);
+
+        lp.finish_clean().await;
+    }
+
+}

--- a/src/coordination/progress.rs
+++ b/src/coordination/progress.rs
@@ -31,8 +31,6 @@ pub struct MigrateProgress {
 }
 
 impl MigrateProgress {
-    /// Totals: tables = `blocks.len()`, bytes = sum of
-    /// `data_end - data_start` over each block.
     pub fn new(blocks: &[CopyBlock]) -> Self {
         Self::with_multi(blocks, MultiProgress::new())
     }
@@ -175,10 +173,8 @@ impl LoadProgress {
         }
     }
 
-    /// Drain the pump (caller must have closed the channel) then clear
-    /// the bars so the next table's bars reuse the screen position.
-    /// Finalizing while the pump is still writing corrupts the next
-    /// bar's render.
+    /// Drain the pump before clearing — finalizing mid-write corrupts
+    /// the next table's render. Caller must have closed the channel.
     pub async fn finish_clean(self) {
         let _ = self.pump.await;
         self.chunk_bar.finish_and_clear();

--- a/src/coordination/progress.rs
+++ b/src/coordination/progress.rs
@@ -1,30 +1,18 @@
 //! Progress bar construction and lifecycle for both load and migrate flows.
 //!
-//! Two consumers:
-//! - `Coordinator::run_load` builds a [`LoadProgress`] either standalone
-//!   (its own `MultiProgress`) or `within` a parent `MultiProgress`
-//!   supplied by the migrate orchestrator.
-//! - `migrate::orchestrator::run_migrate` builds one [`MigrateProgress`]
-//!   for the whole-dump view and threads its `multi` handle into each
-//!   per-table load via `LoadConfig.parent_multi`.
-//!
 //! Bar layout during migrate (top → bottom):
 //! ```text
 //! [elapsed] Tables:     [bar] N/M (P%)              ← MigrateProgress, persistent
-//! [elapsed] Bytes:      [bar] X/Y (P%) | rate ETA Z ← MigrateProgress, persistent
+//! [elapsed] Dump Bytes: [bar] X/Y (P%) | rate ETA Z ← MigrateProgress, persistent
 //! [elapsed] Chunks:     [bar] n/m (P%)              ← LoadProgress, per-table
-//! [elapsed] Rows:       [bar] r/total (P%) | rate   ← LoadProgress, per-table (parquet only)
+//! [elapsed] Rows:       [bar] r/total (P%) | rate   ← LoadProgress, per-table (when row count is known)
 //! [elapsed] Bytes:      [bar] b/size (P%) | rate    ← LoadProgress, per-table
 //! [elapsed] Batch Time: p50/p90/p99                 ← LoadProgress, per-table
 //! ```
 //!
-//! Bar lifecycle (per table):
-//! 1. `LoadProgress::within` adds 4 bars below the 2 persistent ones.
-//! 2. Workers send `TelemetryEvent`s; the pump task updates the bars.
-//! 3. After the load returns, the channel is closed; the pump exits.
-//! 4. `LoadProgress::finish_clean` / `finish_halted` awaits the pump,
-//!    then either clears the per-table bars (clean) or freezes them
-//!    in place (halt) — see method docs for the ordering invariant.
+//! Bar lifecycle (per table): workers send telemetry → channel closes →
+//! pump drains → bars finalize. Finalizing while the pump is still
+//! writing corrupts the next render (see `LoadProgress::finish_clean`).
 
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use std::sync::Arc;
@@ -34,12 +22,8 @@ use crate::formats::pgdump::CopyBlock;
 use crate::formats::reader::FileMetadata;
 use crate::telemetry::{ProgressStats, TelemetryEvent};
 
-/// Whole-dump progress view used by the migrate orchestrator.
-///
-/// Holds two persistent bars (Tables, Bytes) plus a shared
-/// `MultiProgress` handle that per-table [`LoadProgress`] instances
-/// attach to. Constructed once at the top of `run_migrate` and lives
-/// for the duration of the per-table loop.
+/// Whole-dump progress view: two persistent bars (Tables, Dump Bytes)
+/// plus the `MultiProgress` that per-table [`LoadProgress`] attach to.
 pub struct MigrateProgress {
     multi: Arc<MultiProgress>,
     tables_bar: ProgressBar,
@@ -47,16 +31,14 @@ pub struct MigrateProgress {
 }
 
 impl MigrateProgress {
-    /// Build the migrate-wide progress view from the resolved
-    /// `CopyBlock` list. `total_bytes` sums each block's data payload
-    /// (`data_end - data_start`) — already produced by `list_copy_blocks`.
+    /// Totals: tables = `blocks.len()`, bytes = sum of
+    /// `data_end - data_start` over each block.
     pub fn new(blocks: &[CopyBlock]) -> Self {
         Self::with_multi(blocks, MultiProgress::new())
     }
 
-    /// Test/internal constructor: callers can supply a `MultiProgress`
-    /// with `ProgressDrawTarget::hidden()` so `cargo test` doesn't
-    /// stream bars to stderr.
+    /// Test seam: pass a `ProgressDrawTarget::hidden()`-backed
+    /// `MultiProgress` so `cargo test` doesn't stream bars to stderr.
     pub fn with_multi(blocks: &[CopyBlock], multi: MultiProgress) -> Self {
         let total_tables = blocks.len() as u64;
         let total_bytes: u64 = blocks.iter().map(|b| b.data_end - b.data_start).sum();
@@ -88,30 +70,26 @@ impl MigrateProgress {
         }
     }
 
-    /// Shared `MultiProgress` handle for per-table [`LoadProgress`]
-    /// instances to attach to via [`LoadProgress::within`].
+    /// Handle for per-table [`LoadProgress`] instances to attach to.
     pub fn multi(&self) -> Arc<MultiProgress> {
         Arc::clone(&self.multi)
     }
 
-    /// Advance the persistent bars after a clean per-table load.
     pub fn record_table_loaded(&self, block_bytes: u64) {
         self.tables_bar.inc(1);
         self.bytes_bar.inc(block_bytes);
     }
 
-    /// Close the run cleanly: finish both persistent bars at full
-    /// position so the live render is closed before the orchestrator's
-    /// caller (e.g. `main.rs`'s "Loaded tables:" summary) prints.
+    /// Close the persistent bars before the caller prints any trailing
+    /// stdout — otherwise indicatif's live render corrupts that print.
     pub fn finish_clean(&self) {
         self.tables_bar.finish_with_message("done");
         self.bytes_bar.finish_with_message("done");
     }
 
-    /// Close the run on a halting iteration: freeze both persistent
-    /// bars at their current position with a "halted" message. The
-    /// per-table `LoadProgress` for the halting table is finalized
-    /// independently via [`LoadProgress::finish_halted`].
+    /// Freeze both persistent bars at their current position. The
+    /// halting table's per-load bars are finalized inside
+    /// `Coordinator::run_load` before this is called.
     pub fn finish_halted(&self, reason: &str) {
         self.tables_bar
             .abandon_with_message(format!("halted: {reason}"));
@@ -121,9 +99,7 @@ impl MigrateProgress {
 }
 
 /// Per-load progress: 4 bars (chunks / rows / bytes / batch-time) plus
-/// the telemetry pump task that drives them. Constructed by
-/// `Coordinator::run_load` either standalone or attached to a parent
-/// `MultiProgress` from [`MigrateProgress`].
+/// the telemetry pump task that drives them.
 pub struct LoadProgress {
     chunk_bar: ProgressBar,
     rows_bar: Option<ProgressBar>,
@@ -133,9 +109,8 @@ pub struct LoadProgress {
 }
 
 impl LoadProgress {
-    /// Standalone-load path: build a fresh `MultiProgress` and 4 bars,
-    /// spawn the pump task. Equivalent to the previous
-    /// `setup_progress_tracking` body.
+    /// Standalone-load path: own `MultiProgress`, leave bars visible
+    /// after `finish_standalone`.
     pub fn new(
         file_metadata: &FileMetadata,
         total_chunks: u64,
@@ -149,8 +124,8 @@ impl LoadProgress {
         )
     }
 
-    /// Migrate path: attach 4 bars to the caller's `MultiProgress` so
-    /// they render below the persistent dump-wide bars.
+    /// Attach 4 bars to an existing `MultiProgress`; bars render in
+    /// `add` order, so the dump-wide bars must already be inserted.
     pub fn within(
         parent: &MultiProgress,
         file_metadata: &FileMetadata,
@@ -200,12 +175,10 @@ impl LoadProgress {
         }
     }
 
-    /// Migrate clean path: await the pump (channel must already be
-    /// closed by the caller dropping its `telemetry_tx`), then
-    /// `finish_and_clear` the per-table bars so the next iteration's
-    /// bars render in the same screen position. Bars must NOT be
-    /// finalized while the pump is still writing to them — corrupts
-    /// the next bar's render.
+    /// Drain the pump (caller must have closed the channel) then clear
+    /// the bars so the next table's bars reuse the screen position.
+    /// Finalizing while the pump is still writing corrupts the next
+    /// bar's render.
     pub async fn finish_clean(self) {
         let _ = self.pump.await;
         self.chunk_bar.finish_and_clear();
@@ -216,10 +189,8 @@ impl LoadProgress {
         self.stats_bar.finish_and_clear();
     }
 
-    /// Standalone-load termination: same pump-wait ordering as
-    /// `finish_clean`, but leave the bars visible (not cleared) so
-    /// the operator keeps the final state on screen. This is the
-    /// historical behavior of `setup_progress_tracking`'s pump exit.
+    /// Same pump-wait ordering as `finish_clean`, but leave bars
+    /// visible so the operator keeps the final state on screen.
     pub async fn finish_standalone(self) {
         let _ = self.pump.await;
         self.chunk_bar.finish_with_message("All chunks completed");
@@ -231,9 +202,6 @@ impl LoadProgress {
     }
 }
 
-/// Add the four per-load bars to `multi` and return them. Shared
-/// between [`LoadProgress::new`] and [`LoadProgress::within`] so the
-/// templates live in one place.
 fn build_load_bars(
     multi: &MultiProgress,
     file_metadata: &FileMetadata,
@@ -303,10 +271,7 @@ mod tests {
         }
     }
 
-    /// `MigrateProgress::new` derives the dump totals straight from the
-    /// `CopyBlock` list — total tables = blocks.len(), total bytes =
-    /// sum of (data_end - data_start). Pinning so a future refactor of
-    /// `CopyBlock` field semantics surfaces here.
+    /// Pins: tables = `blocks.len()`, bytes = `sum(data_end - data_start)`.
     #[test]
     fn migrate_progress_totals_from_blocks() {
         let blocks = vec![
@@ -320,7 +285,6 @@ mod tests {
         assert_eq!(mp.bytes_bar.length(), Some(100 + 1000 + 50));
     }
 
-    /// `record_table_loaded` advances both persistent bars in lockstep.
     #[test]
     fn migrate_progress_records_advance_both_bars() {
         let blocks = vec![
@@ -337,9 +301,8 @@ mod tests {
         assert_eq!(mp.bytes_bar.position(), 300);
     }
 
-    /// `finish_halted` does NOT advance the bars — they freeze at the
-    /// last `record_table_loaded` position. Pin so a future "set to
-    /// total on halt" refactor surfaces.
+    /// Pins freeze-on-halt: bars stay at the last `record_table_loaded`
+    /// position rather than advancing to total.
     #[test]
     fn migrate_progress_finish_halted_freezes_position() {
         let blocks = vec![
@@ -354,11 +317,8 @@ mod tests {
         assert_eq!(mp.bytes_bar.position(), 100);
     }
 
-    /// `LoadProgress::within` smoke: build, send one telemetry event,
-    /// drop the channel, await `finish_clean`. Exercises the full
-    /// lifecycle (insert → pump → drop → finalize) without any real
-    /// load. Pinned so a future change to the pump's drain semantics
-    /// or finish ordering surfaces.
+    /// Smoke: build → send event → drop tx → `finish_clean` must not
+    /// panic. Catches regressions in the pump-drain-then-finalize order.
     #[tokio::test]
     async fn load_progress_within_lifecycle_finishes_cleanly() {
         let multi = MultiProgress::with_draw_target(ProgressDrawTarget::hidden());

--- a/src/migrate/orchestrator.rs
+++ b/src/migrate/orchestrator.rs
@@ -9,6 +9,7 @@ use crate::formats::pgdump::{extract_ddl, list_copy_blocks};
 use crate::io::{ByteReader, LocalFileByteReader, S3ByteReader, SourceUri};
 use crate::migrate::apply::{AppliedStatement, apply_ddl};
 use crate::migrate::transform::{Diagnostic, TransformResult, transform_ddl};
+use crate::coordination::MigrateProgress;
 use crate::runner::{Format, LoadArgs, OnConflict, run_load_with_pool_for_pgdump_block};
 use anyhow::{Context, Result};
 use aws_config::{BehaviorVersion, Region};
@@ -174,12 +175,23 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
         .await
         .context("Failed to apply DDL to cluster")?;
 
+    // Whole-dump progress view: 2 persistent bars (Tables, Bytes) plus
+    // the shared MultiProgress that per-table LoadProgress instances
+    // attach to. None when --quiet so the inner per-table loads also
+    // stay silent (parent_multi=None propagates that intent).
+    let migrate_progress = if args.quiet {
+        None
+    } else {
+        Some(MigrateProgress::new(&blocks))
+    };
+
     // Halt on the first table with `records_failed > 0`. DSQL doesn't
     // enforce FKs, so continuing would silently load child rows against
     // a partially-loaded parent and the final report would look healthy.
     // The pre-resolved `blocks` and `aws_config` are threaded through so
     // each load skips the dump rescan + credential-chain walk.
     let mut tables = Vec::with_capacity(blocks.len());
+    let mut halted = false;
     for block in &blocks {
         let load_args = build_load_args(&args, &block.table, &block.schema);
         let r = run_load_with_pool_for_pgdump_block(
@@ -187,6 +199,7 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
             load_args,
             block.clone(),
             aws_config.as_ref(),
+            migrate_progress.as_ref().map(MigrateProgress::multi),
         )
         .await
         .with_context(|| {
@@ -197,6 +210,7 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
             )
         })?;
         let records_failed = r.records_failed;
+        let block_bytes = block.data_end - block.data_start;
         tables.push(TableLoadSummary {
             schema: block.schema.clone(),
             table: block.table.clone(),
@@ -205,8 +219,24 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
             persisted_manifest_dir: r.persisted_manifest_dir,
         });
         if records_failed > 0 {
+            if let Some(mp) = &migrate_progress {
+                mp.finish_halted(&format!(
+                    "{schema}.{table}: {n} rows failed",
+                    schema = block.schema,
+                    table = block.table,
+                    n = records_failed,
+                ));
+            }
+            halted = true;
             break;
         }
+        if let Some(mp) = &migrate_progress {
+            mp.record_table_loaded(block_bytes);
+        }
+    }
+
+    if !halted && let Some(mp) = &migrate_progress {
+        mp.finish_clean();
     }
 
     Ok(MigrateReport {
@@ -771,5 +801,80 @@ COPY public.valid_first (id) FROM stdin;
             .unwrap()[0]
             .0;
         assert_eq!(row_count, 0);
+    }
+
+    /// Pin: `quiet=false` migrate exercises the bar-construction path
+    /// (LoadProgress::within + MigrateProgress) without panicking and
+    /// returns the same report shape as the quiet path. This is the
+    /// regression guard for the "no bars at all → bars under a parent
+    /// MultiProgress" lifecycle: insert → pump → drop tx → join pump
+    /// → finish_clean → record_table_loaded → dump-wide finish_clean.
+    /// `cargo test`'s captured stderr swallows the actual render so we
+    /// can't assert on output, but exercising the path catches panics
+    /// from bar misuse (e.g. finish-before-pump-join, double-finish).
+    #[tokio::test]
+    async fn run_migrate_quiet_false_drives_progress_lifecycle_without_panicking() {
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        let dump = write_dump(
+            "\
+CREATE TABLE a (id INTEGER, x TEXT);
+CREATE TABLE b (id INTEGER, x TEXT);
+COPY public.a (id, x) FROM stdin;
+1\tone
+2\ttwo
+\\.
+COPY public.b (id, x) FROM stdin;
+1\talpha
+\\.
+",
+        );
+        let mut args = args_with_pool(&file_uri(dump.path()), pool, false);
+        args.quiet = false;
+
+        let report = run_migrate(args).await.unwrap();
+        assert_eq!(report.tables.len(), 2);
+        assert_eq!(report.tables[0].records_loaded, 2);
+        assert_eq!(report.tables[1].records_loaded, 1);
+        for t in &report.tables {
+            assert_eq!(t.records_failed, 0);
+        }
+    }
+
+    /// Halt path under `quiet=false`: dump-wide bars get
+    /// finish_halted, the per-table bar for the failing iteration is
+    /// already finalized inside run_load (LoadProgress::finish_clean
+    /// runs before records_failed is observed). Pin so a future
+    /// refactor that finalizes the migrate progress before the halt
+    /// branch surfaces here.
+    #[tokio::test]
+    async fn run_migrate_quiet_false_halts_on_records_failed_without_panicking() {
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        // Pre-create with PK, seed a row that the dump will conflict with.
+        pool.execute_query("CREATE TABLE t (id INTEGER PRIMARY KEY, x TEXT)")
+            .await
+            .unwrap();
+        pool.execute_query("INSERT INTO t VALUES (1, 'pre1')")
+            .await
+            .unwrap();
+
+        let dump = write_dump(
+            "\
+COPY public.t (id, x) FROM stdin;
+1\ta
+\\.
+COPY public.t (id, x) FROM stdin;
+2\tb
+\\.
+",
+        );
+        let mut args = args_with_pool(&file_uri(dump.path()), pool, false);
+        args.quiet = false;
+        args.on_conflict = OnConflict::Error;
+
+        let report = run_migrate(args).await.unwrap();
+        // First COPY block hits the duplicate → records_failed > 0 → halt
+        // before the second COPY block runs.
+        assert_eq!(report.tables.len(), 1, "halt must skip the second block");
+        assert!(report.tables[0].records_failed > 0);
     }
 }

--- a/src/migrate/orchestrator.rs
+++ b/src/migrate/orchestrator.rs
@@ -175,10 +175,8 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
         .await
         .context("Failed to apply DDL to cluster")?;
 
-    // Whole-dump progress view: 2 persistent bars (Tables, Bytes) plus
-    // the shared MultiProgress that per-table LoadProgress instances
-    // attach to. None when --quiet so the inner per-table loads also
-    // stay silent (parent_multi=None propagates that intent).
+    // None under `--quiet` so per-table loads inherit silence via
+    // `parent_multi = None`.
     let migrate_progress = if args.quiet {
         None
     } else {
@@ -803,15 +801,9 @@ COPY public.valid_first (id) FROM stdin;
         assert_eq!(row_count, 0);
     }
 
-    /// Pin: `quiet=false` migrate exercises the bar-construction path
-    /// (LoadProgress::within + MigrateProgress) without panicking and
-    /// returns the same report shape as the quiet path. This is the
-    /// regression guard for the "no bars at all → bars under a parent
-    /// MultiProgress" lifecycle: insert → pump → drop tx → join pump
-    /// → finish_clean → record_table_loaded → dump-wide finish_clean.
-    /// `cargo test`'s captured stderr swallows the actual render so we
-    /// can't assert on output, but exercising the path catches panics
-    /// from bar misuse (e.g. finish-before-pump-join, double-finish).
+    /// `quiet=false` smoke: captured stderr hides the render, so this
+    /// only catches panic-class bar misuse (finish-before-pump-join,
+    /// double-finish) plus pins the report shape.
     #[tokio::test]
     async fn run_migrate_quiet_false_drives_progress_lifecycle_without_panicking() {
         let pool = Pool::sqlite_in_memory().await.unwrap();
@@ -840,12 +832,8 @@ COPY public.b (id, x) FROM stdin;
         }
     }
 
-    /// Halt path under `quiet=false`: dump-wide bars get
-    /// finish_halted, the per-table bar for the failing iteration is
-    /// already finalized inside run_load (LoadProgress::finish_clean
-    /// runs before records_failed is observed). Pin so a future
-    /// refactor that finalizes the migrate progress before the halt
-    /// branch surfaces here.
+    /// Pins ordering: the per-table bar is finalized inside `run_load`
+    /// before `records_failed` is observed by the orchestrator.
     #[tokio::test]
     async fn run_migrate_quiet_false_halts_on_records_failed_without_panicking() {
         let pool = Pool::sqlite_in_memory().await.unwrap();
@@ -872,8 +860,6 @@ COPY public.t (id, x) FROM stdin;
         args.on_conflict = OnConflict::Error;
 
         let report = run_migrate(args).await.unwrap();
-        // First COPY block hits the duplicate → records_failed > 0 → halt
-        // before the second COPY block runs.
         assert_eq!(report.tables.len(), 1, "halt must skip the second block");
         assert!(report.tables[0].records_failed > 0);
     }

--- a/src/migrate/orchestrator.rs
+++ b/src/migrate/orchestrator.rs
@@ -3,13 +3,13 @@
 //! table — all against a single shared `Pool` so the production path
 //! pays the IAM/connection-establishment cost only once.
 
+use crate::coordination::MigrateProgress;
 use crate::db::Pool;
 use crate::db::pool::{PoolArgsBuilder, pool as build_dsql_pool};
 use crate::formats::pgdump::{extract_ddl, list_copy_blocks};
 use crate::io::{ByteReader, LocalFileByteReader, S3ByteReader, SourceUri};
 use crate::migrate::apply::{AppliedStatement, apply_ddl};
 use crate::migrate::transform::{Diagnostic, TransformResult, transform_ddl};
-use crate::coordination::MigrateProgress;
 use crate::runner::{Format, LoadArgs, OnConflict, run_load_with_pool_for_pgdump_block};
 use anyhow::{Context, Result};
 use aws_config::{BehaviorVersion, Region};

--- a/src/migrate/orchestrator.rs
+++ b/src/migrate/orchestrator.rs
@@ -175,8 +175,8 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
         .await
         .context("Failed to apply DDL to cluster")?;
 
-    // None under `--quiet` so per-table loads inherit silence via
-    // `parent_multi = None`.
+    // None under `--quiet` skips the dump-wide bars; per-table silence
+    // rides independently on `LoadArgs.quiet` set in `build_load_args`.
     let migrate_progress = if args.quiet {
         None
     } else {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -262,8 +262,15 @@ pub(crate) async fn run_load_with_pool(
         }
     };
 
-    run_load_with_pool_and_reader(pool, args, file_reader, pgdump_columns, delimited_config, None)
-        .await
+    run_load_with_pool_and_reader(
+        pool,
+        args,
+        file_reader,
+        pgdump_columns,
+        delimited_config,
+        None,
+    )
+    .await
 }
 
 /// Migrate-only entry point: load one pg_dump COPY block using a

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -262,7 +262,8 @@ pub(crate) async fn run_load_with_pool(
         }
     };
 
-    run_load_with_pool_and_reader(pool, args, file_reader, pgdump_columns, delimited_config).await
+    run_load_with_pool_and_reader(pool, args, file_reader, pgdump_columns, delimited_config, None)
+        .await
 }
 
 /// Migrate-only entry point: load one pg_dump COPY block using a
@@ -280,6 +281,7 @@ pub(crate) async fn run_load_with_pool_for_pgdump_block(
     args: LoadArgs,
     block: CopyBlock,
     aws_config: Option<&aws_config::SdkConfig>,
+    parent_multi: Option<std::sync::Arc<indicatif::MultiProgress>>,
 ) -> Result<LoadResult> {
     validate_load_args(&args)?;
 
@@ -302,7 +304,15 @@ pub(crate) async fn run_load_with_pool_for_pgdump_block(
         }
     };
 
-    run_load_with_pool_and_reader(pool, args, file_reader, pgdump_columns, delimited_config).await
+    run_load_with_pool_and_reader(
+        pool,
+        args,
+        file_reader,
+        pgdump_columns,
+        delimited_config,
+        parent_multi,
+    )
+    .await
 }
 
 async fn run_load_with_pool_and_reader(
@@ -311,6 +321,7 @@ async fn run_load_with_pool_and_reader(
     file_reader: Arc<dyn crate::formats::reader::FileReader>,
     pgdump_columns: Vec<String>,
     delimited_config: Option<DelimitedConfig>,
+    parent_multi: Option<std::sync::Arc<indicatif::MultiProgress>>,
 ) -> Result<LoadResult> {
     // Set up manifest directory (use temp dir if not provided)
     let (mut temp_dir, manifest_dir_path) = if let Some(dir) = args.manifest_dir {
@@ -364,6 +375,7 @@ async fn run_load_with_pool_and_reader(
         .resume_job_id(args.resume_job_id)
         .on_conflict(args.on_conflict)
         .exclude_columns(args.exclude_columns)
+        .parent_multi(parent_multi)
         .build()?;
 
     let result = coordinator.run_load(&load_config).await?;


### PR DESCRIPTION
## Summary

- Migrate now shows two persistent dump-wide bars (Tables N/M, Dump Bytes X/Y with ETA) plus the same four per-table bars the standalone `load` command already has — closing the silence between "applying DDL" and the final "Loaded tables:" summary.
- All `indicatif` construction extracted into a new `coordination::progress` module (`MigrateProgress`, `LoadProgress`) so the load and migrate flows share one implementation. The standalone `load` command is unchanged on the surface — its bars come from the same builder helper now.
- `--quiet` continues to suppress every bar end-to-end. No new flags.

## What it looks like

**Load command (unchanged — same 4 bars, just refactored under the hood):**

```
[00:00:42] Chunks:     [============================>-]  47/50  (94%)
[00:00:42] Rows:       [===========================>--]  4.5M/4.8M (93%) | 107k/s
[00:00:42] Bytes:      [===========================>--]  9.4MB/10MB (94%) | 226KB/s
[00:00:42] Batch Time: p50: 38ms, p90: 84ms, p99: 198ms
```

**Migrate command (new — 2 persistent dump bars + 4 per-table bars):**

```
[00:14:23] Tables:     [============>-----------------]  12/47  (25%)
[00:14:23] Dump Bytes: [=========>--------------------] 14.2GB/47.0GB (30%) | 16.8MB/s ETA 28m
[00:00:38] Chunks:     [================>-------------]   8/15  (53%)
[00:00:38] Bytes:      [================>-------------] 720MB/1.2GB (60%) | 19MB/s
[00:00:38] Batch Time: p50: 42ms, p90: 88ms, p99: 210ms
```

The top two bars persist across the whole migrate run; the bottom four are scoped to the *currently loading* table and clear between tables — so when `public.events` finishes and `public.orders` starts, the per-table bars reset under the same persistent two.

**Halt path (when `records_failed > 0` on a table):**

```
[00:14:23] Tables:     [============>-----------------]  12/47   halted: public.events: 1234 rows failed
[00:14:23] Dump Bytes: [=========>--------------------] 14.2GB/47.0GB halted: public.events: 1234 rows failed
```

The dump-wide bars freeze at the position they had when the failing table was reached, with a message naming the table and failed-row count.

## Threading

`LoadConfig` gains an optional `parent_multi: Option<Arc<MultiProgress>>`. When `Some` (migrate path) `LoadProgress::within` attaches the four bars to the orchestrator's shared `MultiProgress` so they render below the persistent dump bars; when `None` (standalone path) `LoadProgress::new` constructs its own. The `pub(crate)` `run_load_with_pool_for_pgdump_block` takes a parallel parameter; the public CLI surface is unchanged.

## Lifecycle invariant

Per-iteration ordering is load-bearing: workers drop their telemetry tx → channel closes → pump task drains → bars are finalized. `LoadProgress::finish_clean` / `finish_standalone` `await` the pump first, then `finish_and_clear` (migrate, so the next table reuses the screen position) or `finish_with_message` (standalone, leave visible).

## Test plan

- [x] `cargo test --lib` — 246/246 passing (244 pre-existing + 2 new orchestrator pins).
- [x] `cargo clippy --lib --tests` — clean.
- [x] `cargo fmt -- --check` — clean.
- [x] New `progress.rs` unit tests cover totals from `CopyBlock`, `record_table_loaded` advancing both bars, `finish_halted` freezing position, and `LoadProgress::within` lifecycle (insert → pump → drop → finalize).
- [x] New orchestrator tests pin `quiet=false` happy path and halt-on-records_failed path — exercises the bar lifecycle without panic, validates report shape unchanged.
- [ ] Manual smoke against a multi-table pg_dump fixture — verify bar layout, ETA, and that the "Loaded tables:" summary doesn't overlap the live render on a TTY.