### PR TITLE
fix(progress,verify): defensible PR #33/#34 review follow-ups

### DIFF
--- a/src/coordination/coordinator.rs
+++ b/src/coordination/coordinator.rs
@@ -279,7 +279,7 @@ pub struct LoadConfig {
     /// `Some` attaches bars to the caller's `MultiProgress`; `None`
     /// builds its own. `quiet` overrides both to no bars.
     #[builder(default)]
-    parent_multi: Option<Arc<MultiProgress>>,
+    parent_multi: Option<MultiProgress>,
 }
 
 /// Result of a completed data load operation
@@ -352,7 +352,7 @@ impl Coordinator {
             let total_chunks = chunks.len() as u64;
             Some(match &config.parent_multi {
                 Some(parent) => {
-                    LoadProgress::within(parent, &file_metadata, total_chunks, telemetry_rx)
+                    LoadProgress::within(parent.clone(), &file_metadata, total_chunks, telemetry_rx)
                 }
                 None => LoadProgress::new(&file_metadata, total_chunks, telemetry_rx),
             })
@@ -365,7 +365,7 @@ impl Coordinator {
         // workers finished → channel closed → pump drains → bars finalize.
         if let Some(lp) = load_progress {
             if config.parent_multi.is_some() {
-                lp.finish_clean().await;
+                lp.finish_and_clear().await;
             } else {
                 lp.finish_standalone().await;
             }
@@ -1113,6 +1113,17 @@ mod aggregate_tests {
             mk_chunk_result(2, Some(10)),
         ];
         assert_eq!(aggregate_source_rows(&results, 3), None);
+    }
+
+    #[test]
+    fn aggregate_source_rows_overflow_returns_none() {
+        // Adversarial parquet footer: u64::MAX + 1 must demote to None
+        // (checked_add), not wrap to a small number that fakes a Match.
+        let results = vec![
+            mk_chunk_result(0, Some(u64::MAX)),
+            mk_chunk_result(1, Some(1)),
+        ];
+        assert_eq!(aggregate_source_rows(&results, 2), None);
     }
 }
 

--- a/src/coordination/progress.rs
+++ b/src/coordination/progress.rs
@@ -12,10 +12,9 @@
 //!
 //! Bar lifecycle (per table): workers send telemetry → channel closes →
 //! pump drains → bars finalize. Finalizing while the pump is still
-//! writing corrupts the next render (see `LoadProgress::finish_clean`).
+//! writing corrupts the next render (see `LoadProgress::finish_and_clear`).
 
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use std::sync::Arc;
 use tokio::sync::mpsc;
 
 use crate::formats::pgdump::CopyBlock;
@@ -25,7 +24,7 @@ use crate::telemetry::{ProgressStats, TelemetryEvent};
 /// Whole-dump progress view: two persistent bars (Tables, Dump Bytes)
 /// plus the `MultiProgress` that per-table [`LoadProgress`] attach to.
 pub struct MigrateProgress {
-    multi: Arc<MultiProgress>,
+    multi: MultiProgress,
     tables_bar: ProgressBar,
     bytes_bar: ProgressBar,
 }
@@ -62,15 +61,15 @@ impl MigrateProgress {
         );
 
         Self {
-            multi: Arc::new(multi),
+            multi,
             tables_bar,
             bytes_bar,
         }
     }
 
     /// Handle for per-table [`LoadProgress`] instances to attach to.
-    pub fn multi(&self) -> Arc<MultiProgress> {
-        Arc::clone(&self.multi)
+    pub fn multi(&self) -> MultiProgress {
+        self.multi.clone()
     }
 
     pub fn record_table_loaded(&self, block_bytes: u64) {
@@ -78,9 +77,9 @@ impl MigrateProgress {
         self.bytes_bar.inc(block_bytes);
     }
 
-    /// Close the persistent bars before the caller prints any trailing
-    /// stdout — otherwise indicatif's live render corrupts that print.
-    pub fn finish_clean(&self) {
+    /// Finish the persistent bars "done", leaving them visible. Call
+    /// before any trailing stdout so the live render doesn't corrupt it.
+    pub fn finish_visible(&self) {
         self.tables_bar.finish_with_message("done");
         self.bytes_bar.finish_with_message("done");
     }
@@ -96,9 +95,26 @@ impl MigrateProgress {
     }
 }
 
+impl Drop for MigrateProgress {
+    /// Safety net for `?`-unwind out of the migrate loop: abandon any
+    /// still-live bar so it doesn't interleave with the printed error.
+    /// No-op once `finish_visible`/`finish_halted` has run.
+    fn drop(&mut self) {
+        if !self.tables_bar.is_finished() {
+            self.tables_bar.abandon_with_message("interrupted");
+        }
+        if !self.bytes_bar.is_finished() {
+            self.bytes_bar.abandon_with_message("interrupted");
+        }
+    }
+}
+
 /// Per-load progress: 4 bars (chunks / rows / bytes / batch-time) plus
-/// the telemetry pump task that drives them.
+/// the telemetry pump task that drives them. Keeps its `MultiProgress`
+/// so the embedded path can `remove` finished bars (clearing alone
+/// leaves zombies that pile up across a multi-table migrate).
 pub struct LoadProgress {
+    multi: MultiProgress,
     chunk_bar: ProgressBar,
     rows_bar: Option<ProgressBar>,
     bytes_bar: ProgressBar,
@@ -115,7 +131,7 @@ impl LoadProgress {
         telemetry_rx: mpsc::UnboundedReceiver<TelemetryEvent>,
     ) -> Self {
         Self::with_multi(
-            &MultiProgress::new(),
+            MultiProgress::new(),
             file_metadata,
             total_chunks,
             telemetry_rx,
@@ -125,7 +141,7 @@ impl LoadProgress {
     /// Attach 4 bars to an existing `MultiProgress`; bars render in
     /// `add` order, so the dump-wide bars must already be inserted.
     pub fn within(
-        parent: &MultiProgress,
+        parent: MultiProgress,
         file_metadata: &FileMetadata,
         total_chunks: u64,
         telemetry_rx: mpsc::UnboundedReceiver<TelemetryEvent>,
@@ -134,13 +150,13 @@ impl LoadProgress {
     }
 
     fn with_multi(
-        multi: &MultiProgress,
+        multi: MultiProgress,
         file_metadata: &FileMetadata,
         total_chunks: u64,
         mut telemetry_rx: mpsc::UnboundedReceiver<TelemetryEvent>,
     ) -> Self {
         let (chunk_bar, rows_bar, bytes_bar, stats_bar) =
-            build_load_bars(multi, file_metadata, total_chunks);
+            build_load_bars(&multi, file_metadata, total_chunks);
 
         let chunk_bar_pump = chunk_bar.clone();
         let rows_bar_pump = rows_bar.clone();
@@ -165,6 +181,7 @@ impl LoadProgress {
         });
 
         Self {
+            multi,
             chunk_bar,
             rows_bar,
             bytes_bar,
@@ -173,28 +190,44 @@ impl LoadProgress {
         }
     }
 
-    /// Drain the pump before clearing — finalizing mid-write corrupts
-    /// the next table's render. Caller must have closed the channel.
-    pub async fn finish_clean(self) {
-        let _ = self.pump.await;
-        self.chunk_bar.finish_and_clear();
-        if let Some(bar) = self.rows_bar {
+    /// Drain the pump, then clear and remove each bar (embedded/migrate
+    /// path). Caller must have closed the channel first.
+    pub async fn finish_and_clear(mut self) {
+        self.join_pump().await;
+        for bar in self.bars() {
             bar.finish_and_clear();
+            self.multi.remove(&bar);
         }
-        self.bytes_bar.finish_and_clear();
-        self.stats_bar.finish_and_clear();
     }
 
-    /// Same pump-wait ordering as `finish_clean`, but leave bars
+    /// Same pump-wait ordering as `finish_and_clear`, but leave bars
     /// visible so the operator keeps the final state on screen.
-    pub async fn finish_standalone(self) {
-        let _ = self.pump.await;
+    pub async fn finish_standalone(mut self) {
+        self.join_pump().await;
         self.chunk_bar.finish_with_message("All chunks completed");
-        if let Some(bar) = self.rows_bar {
+        if let Some(bar) = &self.rows_bar {
             bar.finish();
         }
         self.bytes_bar.finish();
         self.stats_bar.finish();
+    }
+
+    fn bars(&self) -> Vec<ProgressBar> {
+        let mut v = vec![self.chunk_bar.clone()];
+        v.extend(self.rows_bar.clone());
+        v.push(self.bytes_bar.clone());
+        v.push(self.stats_bar.clone());
+        v
+    }
+
+    /// Await the pump, surfacing a panic instead of swallowing it — a
+    /// panicked pump means bar positions silently stopped advancing.
+    async fn join_pump(&mut self) {
+        if let Err(e) = (&mut self.pump).await
+            && e.is_panic()
+        {
+            tracing::error!(error = %e, "progress pump panicked; bar positions may under-count");
+        }
     }
 }
 
@@ -313,7 +346,7 @@ mod tests {
         assert_eq!(mp.bytes_bar.position(), 100);
     }
 
-    /// Smoke: build → send event → drop tx → `finish_clean` must not
+    /// Smoke: build → send event → drop tx → `finish_and_clear` must not
     /// panic. Catches regressions in the pump-drain-then-finalize order.
     #[tokio::test]
     async fn load_progress_within_lifecycle_finishes_cleanly() {
@@ -323,7 +356,7 @@ mod tests {
             estimated_rows: Some(50),
         };
         let (tx, rx) = mpsc::unbounded_channel();
-        let lp = LoadProgress::within(&multi, &metadata, 5, rx);
+        let lp = LoadProgress::within(multi, &metadata, 5, rx);
 
         tx.send(TelemetryEvent::ChunkStarted).unwrap();
         tx.send(TelemetryEvent::BatchLoaded {
@@ -334,6 +367,53 @@ mod tests {
         .unwrap();
         drop(tx);
 
-        lp.finish_clean().await;
+        lp.finish_and_clear().await;
+    }
+
+    /// Standalone path (own `MultiProgress`, `finish_standalone`) — the
+    /// entire non-migrate `load` surface, otherwise only covered via
+    /// `within`.
+    #[tokio::test]
+    async fn load_progress_standalone_lifecycle_finishes_cleanly() {
+        let metadata = FileMetadata {
+            file_size_bytes: 1000,
+            estimated_rows: Some(50),
+        };
+        let (tx, rx) = mpsc::unbounded_channel();
+        let lp = LoadProgress::new(&metadata, 5, rx);
+
+        tx.send(TelemetryEvent::BatchLoaded {
+            records_loaded: 10,
+            bytes_processed: 200,
+            duration_ms: 42,
+        })
+        .unwrap();
+        drop(tx);
+
+        lp.finish_standalone().await;
+    }
+
+    /// `estimated_rows: None` → no rows bar; finalizers must skip the
+    /// absent bar without panicking.
+    #[tokio::test]
+    async fn load_progress_without_rows_bar_finishes_cleanly() {
+        let multi = MultiProgress::with_draw_target(ProgressDrawTarget::hidden());
+        let metadata = FileMetadata {
+            file_size_bytes: 1000,
+            estimated_rows: None,
+        };
+        let (tx, rx) = mpsc::unbounded_channel();
+        let lp = LoadProgress::within(multi, &metadata, 5, rx);
+        assert!(lp.rows_bar.is_none());
+
+        tx.send(TelemetryEvent::BatchLoaded {
+            records_loaded: 10,
+            bytes_processed: 200,
+            duration_ms: 42,
+        })
+        .unwrap();
+        drop(tx);
+
+        lp.finish_and_clear().await;
     }
 }

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -489,3 +489,26 @@ impl Executor<'_> for &'_ Pool {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Embedded `"` must be doubled so it can't break out of the quoted
+    /// identifier — defense in depth behind the upstream validator.
+    #[tokio::test]
+    async fn qualified_table_name_escapes_embedded_quote() {
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        // SQLite path quotes the (prefixed) table only.
+        assert_eq!(
+            pool.qualified_table_name("public", "ev\"il"),
+            "\"ev\"\"il\""
+        );
+    }
+
+    #[tokio::test]
+    async fn qualified_table_name_plain_is_unchanged() {
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        assert_eq!(pool.qualified_table_name("public", "orders"), "\"orders\"");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -493,7 +493,11 @@ async fn run_migrate_cli(args: MigrateCliArgs) -> anyhow::Result<()> {
                     String::new()
                 }
             );
-            if let Some(n) = t.source_rows {
+            // Skip when a verify outcome follows — it reprints the same
+            // count in its `counts:` line on non-Match verdicts.
+            if let Some(n) = t.source_rows
+                && t.verify.is_none()
+            {
                 println!("    Source rows: {n}");
             }
             if let Some(path) = &t.persisted_manifest_dir {
@@ -541,9 +545,9 @@ async fn run_migrate_cli(args: MigrateCliArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// True for verdicts that should make the CLI exit non-zero.
-/// `VerifyVerdict` is `#[non_exhaustive]`; unknown future variants
-/// default to non-zero so an unrecognised verdict can't ship green.
+/// True for verdicts that should make the CLI exit non-zero. The `_`
+/// arm is mandatory (cross-crate `#[non_exhaustive]`) and fails closed:
+/// an unknown future variant exits non-zero, never green.
 fn is_bad_verdict(v: &VerifyVerdict) -> bool {
     match v {
         VerifyVerdict::Match | VerifyVerdict::SkippedNoExactSourceCount => false,
@@ -1019,9 +1023,10 @@ mod tests {
     use clap::Parser;
     use std::collections::HashSet;
 
-    /// Pin the CLI exit-code policy: only `Match` and
-    /// `SkippedNoExactSourceCount` are clean. A future verdict variant
-    /// will fail compilation here (no `_ =>` arm).
+    /// Behaviour table for the exit-code policy (not a compile-time
+    /// exhaustiveness pin — `VerifyVerdict` is cross-crate
+    /// `#[non_exhaustive]`, so `is_bad_verdict` keeps a fail-closed `_`
+    /// arm). Add new variants here when they land.
     #[test]
     fn is_bad_verdict_classifies_every_variant() {
         assert!(!is_bad_verdict(&VerifyVerdict::Match));

--- a/src/migrate/orchestrator.rs
+++ b/src/migrate/orchestrator.rs
@@ -237,6 +237,16 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
                             "verify=count: pre-count failed (load not started): {e:#}"
                         )),
                     });
+                    // Mirror the post-count halt: mark halted so the bars
+                    // abandon instead of finishing "done".
+                    if let Some(mp) = &migrate_progress {
+                        mp.finish_halted(&format!(
+                            "{schema}.{table}: verify=count pre-count failed",
+                            schema = block.schema,
+                            table = block.table,
+                        ));
+                    }
+                    halted = true;
                     break;
                 }
             },
@@ -331,7 +341,7 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
     }
 
     if !halted && let Some(mp) = &migrate_progress {
-        mp.finish_clean();
+        mp.finish_visible();
     }
 
     Ok(MigrateReport {
@@ -931,6 +941,9 @@ COPY public.events (id, label) FROM stdin;
         let report = run_migrate(args).await.unwrap();
         assert_eq!(report.tables.len(), 2, "both COPY blocks should load");
         for t in &report.tables {
+            // TableLoadSummary mirrors r.source_rows independently of the
+            // verify outcome; pin it so dropping the plumbing is caught.
+            assert_eq!(t.source_rows, Some(t.records_loaded));
             let v = t
                 .verify
                 .as_ref()
@@ -1098,6 +1111,36 @@ COPY public.t2 (id) FROM stdin;
             .await
             .unwrap();
         assert_eq!(rows[0].0, 0, "t2 must be untouched after t1 halt");
+    }
+
+    /// Pre-count failure halts with a populated `verify_error` (load not
+    /// started) and freezes the report. Triggered by a COPY block whose
+    /// table is never created, so `count(*)` errors before the load.
+    #[tokio::test]
+    async fn run_migrate_verify_count_pre_count_failure_halts_with_error() {
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        // No CREATE TABLE for `missing`, and not pre-created → the
+        // pre-count count(*) fails before any INSERT.
+        let dump = write_dump(
+            "\
+COPY public.missing (id) FROM stdin;
+1
+\\.
+",
+        );
+        let mut args = args_with_pool(&file_uri(dump.path()), pool, false);
+        args.verify = VerifyMode::Count;
+
+        let report = run_migrate(args).await.unwrap();
+        assert_eq!(report.tables.len(), 1);
+        let t = &report.tables[0];
+        assert_eq!(t.records_loaded, 0, "load must not have started");
+        assert!(t.verify.is_none());
+        let err = t.verify_error.as_ref().expect("pre-count error recorded");
+        assert!(
+            err.contains("pre-count failed (load not started)"),
+            "got: {err}"
+        );
     }
 
     /// verify=Count + unfixable: short-circuit still wins, no tables

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -366,7 +366,7 @@ pub(crate) async fn run_load_with_pool_for_pgdump_block(
     args: LoadArgs,
     block: CopyBlock,
     aws_config: Option<&aws_config::SdkConfig>,
-    parent_multi: Option<std::sync::Arc<indicatif::MultiProgress>>,
+    parent_multi: Option<indicatif::MultiProgress>,
 ) -> Result<LoadResult> {
     validate_load_args(&args)?;
     debug_assert_eq!(args.target_table, block.table);
@@ -408,7 +408,7 @@ async fn run_load_with_pool_and_reader(
     file_reader: Arc<dyn crate::formats::reader::FileReader>,
     pgdump_columns: Vec<String>,
     delimited_config: Option<DelimitedConfig>,
-    parent_multi: Option<std::sync::Arc<indicatif::MultiProgress>>,
+    parent_multi: Option<indicatif::MultiProgress>,
 ) -> Result<LoadResult> {
     // Set up manifest directory (use temp dir if not provided)
     let (mut temp_dir, manifest_dir_path) = if let Some(dir) = args.manifest_dir {
@@ -826,5 +826,27 @@ mod tests {
             has_header: None,
             test_pool: None,
         }
+    }
+
+    /// The `debug_assert_eq!` routing-identity guard must fire when
+    /// `args.target_table` and `block.table` disagree — the trap that
+    /// would otherwise allow silent cross-table writes.
+    #[tokio::test]
+    #[should_panic(expected = "assertion `left == right` failed")]
+    async fn pgdump_block_routing_mismatch_panics_in_debug() {
+        let pool = crate::db::Pool::sqlite_in_memory().await.unwrap();
+        let mut args = sample_pgdump_args();
+        args.target_table = "t".into();
+        args.test_pool = Some(pool.clone());
+        let block = CopyBlock {
+            schema: "public".into(),
+            table: "OTHER".into(),
+            header_start: 0,
+            data_start: 1,
+            data_end: 2,
+            block_end: 4,
+            columns: vec!["id".into()],
+        };
+        let _ = run_load_with_pool_for_pgdump_block(pool, args, block, None, None).await;
     }
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -61,8 +61,9 @@ impl ProgressStats {
         let mut sorted = self.batch_durations_ms.clone();
         sorted.sort_unstable();
 
-        let index = ((p / 100.0) * sorted.len() as f64).ceil() as usize - 1;
-        let index = index.min(sorted.len() - 1);
+        // saturating_sub guards p=0.0 (ceil → 0, would underflow on `- 1`).
+        let rank = ((p / 100.0) * sorted.len() as f64).ceil() as usize;
+        let index = rank.saturating_sub(1).min(sorted.len() - 1);
 
         Some(sorted[index])
     }
@@ -74,5 +75,31 @@ impl ProgressStats {
             self.percentile(90.0),
             self.percentile(99.0),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percentile_zero_does_not_underflow() {
+        // p=0.0 → ceil(0)=0; without saturating_sub this panics in debug
+        // / wraps to usize::MAX in release.
+        let mut stats = ProgressStats::new();
+        stats.batch_durations_ms = vec![10, 20, 30];
+        assert_eq!(stats.percentile(0.0), Some(10));
+    }
+
+    #[test]
+    fn percentile_empty_is_none() {
+        assert_eq!(ProgressStats::new().percentile(50.0), None);
+    }
+
+    #[test]
+    fn percentile_hundred_is_max() {
+        let mut stats = ProgressStats::new();
+        stats.batch_durations_ms = vec![10, 20, 30];
+        assert_eq!(stats.percentile(100.0), Some(30));
     }
 }


### PR DESCRIPTION
## Summary

Follow-ups from the reviews on #33 and #34, where @anwesham-lab flagged items as "defer to follow-up." Each was **re-validated against current `main`** before applying — several findings rested on premises that are no longer (or never were) true at HEAD, and those were dropped rather than implemented. The user's instruction was explicit: validate that each item actually improves the code, without assuming the comments are right.

## Applied

**Correctness / UX**
- **Pre-count halt banner** (PR #33 round-3 #1): a transient `count(*)` failure *before* a table's load left `MigrateProgress` finishing with `"done"` while the run had actually halted. Now mirrors the post-count branch: `finish_halted` + `halted = true`. Pinned by a new test.
- **`source_rows` double-print** (PR #33 round-3 #7): under a non-`Match` `verify=count` verdict the migrate CLI printed `Source rows: N` and then `print_verify_detail` reprinted the same number. The explicit line now prints only when no verify outcome follows.
- **`#[non_exhaustive]` doc-vs-code** (PR #33 round-3 #3): the test comment claimed `is_bad_verdict` had "no `_ =>` arm" and would fail compilation on a new variant. `VerifyVerdict` is `#[non_exhaustive]` **from another crate**, so the `_` arm is *mandatory* — the reviewer's "drop the arm" option wouldn't compile. Fixed the comment to describe the real (fail-closed) behavior.

**Progress lifecycle (PR #34 review)**
- **`finish_clean` name collision** (#5): `MigrateProgress::finish_clean` (left bars *visible*) and `LoadProgress::finish_clean` (*erased* bars) were opposite behaviors under one name. Renamed to `finish_visible` / `finish_and_clear`.
- **Zombie bar accumulation** (#2): `finish_and_clear` only marks a bar a zombie; per-table bars piled up in the parent `MultiProgress` across a multi-table migrate. `LoadProgress` now also `remove`s its bars. Verified against indicatif 0.17.11 source (head-only zombie reaping; non-head zombies never reaped).
- **Redundant `Arc<MultiProgress>`** (#7/D1): `MultiProgress` is already `Arc`-backed internally — dropped the extra layer.
- **`MigrateProgress` not finalized on `?`-error** (#1): added a `Drop` guard that abandons still-live bars on unwind so they don't interleave with the printed error. No-op on the normal finish paths.
- **Pump-panic swallowed** (#11/D8): `let _ = pump.await` now logs a panic.

**Hardening**
- **`percentile` underflow** (#11/D8): `ceil() as usize - 1` underflowed at `p=0.0`; now `saturating_sub`.

**Test pins** (regression-detection for code already correct at HEAD):
`aggregate_source_rows` overflow, `percentile` p0/p100/empty, migrate pre-count `verify_error` halt, `TableLoadSummary.source_rows` mirror, `qualified_table_name` escape-doubling, pgdump-block routing `debug_assert`, `LoadProgress` standalone + `rows_bar=None` lifecycles.

## Deliberately NOT done (validated as wrong / not worth it)

- **`LoadConfig.parent_multi` "leaks indicatif on the public API"** (PR #34 #15) and **"`pub mod progress` leaks `LoadProgress`"** (#16): `mod coordination` is **private** at the crate root (`lib.rs:6`), and `runner` re-exports only `MigrateProgress`-free types. Nothing here is externally reachable — the reviewer's own round-3 note on #34 self-corrected this ("N1's reasoning was actually wrong"). No SemVer surface, no change needed.
- **Cancellation / Ctrl-C `Drop` on `LoadProgress`** (PR #34 #4): speculative; no SIGINT handler exists anywhere and the `Drop` guard on `MigrateProgress` already covers the realistic unwind path. YAGNI.
- **`verify::run_l2` DRY helper** (PR #33 #10): the two call sites legitimately diverge in per-phase error handling (pre-count halts before INSERT; post-count surfaces against a populated summary). A shared helper would hide exactly the distinction #3 needs. Left as-is.
- **`tracing`/bar render collision via `MultiProgress::suspend`** (PR #34 #3): real but a larger, separable change (subscriber writer wiring); out of scope for a polish PR.
- **Post-count `verify_error` test, ANSI hardening, banner combine, halt-path keep-visible, byte accounting** (PR #34 #6/#12/#13, PR #33 #6): each needs disproportionate infra (Pool count-injection seam) or is cosmetic on an unreleased feature. The deterministic pre-count path is pinned; the post-count branch shares the same `verify_error` plumbing.
- **CHANGELOG entries**: these are corrections to an **unreleased** feature already described in `[Unreleased]`. No shipped behavior changed.

## Verification
- 289 lib + 25 bin + 1 doc tests pass.
- `cargo fmt --check` clean.
- `cargo clippy --all-targets --all-features -- -D warnings` clean.
