### PR TITLE
feat(verify): value-level fidelity (--verify=full / L3) + affirmative schema check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,9 +1475,9 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dsql-lint"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a63679578341755ed64755651259d94675404d00ed42a722b0c101a36c383a42"
+checksum = "88230fdfd5cd25f44a675cab8fe05dadd084bc9cb40d102f24f04f28a26bd670"
 dependencies = [
  "clap",
  "serde",
@@ -1587,7 +1587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2554,7 +2554,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3153,7 +3153,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3846,7 +3846,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bytes = "1.11"
 chrono = "0.4"
 clap = { version = "4.5.53", features = ["derive"] }
 csv = "1.3"
-dsql-lint = "0.2.5"
+dsql-lint = ">=0.2.6, <1"
 derive_builder = "0.20.2"
 either = "1.15.0"
 futures = "0.3.31"

--- a/README.md
+++ b/README.md
@@ -280,7 +280,27 @@ Resume automatically retries failed chunks and skips completed ones. For safety 
 
 ## Verification
 
-`--verify=count` cross-checks row counts after a load and reports one verdict per table: `Match`, `LoaderDropped(N)`, `MissingTarget(N)`, `ExtraTarget(N)`, `RowsConflictedAtTarget(N)`, or `SkippedNoExactSourceCount` (csv/tsv). Any verdict other than `Match` or `SkippedNoExactSourceCount` exits non-zero. Default: `off` for `load`, `count` for `migrate`. Assumes the loader is the sole writer to the target during the run.
+After a load, `--verify` cross-checks what landed and prints one verdict per table. Pick the level by how much assurance you need vs. how much extra time you'll spend.
+
+| `--verify` | What it confirms | Cost |
+|------------|------------------|------|
+| `off` | Nothing (load only). | None. |
+| `count` | **No rows were lost.** Source row count = rows loaded + rows that failed, and the target table grew by exactly the number loaded. Also confirms the target's columns match the file and it has a primary/unique key. | Two `COUNT(*)` per table. Negligible. |
+| `full` | Everything `count` does, **plus every value landed correctly.** Each row is re-read from the source and compared to the target by primary key, letting the database decide equality (so `1.50` vs `1.5`, JSON key order, timestamp precision, etc. are not false alarms). | One extra full read of each table — roughly doubles load time. Opt-in. |
+
+Default: `off` for `load`, `count` for `migrate`. Both `count` and `full` assume the loader is the sole writer to the target during the run.
+
+**Verdicts** (anything but `Match`, `SkippedNoExactSourceCount`, or `ValueCheckSkipped` exits non-zero, so it fails CI/scripts):
+
+- `Match` — clean.
+- `LoaderDropped(N)` — rows lost before the database (parser/chunker issue).
+- `MissingTarget(N)` / `ExtraTarget(N)` — target grew by less / more than loaded (concurrent writer?).
+- `RowsConflictedAtTarget(N)` — N rows hit `ON CONFLICT` under `do-nothing`/`do-update` (re-run with `--verify=off` if that's an intended idempotent re-apply).
+- `ValueMismatch(N)` / `ValueRowMissingAtTarget(N)` — *(`full` only)* N rows differ in value / are absent at the target; the report lists the offending primary keys.
+- `SkippedNoExactSourceCount` — csv/tsv have no exact source count, so row-count checks can't run.
+- `ValueCheckSkipped` — *(`full` only)* no single-column primary/unique key to align rows by, so the value check couldn't run (explicit, never a silent pass).
+
+`full` verifies that the target faithfully reproduces what the loader read from your file — it catches load, transport, and type-coercion errors, but trusts the reader to have decoded the file correctly (it does not re-validate against the original live source).
 
 ## Performance Tuning
 

--- a/src/coordination/worker.rs
+++ b/src/coordination/worker.rs
@@ -49,26 +49,6 @@ fn apply_field_exclusion(
     (filtered, mismatch, first_mismatch)
 }
 
-/// Type category for SQL type conversion strategy
-#[derive(Debug, Clone, Copy, PartialEq)]
-enum TypeCategory {
-    /// All types except text - bind as string and use CAST() in SQL for type conversion
-    /// This ensures PostgreSQL is the single source of truth for type validation
-    StringCast,
-    /// Text types with direct string binding (TEXT, VARCHAR, CHAR)
-    DirectString,
-}
-
-impl TypeCategory {
-    /// Classify a SQL type into its conversion category
-    fn from_sql_type(col_type: &str) -> Self {
-        match col_type {
-            "TEXT" | "VARCHAR" | "CHAR" => TypeCategory::DirectString,
-            _ => TypeCategory::StringCast,
-        }
-    }
-}
-
 /// Result of executing a batch of records
 #[derive(Debug)]
 struct BatchResult {
@@ -541,7 +521,7 @@ impl Worker {
                         return "NULL".to_string();
                     };
 
-                    let escaped = Self::escape_sql_string(field);
+                    let escaped = crate::db::schema::escape_sql_literal(field);
                     let value_expr = format!("'{}'", escaped);
 
                     // PostgreSQL only: wrap in CAST() for non-text columns
@@ -552,8 +532,7 @@ impl Worker {
                         .and_then(|s| s.columns.get(col_idx))
                         .filter(|col| {
                             use_pg_cast
-                                && TypeCategory::from_sql_type(&col.col_type)
-                                    == TypeCategory::StringCast
+                                && !crate::db::schema::inserts_as_bare_literal(&col.col_type)
                         })
                         .map(|col| format!("CAST({} AS {})", value_expr, col.col_type))
                         .unwrap_or(value_expr)
@@ -685,12 +664,6 @@ impl Worker {
                 }
             }
         }
-    }
-
-    /// Escape a string value for use in SQL
-    /// Handles single quotes by doubling them (SQL standard escaping)
-    fn escape_sql_string(value: &str) -> String {
-        value.replace('\'', "''")
     }
 
     /// Build the ON CONFLICT clause based on the conflict resolution mode

--- a/src/coordination/worker.rs
+++ b/src/coordination/worker.rs
@@ -521,21 +521,16 @@ impl Worker {
                         return "NULL".to_string();
                     };
 
-                    let escaped = crate::db::schema::escape_sql_literal(field);
-                    let value_expr = format!("'{}'", escaped);
-
-                    // PostgreSQL only: wrap in CAST() for non-text columns
-                    // so the server is the single source of truth for type
-                    // coercion. SQLite handles literals natively.
-                    schema
-                        .as_ref()
-                        .and_then(|s| s.columns.get(col_idx))
-                        .filter(|col| {
-                            use_pg_cast
-                                && !crate::db::schema::inserts_as_bare_literal(&col.col_type)
-                        })
-                        .map(|col| format!("CAST({} AS {})", value_expr, col.col_type))
-                        .unwrap_or(value_expr)
+                    // PostgreSQL only: recast non-text columns so the server
+                    // is the single source of truth for type coercion (shared
+                    // with verify's recast-compare). SQLite handles literals
+                    // natively, so emit a bare escaped literal there.
+                    match schema.as_ref().and_then(|s| s.columns.get(col_idx)) {
+                        Some(col) if use_pg_cast => {
+                            crate::db::schema::recast_literal(&col.col_type, field)
+                        }
+                        _ => format!("'{}'", crate::db::schema::escape_sql_literal(field)),
+                    }
                 })
                 .collect();
             value_groups.push(format!("({})", values.join(", ")));

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -117,15 +117,28 @@ impl Pool {
         }
     }
 
-    /// Create an in-memory SQLite pool for testing
+    /// Create an in-memory SQLite pool for testing.
+    ///
+    /// Uses a uniquely-named shared-cache in-memory DB so every pooled
+    /// connection sees the SAME database. Plain `sqlite::memory:` gives each
+    /// connection its own empty DB, so a query landing on a second connection
+    /// can miss tables a `CREATE` ran on the first — a flaky silent divergence
+    /// (e.g. a composite-PK lookup returning one column → a verify skip-test
+    /// spuriously seeing `Ran` instead of `Skipped`). The unique name keeps
+    /// each pool's DB isolated from other concurrently-running test pools.
     #[cfg(test)]
     pub async fn sqlite_in_memory() -> Result<Self, sqlx::Error> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static DB_SEQ: AtomicU64 = AtomicU64::new(0);
+        let id = DB_SEQ.fetch_add(1, Ordering::Relaxed);
+        let uri = format!("sqlite:file:dsql_test_{id}?mode=memory&cache=shared");
+
         let sqlite_pool = sqlx::sqlite::SqlitePoolOptions::new()
             .min_connections(1)
             .max_connections(10)
             .idle_timeout(None)
             .max_lifetime(None)
-            .connect("sqlite::memory:")
+            .connect(&uri)
             .await?;
 
         Ok(Pool {

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -57,6 +57,27 @@ pub fn inserts_as_bare_literal(pg_type: &str) -> bool {
     matches!(pg_type, "TEXT" | "VARCHAR" | "CHAR")
 }
 
+/// Render `value` as the SQL literal a Postgres/DSQL load writes for a
+/// column of `pg_type` (a [`SqlType::to_postgres`] name): bare `'v'` for the
+/// TEXT family, `CAST('v' AS pg_type)` otherwise, so the server's input
+/// function owns the coercion.
+///
+/// Single source of truth for two call sites that must agree: the worker's
+/// INSERT (Postgres path) writes the value through this, and verify's
+/// recast-compare rebuilds the same literal to compare against — keyed on
+/// the identical `to_postgres()` name so a source value coerces the same way
+/// on both. (SQLite isn't Postgres, so the worker bypasses this and emits a
+/// bare literal there; verify still recasts so its comparison matches the
+/// affinity-coerced stored value.)
+pub fn recast_literal(pg_type: &str, value: &str) -> String {
+    let lit = format!("'{}'", escape_sql_literal(value));
+    if inserts_as_bare_literal(pg_type) {
+        lit
+    } else {
+        format!("CAST({lit} AS {pg_type})")
+    }
+}
+
 impl SqlType {
     /// Returns the Postgres type name
     pub fn to_postgres(&self) -> &'static str {
@@ -545,6 +566,26 @@ impl SchemaInferrer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn recast_literal_bare_for_text_family_else_cast() {
+        // TEXT family → bare escaped literal (the worker inserts bare, so
+        // verify compares bare); everything else → CAST through the type.
+        assert_eq!(recast_literal("TEXT", "alice"), "'alice'");
+        assert_eq!(recast_literal("VARCHAR", "alice"), "'alice'");
+        assert_eq!(recast_literal("CHAR", "x"), "'x'");
+        assert_eq!(recast_literal("NUMERIC", "1.5"), "CAST('1.5' AS NUMERIC)");
+        assert_eq!(
+            recast_literal("TIMESTAMP WITH TIME ZONE", "2024-01-01Z"),
+            "CAST('2024-01-01Z' AS TIMESTAMP WITH TIME ZONE)"
+        );
+        // Embedded quotes are doubled on both paths.
+        assert_eq!(recast_literal("TEXT", "o'brien"), "'o''brien'");
+        assert_eq!(
+            recast_literal("JSONB", "{\"k\":\"v\"}"),
+            "CAST('{\"k\":\"v\"}' AS JSONB)"
+        );
+    }
 
     #[test]
     fn test_infer_value_types() {

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -48,11 +48,13 @@ pub fn escape_sql_literal(value: &str) -> String {
 /// Whether a column of the given Postgres type name is written as a bare
 /// `'literal'` (TEXT family) rather than `CAST('literal' AS type)`.
 ///
-/// Single source of truth for the cast-vs-bare decision, keyed on the
-/// `to_postgres()` type name both call sites share: the worker classifies
-/// `ColumnJson.col_type` (always `to_postgres()` output) at INSERT time, and
-/// verify classifies the same name when building its recast comparison, so
-/// the comparison runs through the identical coercion the write used.
+/// Keyed on the worker's `to_postgres()` names (`TEXT`/`VARCHAR`/`CHAR`): the
+/// worker has only the *unparameterized* name, and `CAST('ab' AS CHAR)` would
+/// truncate to `char(1)` — so it inserts the TEXT family bare and lets the
+/// column coerce. Verify recasts through the column's *parameterized* name
+/// (e.g. `character varying(5)`), which carries the length and so casts
+/// faithfully; those names don't match here, so verify always casts. Bare and
+/// parameterized-cast yield the same stored comparison either way.
 pub fn inserts_as_bare_literal(pg_type: &str) -> bool {
     matches!(pg_type, "TEXT" | "VARCHAR" | "CHAR")
 }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -28,10 +28,14 @@ pub enum SqlType {
     Interval,
     Uuid,
     Bytea,
-    /// `json` (the dsql-lint `JSONB`→`json` rewrite lands here). The `json`
-    /// type has no `=` operator, so L3 compares it cast to text rather than
-    /// via the null-safe-equality path used for other types.
+    /// `json` — preserves verbatim input text but has **no `=` operator**, so
+    /// L3 compares it as `CAST(col AS TEXT)` against the source text.
     Json,
+    /// `jsonb` — canonicalizes input (key order / whitespace) but **has `=`**,
+    /// so L3 compares it natively via `CAST('src' AS jsonb)`. (A text compare
+    /// would false-mismatch on the canonicalization.) DSQL supports it
+    /// natively; dsql-lint >=0.2.6 preserves it.
+    Jsonb,
 }
 
 /// Escape a value for a single-quoted SQL string literal (doubles embedded
@@ -75,6 +79,7 @@ impl SqlType {
             SqlType::Uuid => "UUID",
             SqlType::Bytea => "BYTEA",
             SqlType::Json => "JSON",
+            SqlType::Jsonb => "JSONB",
         }
     }
 
@@ -297,7 +302,8 @@ pub async fn query_table_schema(
             "INTERVAL" => SqlType::Interval,
             "UUID" => SqlType::Uuid,
             "BYTEA" => SqlType::Bytea,
-            "JSON" | "JSONB" => SqlType::Json,
+            "JSON" => SqlType::Json,
+            "JSONB" => SqlType::Jsonb,
             _ => SqlType::Text, // Default to TEXT for unsupported types
         };
 

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -28,6 +28,29 @@ pub enum SqlType {
     Interval,
     Uuid,
     Bytea,
+    /// `json` (the dsql-lint `JSONB`→`json` rewrite lands here). The `json`
+    /// type has no `=` operator, so L3 compares it cast to text rather than
+    /// via the null-safe-equality path used for other types.
+    Json,
+}
+
+/// Escape a value for a single-quoted SQL string literal (doubles embedded
+/// quotes). Shared between the worker's INSERT generation and verify's
+/// recast-compare so the two paths escape identically.
+pub fn escape_sql_literal(value: &str) -> String {
+    value.replace('\'', "''")
+}
+
+/// Whether a column of the given Postgres type name is written as a bare
+/// `'literal'` (TEXT family) rather than `CAST('literal' AS type)`.
+///
+/// Single source of truth for the cast-vs-bare decision, keyed on the
+/// `to_postgres()` type name both call sites share: the worker classifies
+/// `ColumnJson.col_type` (always `to_postgres()` output) at INSERT time, and
+/// verify classifies the same name when building its recast comparison, so
+/// the comparison runs through the identical coercion the write used.
+pub fn inserts_as_bare_literal(pg_type: &str) -> bool {
+    matches!(pg_type, "TEXT" | "VARCHAR" | "CHAR")
 }
 
 impl SqlType {
@@ -51,6 +74,7 @@ impl SqlType {
             SqlType::Interval => "INTERVAL",
             SqlType::Uuid => "UUID",
             SqlType::Bytea => "BYTEA",
+            SqlType::Json => "JSON",
         }
     }
 
@@ -273,6 +297,7 @@ pub async fn query_table_schema(
             "INTERVAL" => SqlType::Interval,
             "UUID" => SqlType::Uuid,
             "BYTEA" => SqlType::Bytea,
+            "JSON" | "JSONB" => SqlType::Json,
             _ => SqlType::Text, // Default to TEXT for unsupported types
         };
 

--- a/src/formats/pgdump/mod.rs
+++ b/src/formats/pgdump/mod.rs
@@ -16,4 +16,4 @@ mod scan;
 mod tests;
 
 pub use reader::PgDumpReader;
-pub use scan::{CopyBlock, extract_ddl, list_copy_blocks};
+pub use scan::{CopyBlock, extract_ddl, find_copy_block, list_copy_blocks};

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -4839,12 +4839,10 @@ mod tests {
         assert_eq!(emails, vec!["a@example.com", "b@example.com"]);
 
         // ── Stage 4: L3 catches a post-load divergence on real DSQL ─────
-        // The migrate-time verify passed (Match) because the load was
-        // faithful. Now mutate one target value out from under the loader
-        // and re-run L3 directly: it must flag ValueMismatch and localize
-        // the offending PK. This is the case L3 exists for — a value that
-        // doesn't match the source, with counts intact (the gap count-only
-        // verification cannot see).
+        // The migrate-time verify passed (Match). Now mutate one target
+        // value out from under the loader and re-run L3 directly: it must
+        // flag ValueMismatch and localize the offending PK — a value that
+        // diverges from the source while counts stay intact.
         {
             // Find events row (label 'alpha') and corrupt its note. `id` is
             // BIGINT after the SERIAL→IDENTITY rewrite, so fetch as i64.

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -4897,6 +4897,107 @@ mod tests {
         Ok(())
     }
 
+    /// Regression: `load --verify=full` into columns whose declared
+    /// precision/scale is NARROWER than the source text must still verify as
+    /// `Match`. The load coerces the value to the column's typmod (e.g.
+    /// `numeric(10,2)` stores `1.005`→`1.01`, `timestamp(0)` drops sub-second);
+    /// L3 must recast the source through the column's *parameterized* type so
+    /// it rounds identically. Before the fix L3 recast through the bare type
+    /// name (no scale), keeping `1.005`, and false-mismatched every such row.
+    ///
+    /// `#[ignore]` — needs a real DSQL cluster + IAM (CI `e2e-dsql`). DSQL is
+    /// the type authority here; SQLite can't reproduce typmod coercion.
+    #[tokio::test]
+    #[ignore]
+    async fn pgdump_load_verify_full_typmod_narrower_than_source_matches() -> anyhow::Result<()> {
+        let dsql_endpoint = std::env::var("LOADER_DSQL_E2E_ENDPOINT").map_err(|_| {
+            anyhow::anyhow!("LOADER_DSQL_E2E_ENDPOINT must be set (<cluster>.dsql.<region>.on.aws)")
+        })?;
+        let dsql_region =
+            std::env::var("LOADER_DSQL_E2E_REGION").unwrap_or_else(|_| "us-east-1".to_string());
+        anyhow::ensure!(
+            !dsql_endpoint.is_empty(),
+            "LOADER_DSQL_E2E_ENDPOINT is empty"
+        );
+
+        let dsql_pool = build_dsql_pool(
+            PoolArgsBuilder::default()
+                .endpoint(&dsql_endpoint)
+                .region(&dsql_region)
+                .username("admin")
+                .build()?,
+        )
+        .await?;
+
+        // UUID-suffixed table so parallel runs on a shared cluster don't collide.
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let table = format!("e2e_typmod_{suffix}");
+
+        // Narrow columns: scale-2 numeric and second-precision timestamps.
+        dsql_pool
+            .execute_query(&format!(
+                "CREATE TABLE {table} (
+                    id    int PRIMARY KEY,
+                    amt   numeric(10,2),
+                    ts0   timestamp(0),
+                    tstz0 timestamptz(0)
+                )"
+            ))
+            .await?;
+
+        // Source COPY text is WIDER than every column's precision, so a
+        // faithful load must coerce: 1.005→1.01, .6 seconds→rounded.
+        let mut f = tempfile::NamedTempFile::new()?;
+        writeln!(f, "COPY public.{table} (id, amt, ts0, tstz0) FROM stdin;")?;
+        writeln!(
+            f,
+            "1\t1.005\t2024-01-01 10:23:54.6\t2024-01-01 10:23:54.6+02"
+        )?;
+        writeln!(
+            f,
+            "2\t2.675\t2024-06-30 23:59:59.5\t2024-06-30 23:59:59.5+00"
+        )?;
+        writeln!(f, "\\.")?;
+        f.flush()?;
+
+        let mut args = pgdump_load_args(
+            f.path().to_string_lossy().into_owned(),
+            &table,
+            dsql_pool.clone(),
+        );
+        args.verify = VerifyMode::Full;
+
+        let result = run_load(args).await?;
+
+        // The fix's payoff: a faithful narrowing load verifies clean. Before
+        // the parameterized recast this was ValueMismatch(2).
+        let v = result.verify.expect("verify=full must populate verify");
+        assert_eq!(
+            v.verdict,
+            crate::verify::VerifyVerdict::Match,
+            "narrowing load must verify as Match, got {:?} (l3_details={:?})",
+            v.verdict,
+            v.l3_details,
+        );
+
+        // Guard against a trivial pass: prove the column REALLY coerced the
+        // value (so the recast genuinely had to round to match, not just
+        // compare equal text). 1.005 must be stored as 1.01.
+        let (stored_amt,): (String,) =
+            sqlx::query_as(&format!("SELECT amt::text FROM {table} WHERE id = 1"))
+                .fetch_one(&dsql_pool)
+                .await?;
+        assert_eq!(
+            stored_amt, "1.01",
+            "column must have rounded 1.005→1.01 (else the test isn't exercising typmod)"
+        );
+
+        let _ = dsql_pool
+            .execute_query(&format!("DROP TABLE IF EXISTS {table}"))
+            .await;
+        Ok(())
+    }
+
     #[tokio::test]
     async fn pgdump_errors_on_column_set_mismatch() -> anyhow::Result<()> {
         // Target table has an extra column not present in the dump's COPY clause.

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -4615,7 +4615,7 @@ mod tests {
         // ── Stage 1.5: per-table verification verdict (verify=Full) ─────
         // L1+L2+L3 all ran; every loaded table must come back as Match —
         // proving the server-side recast-compare canonicalizes the seeded
-        // values (numeric/timestamptz/jsonb/uuid/\N) on real DSQL. The
+        // values (timestamptz µs / jsonb / \N) on real DSQL. The
         // affirmative schema check must also be populated.
         for t in &report.tables {
             let v = t.verify.as_ref().unwrap_or_else(|| {
@@ -4650,7 +4650,7 @@ mod tests {
                 )
             });
             assert!(
-                sc.columns_matched > 0 && sc.pk_present,
+                sc.columns_matched.is_some_and(|n| n > 0) && sc.pk_present,
                 "{}.{}: expected columns_matched>0 + pk_present, got {sc:?}",
                 t.schema,
                 t.table,
@@ -5197,7 +5197,7 @@ mod tests {
         assert_eq!(
             v.schema_check,
             Some(crate::verify::SchemaCheck {
-                columns_matched: 2,
+                columns_matched: Some(2),
                 pk_present: true,
             })
         );

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -4452,7 +4452,7 @@ mod tests {
         //   events.id       SERIAL PRIMARY KEY    → serial_sequence_idiom
         //                                           + alter_add_primary_key_collapse
         //   events.user_id  REFERENCES            → foreign_key (removed)
-        //   events.payload  JSONB                 → json_type
+        //   events.payload  JSONB                 (preserved — DSQL native)
         //   events_label_idx CREATE INDEX … USING btree
         //                                         → index_async + index_using
         //   events.note     NOT NULL DEFAULT ''   (preserved as-is)
@@ -4587,9 +4587,13 @@ mod tests {
             "UNIQUE should fold via alter_add_unique_collapse, got: {:?}",
             report.ddl_changes
         );
-        assert!(
-            rule_count("json_type") >= 1,
-            "JSONB → JSON rewrite should fire for events.payload, got: {:?}",
+        // DSQL supports JSONB natively (dsql-lint >=0.2.6 dropped the
+        // JSONB→JSON rewrite), so the json_type rule must NOT fire — the
+        // column is preserved as jsonb (asserted on the destination below).
+        assert_eq!(
+            rule_count("json_type"),
+            0,
+            "JSONB must be preserved (no json_type rewrite), got: {:?}",
             report.ddl_changes
         );
         assert!(
@@ -4691,7 +4695,8 @@ mod tests {
             "{users_src} must have exactly 1 UNIQUE constraint"
         );
 
-        // JSONB → JSON: post-migrate column data_type is `json`, not `jsonb`.
+        // JSONB preserved: DSQL supports it natively, so the column stays
+        // `jsonb` (dsql-lint >=0.2.6 no longer rewrites it to `json`).
         let (payload_type,): (String,) = sqlx::query_as(&format!(
             "SELECT data_type FROM information_schema.columns \
              WHERE table_schema='public' AND table_name='{events_src}' AND column_name='payload'"
@@ -4699,8 +4704,8 @@ mod tests {
         .fetch_one(&dsql_pool)
         .await?;
         assert_eq!(
-            payload_type, "json",
-            "{events_src}.payload must be data_type='json' (not 'jsonb')"
+            payload_type, "jsonb",
+            "{events_src}.payload must be preserved as data_type='jsonb'"
         );
 
         // NOT NULL DEFAULT '' preserved on events.note.

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -20,9 +20,9 @@ mod tests {
         },
         formats::{
             DelimitedConfig, FileReader, delimited::reader::GenericDelimitedReader,
-            parquet::GenericParquetReader,
+            parquet::GenericParquetReader, pgdump::find_copy_block,
         },
-        io::LocalFileByteReader,
+        io::{ByteReader, LocalFileByteReader},
         runner::{Format, LoadArgs, MigrateArgs, VerifyMode, run_load, run_migrate},
     };
     use arrow::array::*;
@@ -4551,10 +4551,12 @@ mod tests {
             batch_concurrency: 1,
             chunk_size_bytes: 1024 * 1024,
             on_conflict: OnConflict::Error,
-            // Exercise the migrate default end-to-end: every loaded table
-            // gets a VerifyOutcome and the assertions below pin the verdict
-            // shape we promise (`Match` for both tables on a fresh cluster).
-            verify: VerifyMode::Count,
+            // Exercise the deepest tier end-to-end: `Full` runs L1+L2 +
+            // the affirmative schema check + L3 per-row value verification.
+            // The assertions below pin `Match` for both tables on a fresh
+            // cluster, proving the recast-compare canonicalizes correctly
+            // against real DSQL (the claim SQLite tests cannot make).
+            verify: VerifyMode::Full,
             quiet: true,
             debug: false,
             test_pool: None,
@@ -4606,20 +4608,22 @@ mod tests {
         )
         .await?;
 
-        // ── Stage 1.5: per-table verification verdict ───────────────────
-        // verify=Count is on by default; every loaded table must come
-        // back as Match.
+        // ── Stage 1.5: per-table verification verdict (verify=Full) ─────
+        // L1+L2+L3 all ran; every loaded table must come back as Match —
+        // proving the server-side recast-compare canonicalizes the seeded
+        // values (numeric/timestamptz/jsonb/uuid/\N) on real DSQL. The
+        // affirmative schema check must also be populated.
         for t in &report.tables {
             let v = t.verify.as_ref().unwrap_or_else(|| {
                 panic!(
-                    "verify must be Some on {}.{} under default migrate verify=Count",
+                    "verify must be Some on {}.{} under verify=Full",
                     t.schema, t.table
                 )
             });
             assert_eq!(
                 v.verdict,
                 crate::runner::VerifyVerdict::Match,
-                "{}.{} expected Match, got {:?} (source_rows={:?}, loaded={}, failed={}, target_counts={:?})",
+                "{}.{} expected Match, got {:?} (source_rows={:?}, loaded={}, failed={}, target_counts={:?}, l3_details={:?})",
                 t.schema,
                 t.table,
                 v.verdict,
@@ -4627,10 +4631,23 @@ mod tests {
                 v.records_loaded,
                 v.records_failed,
                 v.target_counts,
+                v.l3_details,
             );
             assert!(
                 v.source_rows.is_some(),
                 "pgdump must produce exact source_rows; got None for {}.{}",
+                t.schema,
+                t.table,
+            );
+            let sc = v.schema_check.as_ref().unwrap_or_else(|| {
+                panic!(
+                    "verify=Full must populate schema_check on {}.{}",
+                    t.schema, t.table
+                )
+            });
+            assert!(
+                sc.columns_matched > 0 && sc.pk_present,
+                "{}.{}: expected columns_matched>0 + pk_present, got {sc:?}",
                 t.schema,
                 t.table,
             );
@@ -4820,6 +4837,47 @@ mod tests {
                 .await?;
         let emails: Vec<&str> = user_rows.iter().map(|u| u.email.as_str()).collect();
         assert_eq!(emails, vec!["a@example.com", "b@example.com"]);
+
+        // ── Stage 4: L3 catches a post-load divergence on real DSQL ─────
+        // The migrate-time verify passed (Match) because the load was
+        // faithful. Now mutate one target value out from under the loader
+        // and re-run L3 directly: it must flag ValueMismatch and localize
+        // the offending PK. This is the case L3 exists for — a value that
+        // doesn't match the source, with counts intact (the gap count-only
+        // verification cannot see).
+        {
+            // Find events row (label 'alpha') and corrupt its note. `id` is
+            // BIGINT after the SERIAL→IDENTITY rewrite, so fetch as i64.
+            let (alpha_id,): (i64,) = sqlx::query_as(&format!(
+                "SELECT id FROM {events_src} WHERE label = 'alpha'"
+            ))
+            .fetch_one(&dsql_pool)
+            .await?;
+            dsql_pool
+                .execute_query(&format!(
+                    "UPDATE {events_src} SET note = 'CORRUPTED' WHERE id = {alpha_id}"
+                ))
+                .await?;
+
+            let reader: Arc<dyn ByteReader> = Arc::new(LocalFileByteReader::new(&dump_path));
+            let block = find_copy_block(&*reader, "public", &events_src).await?;
+            let (outcome, details) =
+                crate::verify::verify_table_values(&dsql_pool, reader, &block, 1024 * 1024).await?;
+
+            assert_eq!(
+                outcome,
+                crate::verify::L3Outcome::Ran {
+                    value_mismatches: 1,
+                    rows_missing_at_target: 0
+                },
+                "post-load mutation must surface exactly one value mismatch",
+            );
+            assert_eq!(
+                details.mismatch_pks,
+                vec![alpha_id.to_string()],
+                "L3 must localize the corrupted row's primary key",
+            );
+        }
 
         // ── Cleanup: best-effort (per-run CI cluster is torn down anyway).
         let _ = sqlx::query(&format!(
@@ -5109,6 +5167,36 @@ mod tests {
         assert!(
             err.contains("pg_dump column identifier") && err.contains("unsafe character"),
             "expected validation error naming the column field; got: {err}"
+        );
+        Ok(())
+    }
+
+    /// Plain `load --verify=full` on pgdump runs L3 end-to-end (resolving
+    /// the COPY block itself, unlike migrate) and reports a clean Match
+    /// with the affirmative schema_check populated. Pins the load-path L3
+    /// wiring, which is separate from the migrate orchestrator path.
+    #[tokio::test]
+    async fn pgdump_load_verify_full_matches_with_schema_check() -> anyhow::Result<()> {
+        let mut f = tempfile::NamedTempFile::new()?;
+        writeln!(f, "COPY public.things (id, name) FROM stdin;")?;
+        writeln!(f, "1\talpha")?;
+        writeln!(f, "2\tbeta")?;
+        writeln!(f, "\\.")?;
+        f.flush()?;
+
+        let pool = setup_sqlite_table("things", "id INTEGER PRIMARY KEY, name TEXT").await;
+        let mut args = pgdump_load_args(f.path().to_string_lossy().into_owned(), "things", pool);
+        args.verify = VerifyMode::Full;
+
+        let result = run_load(args).await?;
+        let v = result.verify.expect("verify=full must populate verify");
+        assert_eq!(v.verdict, crate::verify::VerifyVerdict::Match);
+        assert_eq!(
+            v.schema_check,
+            Some(crate::verify::SchemaCheck {
+                columns_matched: 2,
+                pk_present: true,
+            })
         );
         Ok(())
     }

--- a/src/io/byte_reader.rs
+++ b/src/io/byte_reader.rs
@@ -16,6 +16,21 @@ pub trait ByteReader: Send + Sync {
     async fn read_range(&self, start: u64, end: u64) -> Result<Vec<u8>>;
 }
 
+/// Forward `ByteReader` through an `Arc`, so a shared `Arc<dyn ByteReader>`
+/// (e.g. the source opened once by the migrate orchestrator) satisfies the
+/// `R: ByteReader` bound on readers like `PgDumpReader::from_block` without
+/// re-opening the underlying file/object.
+#[async_trait]
+impl<R: ByteReader + ?Sized> ByteReader for std::sync::Arc<R> {
+    async fn size(&self) -> Result<u64> {
+        (**self).size().await
+    }
+
+    async fn read_range(&self, start: u64, end: u64) -> Result<Vec<u8>> {
+        (**self).read_range(start, end).await
+    }
+}
+
 /// Helper functions for working with ByteReaders
 /// Find the start of the next complete record after the given offset
 /// Returns the byte offset of the start of the next line

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,11 +108,12 @@ struct LoadParams {
     #[arg(long, default_value = "do-nothing")]
     on_conflict: String,
 
-    /// Post-load verification (`off` | `count`). `count` adds pre/post
-    /// `count(*)` and reports an L1+L2 verdict per table. Assumes the
-    /// loader is the sole writer during the run. L2 is skipped under
-    /// `--if-not-exists` (no stable pre-count) and on csv/tsv (no exact
-    /// source count); the per-table verdict still surfaces.
+    /// Post-load verification (`off` | `count` | `full`). `count` adds
+    /// pre/post `count(*)` and reports an L1+L2 verdict per table. `full`
+    /// adds per-row value verification (L3) — opt-in, ~one extra full table
+    /// read. Assumes the loader is the sole writer during the run. L2 is
+    /// skipped under `--if-not-exists` (no stable pre-count) and on csv/tsv
+    /// (no exact source count); the per-table verdict still surfaces.
     #[arg(long, default_value = "off")]
     verify: String,
 
@@ -239,10 +240,11 @@ enum Command {
         #[arg(long, default_value = "error")]
         on_conflict: String,
 
-        /// Post-load verification (`off` | `count`). Default `count`:
-        /// pre/post `count(*)` per loaded table → L1+L2 verdict.
-        /// Fresh-cluster migrate makes the sole-writer assumption hold
-        /// trivially.
+        /// Post-load verification (`off` | `count` | `full`). Default
+        /// `count`: pre/post `count(*)` per loaded table → L1+L2 verdict
+        /// plus the affirmative schema check. `full` adds per-row value
+        /// verification (L3) — ~one extra full table read. Fresh-cluster
+        /// migrate makes the sole-writer assumption hold trivially.
         #[arg(long, default_value = "count")]
         verify: String,
 
@@ -526,6 +528,18 @@ async fn run_migrate_cli(args: MigrateCliArgs) -> anyhow::Result<()> {
                  Inspect the output above before re-running."
             );
         }
+
+        // Discoverability nudge: only when count+schema actually ran (mode
+        // Count) — point the operator at the deeper per-row check they
+        // didn't opt into. Not under `off` (nothing verified) or `full`
+        // (already the deepest).
+        if verify == VerifyMode::Count {
+            println!();
+            println!(
+                "Row counts and schema verified. For per-row value verification, \
+                 re-run with --verify=full."
+            );
+        }
     }
 
     // Mirror `run_loader`: per-table failures, non-Match verdicts, and
@@ -550,27 +564,52 @@ async fn run_migrate_cli(args: MigrateCliArgs) -> anyhow::Result<()> {
 /// an unknown future variant exits non-zero, never green.
 fn is_bad_verdict(v: &VerifyVerdict) -> bool {
     match v {
-        VerifyVerdict::Match | VerifyVerdict::SkippedNoExactSourceCount => false,
+        // `ValueCheckSkipped` mirrors `SkippedNoExactSourceCount`: an
+        // explicit "not checked" is not itself a failure.
+        VerifyVerdict::Match
+        | VerifyVerdict::SkippedNoExactSourceCount
+        | VerifyVerdict::ValueCheckSkipped => false,
         VerifyVerdict::LoaderDropped(_)
         | VerifyVerdict::MissingTarget(_)
         | VerifyVerdict::ExtraTarget(_)
-        | VerifyVerdict::RowsConflictedAtTarget(_) => true,
+        | VerifyVerdict::RowsConflictedAtTarget(_)
+        | VerifyVerdict::ValueMismatch(_)
+        | VerifyVerdict::ValueRowMissingAtTarget(_) => true,
         _ => true,
     }
 }
 
-/// Print `Verify: <verdict>` and, on a non-clean verdict, the raw counts
-/// so the operator can size the gap without re-running. `nested` indents
-/// under a parent bullet (used for per-table rows in the `migrate` report).
+/// Print `Verify: <verdict>`, the affirmative schema-conformance line (when
+/// present), and — on a non-clean verdict — the raw counts plus the first
+/// offending primary keys so the operator can act without re-running.
+/// `nested` indents under a parent bullet (per-table `migrate` rows).
 fn print_verify_detail(v: &VerifyOutcome, nested: bool) {
     let indent = if nested { "    " } else { "" };
     println!("{indent}Verify: {}", format_verdict(&v.verdict));
+
+    // Affirmative schema line: shown regardless of verdict (it's the
+    // default-on MUST #3 floor). Scoped to column-set + PK presence.
+    if let Some(s) = &v.schema_check {
+        let pk = if s.pk_present {
+            "primary key present"
+        } else {
+            "no primary key"
+        };
+        println!(
+            "{indent}  Schema: {cols} column(s) match, {pk}",
+            cols = s.columns_matched
+        );
+    }
+
     if matches!(
         v.verdict,
-        VerifyVerdict::Match | VerifyVerdict::SkippedNoExactSourceCount
+        VerifyVerdict::Match
+            | VerifyVerdict::SkippedNoExactSourceCount
+            | VerifyVerdict::ValueCheckSkipped
     ) {
         return;
     }
+
     let fmt = |n: Option<u64>| n.map_or("n/a".to_string(), |n| n.to_string());
     let (pre, post) = match v.target_counts {
         Some(c) => (fmt(Some(c.pre)), fmt(Some(c.post))),
@@ -582,6 +621,16 @@ fn print_verify_detail(v: &VerifyOutcome, nested: bool) {
         loaded = v.records_loaded,
         failed = v.records_failed,
     );
+
+    // First offending PKs (capped) so the operator can inspect them.
+    if let Some(d) = &v.l3_details {
+        if !d.mismatch_pks.is_empty() {
+            println!("{indent}  mismatched PKs: {}", d.mismatch_pks.join(", "));
+        }
+        if !d.missing_pks.is_empty() {
+            println!("{indent}  missing PKs: {}", d.missing_pks.join(", "));
+        }
+    }
 }
 
 /// One-line CLI summary per VerifyVerdict.
@@ -610,6 +659,15 @@ fn format_verdict(v: &VerifyVerdict) -> String {
         }
         VerifyVerdict::SkippedNoExactSourceCount => {
             "SKIPPED — no exact source-row count for this format (csv/tsv)".to_string()
+        }
+        VerifyVerdict::ValueMismatch(n) => {
+            format!("VALUE MISMATCH {n} row(s) — target value differs from source by primary key")
+        }
+        VerifyVerdict::ValueRowMissingAtTarget(n) => {
+            format!("MISSING AT TARGET {n} row(s) — source primary key not found in target")
+        }
+        VerifyVerdict::ValueCheckSkipped => {
+            "SKIPPED value check — no single-column primary key to align rows".to_string()
         }
         _ => format!("UNKNOWN VERDICT: {v:?}"),
     }
@@ -1031,10 +1089,13 @@ mod tests {
     fn is_bad_verdict_classifies_every_variant() {
         assert!(!is_bad_verdict(&VerifyVerdict::Match));
         assert!(!is_bad_verdict(&VerifyVerdict::SkippedNoExactSourceCount));
+        assert!(!is_bad_verdict(&VerifyVerdict::ValueCheckSkipped));
         assert!(is_bad_verdict(&VerifyVerdict::LoaderDropped(1)));
         assert!(is_bad_verdict(&VerifyVerdict::MissingTarget(1)));
         assert!(is_bad_verdict(&VerifyVerdict::ExtraTarget(1)));
         assert!(is_bad_verdict(&VerifyVerdict::RowsConflictedAtTarget(1)));
+        assert!(is_bad_verdict(&VerifyVerdict::ValueMismatch(1)));
+        assert!(is_bad_verdict(&VerifyVerdict::ValueRowMissingAtTarget(1)));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -563,20 +563,14 @@ async fn run_migrate_cli(args: MigrateCliArgs) -> anyhow::Result<()> {
 /// arm is mandatory (cross-crate `#[non_exhaustive]`) and fails closed:
 /// an unknown future variant exits non-zero, never green.
 fn is_bad_verdict(v: &VerifyVerdict) -> bool {
-    match v {
-        // `ValueCheckSkipped` mirrors `SkippedNoExactSourceCount`: an
-        // explicit "not checked" is not itself a failure.
+    // Only a clean or explicitly-not-checked verdict is non-failing; every
+    // other variant (incl. unknown future ones, via the `_`) fails closed.
+    !matches!(
+        v,
         VerifyVerdict::Match
-        | VerifyVerdict::SkippedNoExactSourceCount
-        | VerifyVerdict::ValueCheckSkipped => false,
-        VerifyVerdict::LoaderDropped(_)
-        | VerifyVerdict::MissingTarget(_)
-        | VerifyVerdict::ExtraTarget(_)
-        | VerifyVerdict::RowsConflictedAtTarget(_)
-        | VerifyVerdict::ValueMismatch(_)
-        | VerifyVerdict::ValueRowMissingAtTarget(_) => true,
-        _ => true,
-    }
+            | VerifyVerdict::SkippedNoExactSourceCount
+            | VerifyVerdict::ValueCheckSkipped
+    )
 }
 
 /// Print `Verify: <verdict>`, the affirmative schema-conformance line (when
@@ -595,10 +589,11 @@ fn print_verify_detail(v: &VerifyOutcome, nested: bool) {
         } else {
             "no primary/unique key"
         };
-        println!(
-            "{indent}  Schema: {cols} column(s) match, {pk}",
-            cols = s.columns_matched
-        );
+        let cols = match s.columns_matched {
+            Some(n) => format!("{n} column(s) match"),
+            None => "column set verified via load".to_string(),
+        };
+        println!("{indent}  Schema: {cols}, {pk}");
     }
 
     if matches!(
@@ -667,7 +662,7 @@ fn format_verdict(v: &VerifyVerdict) -> String {
             format!("MISSING AT TARGET {n} row(s) — source primary key not found in target")
         }
         VerifyVerdict::ValueCheckSkipped => {
-            "SKIPPED value check — no single-column primary key to align rows".to_string()
+            "SKIPPED value check — no single-column primary/unique key to align rows".to_string()
         }
         _ => format!("UNKNOWN VERDICT: {v:?}"),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -591,9 +591,9 @@ fn print_verify_detail(v: &VerifyOutcome, nested: bool) {
     // default-on MUST #3 floor). Scoped to column-set + PK presence.
     if let Some(s) = &v.schema_check {
         let pk = if s.pk_present {
-            "primary key present"
+            "primary/unique key present"
         } else {
-            "no primary key"
+            "no primary/unique key"
         };
         println!(
             "{indent}  Schema: {cols} column(s) match, {pk}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1093,6 +1093,19 @@ mod tests {
         assert!(is_bad_verdict(&VerifyVerdict::ValueRowMissingAtTarget(1)));
     }
 
+    /// The L3 verdict strings are the operator's only window into a failed
+    /// value check; pin that each renders its key token and interpolates the
+    /// magnitude (a swapped arm or dropped count would ship silently).
+    #[test]
+    fn format_verdict_renders_l3_verdicts() {
+        assert!(format_verdict(&VerifyVerdict::ValueMismatch(7)).contains("VALUE MISMATCH 7"));
+        assert!(
+            format_verdict(&VerifyVerdict::ValueRowMissingAtTarget(3))
+                .contains("MISSING AT TARGET 3")
+        );
+        assert!(format_verdict(&VerifyVerdict::ValueCheckSkipped).contains("SKIPPED value check"));
+    }
+
     #[test]
     fn parse_exclude_columns_basic() {
         assert_eq!(

--- a/src/migrate/orchestrator.rs
+++ b/src/migrate/orchestrator.rs
@@ -1052,11 +1052,6 @@ COPY public.users (id, email) FROM stdin;
     /// silent pass), while the affirmative schema_check still reports
     /// `pk_present: false`. Pins that the Full wiring reaches L3 and routes
     /// the skip through to the summary.
-    ///
-    /// (An L3 `ValueMismatch` requires L1+L2 to both pass while a value
-    /// still diverges — only reachable via post-load mutation, which is the
-    /// real-DSQL E2E's job. The value_check unit tests pin mismatch +
-    /// PK-localization directly.)
     #[tokio::test]
     async fn run_migrate_verify_full_no_pk_skips_value_check() {
         let pool = Pool::sqlite_in_memory().await.unwrap();

--- a/src/migrate/orchestrator.rs
+++ b/src/migrate/orchestrator.rs
@@ -1035,7 +1035,7 @@ COPY public.users (id, email) FROM stdin;
         assert_eq!(
             v.schema_check,
             Some(crate::verify::SchemaCheck {
-                columns_matched: 2,
+                columns_matched: Some(2),
                 pk_present: true,
             })
         );
@@ -1073,7 +1073,7 @@ COPY public.logs (id, msg) FROM stdin;
         assert_eq!(
             v.schema_check,
             Some(crate::verify::SchemaCheck {
-                columns_matched: 2,
+                columns_matched: Some(2),
                 pk_present: false,
             })
         );

--- a/src/migrate/orchestrator.rs
+++ b/src/migrate/orchestrator.rs
@@ -13,7 +13,10 @@ use crate::migrate::transform::{Diagnostic, TransformResult, transform_ddl};
 use crate::runner::{
     Format, LoadArgs, OnConflict, VerifyMode, run_load_with_pool_for_pgdump_block,
 };
-use crate::verify::{L2Counts, VerifyInputs, VerifyOutcome, count_table_rows};
+use crate::verify::{
+    L2Counts, L3Outcome, VerifyInputs, VerifyOutcome, count_table_rows, schema_check,
+    verify_table_values,
+};
 use anyhow::{Context, Result};
 use aws_config::{BehaviorVersion, Region};
 use std::collections::HashMap;
@@ -221,35 +224,39 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
         // verify_error against an empty TableLoadSummary so the report
         // shows which table blocked. The cluster is unchanged for this
         // block (`apply_ddl` already ran but no INSERTs hit yet).
+        // `Count` and `Full` both need the L2 pre-count; `Full` adds L3
+        // on top after the load (wired below). `Off` skips L2 entirely.
         let target_pre = match args.verify {
-            VerifyMode::Count => match count_table_rows(&pool, &block.schema, &block.table).await {
-                Ok(n) => Some(n),
-                Err(e) => {
-                    tables.push(TableLoadSummary {
-                        schema: block.schema.clone(),
-                        table: block.table.clone(),
-                        records_loaded: 0,
-                        records_failed: 0,
-                        source_rows: None,
-                        persisted_manifest_dir: None,
-                        verify: None,
-                        verify_error: Some(format!(
-                            "verify=count: pre-count failed (load not started): {e:#}"
-                        )),
-                    });
-                    // Mirror the post-count halt: mark halted so the bars
-                    // abandon instead of finishing "done".
-                    if let Some(mp) = &migrate_progress {
-                        mp.finish_halted(&format!(
-                            "{schema}.{table}: verify=count pre-count failed",
-                            schema = block.schema,
-                            table = block.table,
-                        ));
+            VerifyMode::Count | VerifyMode::Full => {
+                match count_table_rows(&pool, &block.schema, &block.table).await {
+                    Ok(n) => Some(n),
+                    Err(e) => {
+                        tables.push(TableLoadSummary {
+                            schema: block.schema.clone(),
+                            table: block.table.clone(),
+                            records_loaded: 0,
+                            records_failed: 0,
+                            source_rows: None,
+                            persisted_manifest_dir: None,
+                            verify: None,
+                            verify_error: Some(format!(
+                                "verify: pre-count failed (load not started): {e:#}"
+                            )),
+                        });
+                        // Mirror the post-count halt: mark halted so the bars
+                        // abandon instead of finishing "done".
+                        if let Some(mp) = &migrate_progress {
+                            mp.finish_halted(&format!(
+                                "{schema}.{table}: verify pre-count failed",
+                                schema = block.schema,
+                                table = block.table,
+                            ));
+                        }
+                        halted = true;
+                        break;
                     }
-                    halted = true;
-                    break;
                 }
-            },
+            }
             VerifyMode::Off => None,
         };
 
@@ -274,32 +281,26 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
 
         // Post-count failure: load committed, count(*) failed. Surface
         // the error against a populated summary so the operator sees what
-        // landed and which table needs manual verification.
+        // landed and which table needs manual verification. `Count` and
+        // `Full` both run the L2 post-count + the affirmative schema check;
+        // `Full` additionally runs L3 value verification.
         let (verify, verify_error) = match args.verify {
-            VerifyMode::Count => match count_table_rows(&pool, &block.schema, &block.table).await {
-                Ok(post) => {
-                    let target_counts = target_pre.map(|pre| L2Counts { pre, post });
-                    let outcome = VerifyOutcome::from_inputs(
-                        block.schema.clone(),
-                        block.table.clone(),
-                        VerifyInputs {
-                            mode: args.verify,
-                            on_conflict: args.on_conflict,
-                            source_rows: r.source_rows,
-                            records_loaded: r.records_loaded,
-                            records_failed,
-                            target_counts,
-                        },
-                    );
-                    (Some(outcome), None)
+            VerifyMode::Count | VerifyMode::Full => {
+                match build_table_verify(
+                    &args,
+                    &pool,
+                    reader.clone(),
+                    block,
+                    &r,
+                    records_failed,
+                    target_pre,
+                )
+                .await
+                {
+                    Ok(outcome) => (Some(outcome), None),
+                    Err(e) => (None, Some(format!("verify failed (load completed): {e:#}"))),
                 }
-                Err(e) => (
-                    None,
-                    Some(format!(
-                        "verify=count: post-count failed (load completed): {e:#}"
-                    )),
-                ),
-            },
+            }
             VerifyMode::Off => (None, None),
         };
 
@@ -325,7 +326,7 @@ pub async fn run_migrate(args: MigrateArgs) -> Result<MigrateReport> {
                     )
                 } else {
                     format!(
-                        "{schema}.{table}: verify=count post-count failed",
+                        "{schema}.{table}: post-load verification failed",
                         schema = block.schema,
                         table = block.table,
                     )
@@ -395,6 +396,50 @@ async fn open_source(
             )
         }
     })
+}
+
+/// Build the per-table [`VerifyOutcome`] after a load completes: the L2
+/// post-count, the affirmative schema check (both `Count` and `Full`), and
+/// — under `Full` — the L3 value verification (reusing the already-open
+/// `reader`, no re-open). Any DB error here propagates as a single
+/// `verify failed` so the caller records it against the table.
+async fn build_table_verify(
+    args: &MigrateArgs,
+    pool: &Pool,
+    reader: Arc<dyn ByteReader>,
+    block: &crate::formats::pgdump::CopyBlock,
+    r: &crate::runner::LoadResult,
+    records_failed: u64,
+    target_pre: Option<u64>,
+) -> Result<VerifyOutcome> {
+    let post = count_table_rows(pool, &block.schema, &block.table).await?;
+    let target_counts = target_pre.map(|pre| L2Counts { pre, post });
+    let schema = schema_check(pool, block).await?;
+
+    let (l3, l3_details) = if args.verify == VerifyMode::Full {
+        let (outcome, details) =
+            verify_table_values(pool, reader, block, args.chunk_size_bytes).await?;
+        let details = matches!(outcome, L3Outcome::Ran { .. }).then_some(details);
+        (Some(outcome), details)
+    } else {
+        (None, None)
+    };
+
+    Ok(VerifyOutcome::from_inputs(
+        block.schema.clone(),
+        block.table.clone(),
+        VerifyInputs {
+            mode: args.verify,
+            on_conflict: args.on_conflict,
+            source_rows: r.source_rows,
+            records_loaded: r.records_loaded,
+            records_failed,
+            target_counts,
+            l3,
+        },
+        Some(schema),
+        l3_details,
+    ))
 }
 
 /// Build the `LoadArgs` for a single COPY block. Forwards the migrate
@@ -964,6 +1009,79 @@ COPY public.events (id, label) FROM stdin;
             );
             assert_eq!(v.source_rows, Some(t.records_loaded));
         }
+    }
+
+    /// verify=Full happy path: every table reports `Match`, the affirmative
+    /// `schema_check` is populated (column-set + PK presence), and the L3
+    /// value pass found no divergence (empty `l3_details`).
+    #[tokio::test]
+    async fn run_migrate_verify_full_clean_load_matches_with_schema_check() {
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        let dump = write_dump(
+            "\
+CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT);
+COPY public.users (id, email) FROM stdin;
+1\ta@example.com
+2\tb@example.com
+\\.
+",
+        );
+        let mut args = args_with_pool(&file_uri(dump.path()), pool, false);
+        args.verify = VerifyMode::Full;
+
+        let report = run_migrate(args).await.unwrap();
+        let v = report.tables[0].verify.as_ref().unwrap();
+        assert_eq!(v.verdict, VerifyVerdict::Match);
+        assert_eq!(
+            v.schema_check,
+            Some(crate::verify::SchemaCheck {
+                columns_matched: 2,
+                pk_present: true,
+            })
+        );
+        // Clean load → no per-PK detail recorded.
+        assert!(
+            v.l3_details
+                .as_ref()
+                .is_none_or(|d| d.mismatch_pks.is_empty() && d.missing_pks.is_empty())
+        );
+    }
+
+    /// verify=Full on a table with no primary key: L3 cannot row-align, so
+    /// the verdict is `ValueCheckSkipped` (explicit "not checked", never a
+    /// silent pass), while the affirmative schema_check still reports
+    /// `pk_present: false`. Pins that the Full wiring reaches L3 and routes
+    /// the skip through to the summary.
+    ///
+    /// (An L3 `ValueMismatch` requires L1+L2 to both pass while a value
+    /// still diverges — only reachable via post-load mutation, which is the
+    /// real-DSQL E2E's job. The value_check unit tests pin mismatch +
+    /// PK-localization directly.)
+    #[tokio::test]
+    async fn run_migrate_verify_full_no_pk_skips_value_check() {
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        let dump = write_dump(
+            "\
+CREATE TABLE logs (id INTEGER, msg TEXT);
+COPY public.logs (id, msg) FROM stdin;
+1\thello
+2\tworld
+\\.
+",
+        );
+        let mut args = args_with_pool(&file_uri(dump.path()), pool, false);
+        args.verify = VerifyMode::Full;
+
+        let report = run_migrate(args).await.unwrap();
+        let v = report.tables[0].verify.as_ref().unwrap();
+        assert_eq!(v.verdict, VerifyVerdict::ValueCheckSkipped);
+        assert_eq!(
+            v.schema_check,
+            Some(crate::verify::SchemaCheck {
+                columns_matched: 2,
+                pk_present: false,
+            })
+        );
     }
 
     /// verify=Off → TableLoadSummary.verify is None, no count(*) runs.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -119,8 +119,9 @@ pub struct LoadArgs {
     // Conflict resolution strategy
     pub on_conflict: OnConflict,
 
-    /// L2 toggle. Source-row counting runs parser-side regardless;
-    /// `Count` adds pre/post `count(*)` and a per-table verdict. CLI
+    /// Verification toggle. Source-row counting runs parser-side
+    /// regardless; `Count` adds pre/post `count(*)` + the affirmative schema
+    /// check; `Full` additionally runs the per-row L3 value check. CLI
     /// default: `load`=Off, `migrate`=Count.
     pub verify: VerifyMode,
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -19,7 +19,9 @@ pub use crate::migrate::{
 // Re-export the verification surface — `VerifyMode` is set by the CLI on
 // `LoadArgs`, and `VerifyOutcome` / `VerifyVerdict` ship as fields of
 // `LoadResult` and `TableLoadSummary`.
-pub use crate::verify::{L2Counts, VerifyMode, VerifyOutcome, VerifyVerdict};
+pub use crate::verify::{
+    L2Counts, L3Details, SchemaCheck, VerifyMode, VerifyOutcome, VerifyVerdict,
+};
 
 use anyhow::{Context, Result};
 use aws_config::{BehaviorVersion, Region};
@@ -220,26 +222,28 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     // meaningful. Skip on `--if-not-exists` (table may not exist yet, and a
     // re-run would mis-classify as ExtraTarget) and on csv/tsv (classify()
     // short-circuits to SkippedNoExactSourceCount, wasting two count(*)).
-    let l2_runs = args.verify == VerifyMode::Count
+    // L2 runs under Count and Full alike (Full implies Count). Off skips it.
+    let verify_on = matches!(args.verify, VerifyMode::Count | VerifyMode::Full);
+    let l2_runs = verify_on
         && !args.create_table_if_missing
         && matches!(args.format, Format::PgDump | Format::Parquet);
     let target_pre = if l2_runs {
         Some(
             verify::count_table_rows(&pool, &args.schema, &args.target_table)
                 .await
-                .context("verify=count: failed to read target pre-count")?,
+                .context("verify: failed to read target pre-count")?,
         )
     } else {
         None
     };
 
-    if args.verify == VerifyMode::Count && !l2_runs {
-        // Operator opted into count(*) but the gating conditions skipped
+    if verify_on && !l2_runs {
+        // Operator opted into verification but the gating conditions skipped
         // L2; surface that instead of silently returning Match.
         tracing::info!(
             schema = %args.schema,
             table = %args.target_table,
-            "verify=count: L2 skipped (--if-not-exists or csv/tsv); L1 only"
+            "verify: L2 skipped (--if-not-exists or csv/tsv); L1 only"
         );
     }
 
@@ -247,15 +251,20 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     let target_table = args.target_table.clone();
     let on_conflict = args.on_conflict;
     let verify_mode = args.verify;
+    // Captured for the L3 re-read (args is moved into run_load_with_pool).
+    let source_uri = args.source_uri.clone();
+    let region = args.region.clone();
+    let format = args.format;
+    let chunk_size_bytes = args.chunk_size_bytes;
 
     let mut result = run_load_with_pool(pool.clone(), args).await?;
 
-    if verify_mode == VerifyMode::Count {
+    if verify_on {
         let target_post = if l2_runs {
             Some(
                 verify::count_table_rows(&pool, &schema, &target_table)
                     .await
-                    .context("verify=count: failed to read target post-count")?,
+                    .context("verify: failed to read target post-count")?,
             )
         } else {
             None
@@ -263,6 +272,36 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
         let target_counts = target_pre
             .zip(target_post)
             .map(|(pre, post)| L2Counts { pre, post });
+
+        // Affirmative schema check runs under both Count and Full (the
+        // MUST #3 floor, matching migrate); the per-row L3 value check runs
+        // under Full only. The load path resolves the COPY block itself
+        // (unlike migrate, which pre-resolved it). `l3`/`l3_details` ride
+        // only under Full (and details only when L3 actually Ran).
+        let run_value_check = verify_mode == VerifyMode::Full;
+        let (l3, schema_check, l3_details) = {
+            let (sc, outcome, details) = verify::run_load_value_check(
+                &pool,
+                verify::LoadVerifyTarget {
+                    source_uri: &source_uri,
+                    region: &region,
+                    schema: &schema,
+                    table: &target_table,
+                    is_pgdump: format == Format::PgDump,
+                    run_value_check,
+                    chunk_size_bytes,
+                },
+            )
+            .await?;
+            if run_value_check {
+                let details =
+                    matches!(outcome, crate::verify::L3Outcome::Ran { .. }).then_some(details);
+                (Some(outcome), Some(sc), details)
+            } else {
+                (None, Some(sc), None)
+            }
+        };
+
         result.verify = Some(VerifyOutcome::from_inputs(
             schema,
             target_table,
@@ -273,7 +312,10 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
                 records_loaded: result.records_loaded,
                 records_failed: result.records_failed,
                 target_counts,
+                l3,
             },
+            schema_check,
+            l3_details,
         ));
     }
 
@@ -532,13 +574,14 @@ fn validate_load_args(args: &LoadArgs) -> Result<()> {
         }
     }
 
-    // verify=count's L2 needs target_pre sampled at the start of the
-    // load; on resume the manifest already holds rows from the original
-    // run, so post-pre would be < records_loaded and classify produces a
-    // false MissingTarget/RowsConflictedAtTarget.
-    if args.resume_job_id.is_some() && args.verify == VerifyMode::Count {
+    // L2 (run under both Count and Full) needs target_pre sampled at the
+    // start of the load; on resume the manifest already holds rows from the
+    // original run, so post-pre would be < records_loaded and classify
+    // produces a false MissingTarget/RowsConflictedAtTarget. Full also
+    // re-reads only the resumed portion for L3, compounding the problem.
+    if args.resume_job_id.is_some() && matches!(args.verify, VerifyMode::Count | VerifyMode::Full) {
         anyhow::bail!(
-            "--verify=count cannot be combined with --resume-job-id: pre-count \
+            "--verify (count/full) cannot be combined with --resume-job-id: pre-count \
              would not include rows from the original run. Re-run with --verify=off."
         );
     }
@@ -751,17 +794,28 @@ mod tests {
         assert!(err.contains("create_table_if_missing"), "{err}");
     }
 
-    /// Resume + verify=count would mis-classify: pre-count is sampled
-    /// at resume start but records_loaded sums the entire manifest, so
-    /// post − pre < records_loaded → false MissingTarget.
+    /// Resume + verify (count OR full) would mis-classify: pre-count is
+    /// sampled at resume start but records_loaded sums the entire manifest,
+    /// so post − pre < records_loaded → false MissingTarget. Both L2-running
+    /// modes must be rejected.
     #[test]
-    fn resume_with_verify_count_is_rejected_at_validation() {
+    fn resume_with_verify_count_or_full_is_rejected_at_validation() {
+        for mode in [VerifyMode::Count, VerifyMode::Full] {
+            let mut args = sample_pgdump_args();
+            args.resume_job_id = Some("abc-123".into());
+            args.verify = mode;
+            let err = validate_load_args(&args).unwrap_err().to_string();
+            assert!(err.contains("--resume-job-id"), "mode {mode:?}: {err}");
+        }
+    }
+
+    /// Resume + verify=off is allowed (no L2 to mis-classify).
+    #[test]
+    fn resume_with_verify_off_is_allowed() {
         let mut args = sample_pgdump_args();
         args.resume_job_id = Some("abc-123".into());
-        args.verify = VerifyMode::Count;
-        let err = validate_load_args(&args).unwrap_err().to_string();
-        assert!(err.contains("--verify=count"), "{err}");
-        assert!(err.contains("--resume-job-id"), "{err}");
+        args.verify = VerifyMode::Off;
+        validate_load_args(&args).unwrap();
     }
 
     #[tokio::test]

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -98,7 +98,10 @@ pub enum L3Outcome {
 /// checks are out of scope, see the requirements doc).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SchemaCheck {
-    pub columns_matched: u64,
+    /// `Some(n)` = the load enforced an n-column COPY set; `None` = not
+    /// counted (non-pgdump format has no COPY block to measure), distinct
+    /// from `Some(0)`.
+    pub columns_matched: Option<u64>,
     /// True when the target has a primary key OR a unique constraint
     /// (`get_unique_constraint_columns` falls back to the first unique key).
     pub pk_present: bool,
@@ -165,8 +168,8 @@ pub enum VerifyVerdict {
     /// `ValueMismatch` for the single verdict slot.
     ValueRowMissingAtTarget(u64),
     /// L3 requested (`mode=Full`) but could not run — no usable
-    /// single-column non-null primary key, or a format without an exact
-    /// source-row count. Explicit "not checked", never a silent pass.
+    /// single-column non-null primary/unique key, or a format without an
+    /// exact source-row count. Explicit "not checked", never a silent pass.
     ValueCheckSkipped,
 }
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,30 +1,43 @@
-//! Count-level load verification.
+//! Load verification.
 //!
 //! - **L1**: source `source_rows` vs `loaded + failed`. Catches drops
 //!   between source bytes and the DB layer (parser/chunker bugs).
 //! - **L2**: target `post - pre` vs `loaded`. Catches drops between
 //!   INSERT and table contents. Shortfall is `MissingTarget` under
 //!   `Error`, `RowsConflictedAtTarget` under `DoNothing`/`DoUpdate`.
-//!
-//! Counts only — no value-level fidelity check.
+//! - **L3** (`mode=Full`): per-row value comparison by primary key — see
+//!   [`value_check`]. Verifies the target reproduces the loaded value;
+//!   trusts the reader to decode (the self-as-oracle ceiling).
+
+mod value_check;
+
+pub(crate) use value_check::{
+    LoadVerifyTarget, run_load_value_check, schema_check, verify_table_values,
+};
 
 use crate::coordination::manifest::OnConflict;
 use crate::db::Pool;
 use anyhow::{Context, Result};
 
-/// L2 toggle. Source-row counting happens parser-side regardless;
-/// `Count` adds pre/post `count(*)` and produces a `VerifyOutcome` per
-/// loaded table.
+/// Verification depth toggle. Source-row counting happens parser-side
+/// regardless; higher modes add more checks and produce a `VerifyOutcome`
+/// per loaded table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum VerifyMode {
     #[default]
     Off,
-    /// Pre/post `count(*)` per loaded table. Assumes the load is the
+    /// Pre/post `count(*)` per loaded table (L2). Assumes the load is the
     /// sole writer to the target during the load window — concurrent
     /// writes surface as `ExtraTarget` (insert) or `MissingTarget`
     /// (delete). `migrate` against a fresh cluster satisfies this.
     Count,
+    /// Everything `Count` does, plus per-row value verification (L3):
+    /// re-read the source, fetch each target row by primary key, and
+    /// confirm the target reproduces the loaded value. Cost ≈ one extra
+    /// full read of the table — opt-in. Carries an inherent decode-class
+    /// blind spot (it trusts the reader); see the value-fidelity design.
+    Full,
 }
 
 impl std::str::FromStr for VerifyMode {
@@ -34,8 +47,9 @@ impl std::str::FromStr for VerifyMode {
         match s.to_lowercase().as_str() {
             "off" => Ok(VerifyMode::Off),
             "count" => Ok(VerifyMode::Count),
+            "full" => Ok(VerifyMode::Full),
             _ => Err(anyhow::anyhow!(
-                "Invalid --verify value '{}'. Must be one of: off, count",
+                "Invalid --verify value '{}'. Must be one of: off, count, full",
                 s
             )),
         }
@@ -47,6 +61,7 @@ impl std::fmt::Display for VerifyMode {
         match self {
             VerifyMode::Off => write!(f, "off"),
             VerifyMode::Count => write!(f, "count"),
+            VerifyMode::Full => write!(f, "full"),
         }
     }
 }
@@ -58,6 +73,44 @@ impl std::fmt::Display for VerifyMode {
 pub struct L2Counts {
     pub pre: u64,
     pub post: u64,
+}
+
+/// Result of the L3 value-verification pass (`mode=Full`). `Ran` carries
+/// the aggregate counts across all PK-range batches; `Skipped` means L3
+/// was requested but could not run (no usable PK / non-exact-count format).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum L3Outcome {
+    Ran {
+        /// True total of rows whose target value diverged, summed across
+        /// every batch (not capped — the detail list is capped separately).
+        value_mismatches: u64,
+        /// True total of source PKs not found at the target.
+        rows_missing_at_target: u64,
+    },
+    Skipped,
+}
+
+/// Affirmative schema-conformance line (MUST #3): the column set the load
+/// enforced matched the dump's COPY columns, and whether the table has a
+/// primary key. Scoped to **column-set + PK presence only** — NOT column
+/// types/nullability/defaults (a successful load already proves the column
+/// set matches via `align_pgdump_schema_to_copy_columns`; deeper checks are
+/// out of scope, see the requirements doc).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SchemaCheck {
+    pub columns_matched: u64,
+    pub pk_present: bool,
+}
+
+/// Per-PK localization for L3 (`mode=Full`): the first K offending primary
+/// keys, so the operator sees *which* rows diverged, not just how many.
+/// PK-level only (the DMS `KEY` analog); column-level detail (DMS
+/// `DETAILS`) is a follow-up. Lists are capped; the verdict magnitude
+/// carries the true total.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct L3Details {
+    pub mismatch_pks: Vec<String>,
+    pub missing_pks: Vec<String>,
 }
 
 /// One verification outcome per loaded table.
@@ -73,6 +126,11 @@ pub struct VerifyOutcome {
     /// `Some` when L2 ran, `None` otherwise.
     pub target_counts: Option<L2Counts>,
     pub verdict: VerifyVerdict,
+    /// Affirmative schema-conformance line; `None` when verify is `Off`.
+    pub schema_check: Option<SchemaCheck>,
+    /// First-K offending PKs when L3 found divergence; `None` when L3 didn't
+    /// run or found nothing to localize.
+    pub l3_details: Option<L3Details>,
 }
 
 /// Most actionable verdict per table; payload is the magnitude.
@@ -96,6 +154,18 @@ pub enum VerifyVerdict {
     RowsConflictedAtTarget(u64),
     /// csv/tsv: no exact source count, so L1 can't run.
     SkippedNoExactSourceCount,
+    /// L3 (`mode=Full`): N rows where the target value differs from the
+    /// source after server-side re-cast. The **true total** across all
+    /// PK-range batches; per-PK detail (capped) rides `VerifyOutcome`.
+    ValueMismatch(u64),
+    /// L3: N source PKs absent from the target. More fundamental than a
+    /// value diff (the row isn't there at all), so it outranks
+    /// `ValueMismatch` for the single verdict slot.
+    ValueRowMissingAtTarget(u64),
+    /// L3 requested (`mode=Full`) but could not run — no usable
+    /// single-column non-null primary key, or a format without an exact
+    /// source-row count. Explicit "not checked", never a silent pass.
+    ValueCheckSkipped,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -107,11 +177,22 @@ pub(crate) struct VerifyInputs {
     pub records_failed: u64,
     /// `Some` when L2 ran, `None` otherwise.
     pub target_counts: Option<L2Counts>,
+    /// `Some` when L3 (`mode=Full`) ran or was attempted, `None` otherwise.
+    pub l3: Option<L3Outcome>,
 }
 
 impl VerifyOutcome {
-    /// Classify `inputs` and bind the verdict to `(schema, table)`.
-    pub(crate) fn from_inputs(schema: String, table: String, inputs: VerifyInputs) -> Self {
+    /// Classify `inputs` and bind the verdict to `(schema, table)`. The
+    /// affirmative outputs (`schema_check`, `l3_details`) are report-only —
+    /// they don't affect the verdict, so they ride alongside `inputs`
+    /// (which stays `Copy`) rather than feeding `classify`.
+    pub(crate) fn from_inputs(
+        schema: String,
+        table: String,
+        inputs: VerifyInputs,
+        schema_check: Option<SchemaCheck>,
+        l3_details: Option<L3Details>,
+    ) -> Self {
         let verdict = classify(inputs);
         VerifyOutcome {
             schema,
@@ -121,15 +202,19 @@ impl VerifyOutcome {
             records_failed: inputs.records_failed,
             target_counts: inputs.target_counts,
             verdict,
+            schema_check,
+            l3_details,
         }
     }
 }
 
 /// Pure verdict classifier — no I/O, exhaustively unit-tested.
 ///
-/// Order: source `None` → `SkippedNoExactSourceCount`; L1 shortfall →
-/// `LoaderDropped`; L2 (if mode=Count and counts present) → see
-/// variants; otherwise `Match`.
+/// Order (precedence source > L1 > L2 > L3): source `None` →
+/// `SkippedNoExactSourceCount`; L1 shortfall → `LoaderDropped`; L2 (if
+/// mode is Count/Full and counts present) → `Missing`/`Extra`/`Conflicted`;
+/// L3 (if mode is Full) → `ValueRowMissingAtTarget`/`ValueMismatch`/
+/// `ValueCheckSkipped`; otherwise `Match`.
 pub(crate) fn classify(inputs: VerifyInputs) -> VerifyVerdict {
     let Some(source_rows) = inputs.source_rows else {
         return VerifyVerdict::SkippedNoExactSourceCount;
@@ -143,7 +228,8 @@ pub(crate) fn classify(inputs: VerifyInputs) -> VerifyVerdict {
     // parquet (counts are exact); collapse to Match. Add a variant when
     // a future format introduces uncertainty.
 
-    if inputs.mode == VerifyMode::Count
+    // L2 runs under both Count and Full (Full implies Count).
+    if matches!(inputs.mode, VerifyMode::Count | VerifyMode::Full)
         && let Some(L2Counts { pre, post }) = inputs.target_counts
     {
         // saturating_sub: a concurrent DELETE (post < pre) normalises to
@@ -163,6 +249,26 @@ pub(crate) fn classify(inputs: VerifyInputs) -> VerifyVerdict {
                     VerifyVerdict::RowsConflictedAtTarget(shortfall)
                 }
             };
+        }
+    }
+
+    // L3 (mode=Full): runs only after L1 and L2 cleared, preserving
+    // precedence source > L1 > L2 > L3. Within L3, a missing row (data
+    // absent) outranks a value mismatch for the single verdict slot.
+    if let Some(l3) = inputs.l3 {
+        match l3 {
+            L3Outcome::Skipped => return VerifyVerdict::ValueCheckSkipped,
+            L3Outcome::Ran {
+                value_mismatches,
+                rows_missing_at_target,
+            } => {
+                if rows_missing_at_target > 0 {
+                    return VerifyVerdict::ValueRowMissingAtTarget(rows_missing_at_target);
+                }
+                if value_mismatches > 0 {
+                    return VerifyVerdict::ValueMismatch(value_mismatches);
+                }
+            }
         }
     }
 
@@ -215,7 +321,98 @@ mod tests {
             records_loaded: loaded,
             records_failed: failed,
             target_counts,
+            l3: None,
         }
+    }
+
+    /// L1+L2-clean inputs at `mode=Full` carrying an L3 outcome — the base
+    /// for the value-verdict tests. Counts are set so L1 and L2 both pass,
+    /// so the verdict is driven purely by `l3`.
+    fn full_with_l3(l3: L3Outcome) -> VerifyInputs {
+        VerifyInputs {
+            l3: Some(l3),
+            ..inputs(
+                VerifyMode::Full,
+                OnConflict::Error,
+                Some(100),
+                100,
+                0,
+                Some(0),
+                Some(100),
+            )
+        }
+    }
+
+    #[test]
+    fn l3_clean_is_match() {
+        let v = classify(full_with_l3(L3Outcome::Ran {
+            value_mismatches: 0,
+            rows_missing_at_target: 0,
+        }));
+        assert_eq!(v, VerifyVerdict::Match);
+    }
+
+    #[test]
+    fn l3_value_mismatch_reports_total() {
+        let v = classify(full_with_l3(L3Outcome::Ran {
+            value_mismatches: 7,
+            rows_missing_at_target: 0,
+        }));
+        assert_eq!(v, VerifyVerdict::ValueMismatch(7));
+    }
+
+    #[test]
+    fn l3_missing_at_target_reports_total() {
+        let v = classify(full_with_l3(L3Outcome::Ran {
+            value_mismatches: 0,
+            rows_missing_at_target: 3,
+        }));
+        assert_eq!(v, VerifyVerdict::ValueRowMissingAtTarget(3));
+    }
+
+    #[test]
+    fn l3_missing_takes_precedence_over_mismatch() {
+        // A table with both missing rows and value mismatches: missing
+        // (data absent) is the more fundamental signal and wins the single
+        // verdict slot. The per-PK detail list carries both.
+        let v = classify(full_with_l3(L3Outcome::Ran {
+            value_mismatches: 5,
+            rows_missing_at_target: 2,
+        }));
+        assert_eq!(v, VerifyVerdict::ValueRowMissingAtTarget(2));
+    }
+
+    #[test]
+    fn l3_skipped_is_value_check_skipped() {
+        // mode=Full requested but L3 couldn't run (no usable PK, or a
+        // non-exact-count format) — explicit "not checked", never a silent
+        // pass.
+        let v = classify(full_with_l3(L3Outcome::Skipped));
+        assert_eq!(v, VerifyVerdict::ValueCheckSkipped);
+    }
+
+    #[test]
+    fn l1_drop_takes_precedence_over_l3() {
+        // L1 shortfall must win over any L3 result (source > L1 > L2 > L3).
+        let mut i = full_with_l3(L3Outcome::Ran {
+            value_mismatches: 9,
+            rows_missing_at_target: 0,
+        });
+        i.source_rows = Some(100);
+        i.records_loaded = 90;
+        i.records_failed = 0;
+        assert_eq!(classify(i), VerifyVerdict::LoaderDropped(10));
+    }
+
+    #[test]
+    fn l2_shortfall_takes_precedence_over_l3() {
+        // L2 shortfall must win over L3 (precedence L2 > L3).
+        let mut i = full_with_l3(L3Outcome::Ran {
+            value_mismatches: 9,
+            rows_missing_at_target: 0,
+        });
+        i.target_counts = Some(L2Counts { pre: 0, post: 95 });
+        assert_eq!(classify(i), VerifyVerdict::MissingTarget(5));
     }
 
     #[test]
@@ -391,7 +588,7 @@ mod tests {
 
     #[test]
     fn verify_mode_round_trips_through_str() {
-        for m in [VerifyMode::Off, VerifyMode::Count] {
+        for m in [VerifyMode::Off, VerifyMode::Count, VerifyMode::Full] {
             let s = m.to_string();
             assert_eq!(s.parse::<VerifyMode>().unwrap(), m);
         }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -76,8 +76,8 @@ pub struct L2Counts {
 }
 
 /// Result of the L3 value-verification pass (`mode=Full`). `Ran` carries
-/// the aggregate counts across all PK-range batches; `Skipped` means L3
-/// was requested but could not run (no usable PK / non-exact-count format).
+/// the aggregate counts across all PK batches; `Skipped` means L3 was
+/// requested but could not run (no usable PK / non-exact-count format).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum L3Outcome {
     Ran {
@@ -92,13 +92,15 @@ pub enum L3Outcome {
 
 /// Affirmative schema-conformance line (MUST #3): the column set the load
 /// enforced matched the dump's COPY columns, and whether the table has a
-/// primary key. Scoped to **column-set + PK presence only** — NOT column
-/// types/nullability/defaults (a successful load already proves the column
-/// set matches via `align_pgdump_schema_to_copy_columns`; deeper checks are
-/// out of scope, see the requirements doc).
+/// primary or unique key. Scoped to **column-set + key presence only** —
+/// NOT column types/nullability/defaults (a successful load already proves
+/// the column set matches via `align_pgdump_schema_to_copy_columns`; deeper
+/// checks are out of scope, see the requirements doc).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SchemaCheck {
     pub columns_matched: u64,
+    /// True when the target has a primary key OR a unique constraint
+    /// (`get_unique_constraint_columns` falls back to the first unique key).
     pub pk_present: bool,
 }
 
@@ -156,7 +158,7 @@ pub enum VerifyVerdict {
     SkippedNoExactSourceCount,
     /// L3 (`mode=Full`): N rows where the target value differs from the
     /// source after server-side re-cast. The **true total** across all
-    /// PK-range batches; per-PK detail (capped) rides `VerifyOutcome`.
+    /// PK batches; per-PK detail (capped) rides `VerifyOutcome`.
     ValueMismatch(u64),
     /// L3: N source PKs absent from the target. More fundamental than a
     /// value diff (the row isn't there at all), so it outranks

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -168,8 +168,9 @@ pub enum VerifyVerdict {
     /// `ValueMismatch` for the single verdict slot.
     ValueRowMissingAtTarget(u64),
     /// L3 requested (`mode=Full`) but could not run — no usable
-    /// single-column non-null primary/unique key, or a format without an
-    /// exact source-row count. Explicit "not checked", never a silent pass.
+    /// single-column primary/unique key, or a format without an exact
+    /// source-row count. Explicit "not checked", never a silent pass.
+    /// (A NULL value in the source key errors, it does not skip.)
     ValueCheckSkipped,
 }
 

--- a/src/verify/value_check.rs
+++ b/src/verify/value_check.rs
@@ -314,12 +314,14 @@ fn recast_literal(ty: &SqlType, value: &str) -> String {
 /// Per-column match predicate: `None` (source `\N`) → `"col" IS NULL`;
 /// `Some(v)` → `"col" <nseq> <recast literal>`. `col` is double-quoted.
 ///
-/// `json` has no `=` operator, so a direct `IS NOT DISTINCT FROM` errors on
-/// Postgres/DSQL. The loader stores `json` as the verbatim source COPY text
-/// (the type preserves input formatting), so we compare `CAST("col" AS
-/// text)` against the bare source text — exact and equality-capable. This
-/// is a textual, not semantic-JSON, comparison (whitespace-sensitive),
-/// which is correct here because the target text IS the source text.
+/// `json` is special-cased: it has no `=` operator (a direct
+/// `IS NOT DISTINCT FROM` errors), but it stores the verbatim source COPY
+/// text, so we compare `CAST("col" AS text)` against the bare source text —
+/// exact and equality-capable. This is textual, not semantic-JSON. `jsonb`
+/// is NOT special-cased: it *has* `=` and canonicalizes input (key order /
+/// whitespace), so it must compare via native `CAST('v' AS jsonb)` (a text
+/// compare would false-mismatch on the canonicalization) — that's the
+/// default `recast_literal` arm below.
 fn column_predicate(col: &str, ty: &SqlType, value: Option<&str>, is_postgres: bool) -> String {
     let quoted = format!("\"{col}\"");
     let nseq = null_safe_eq(is_postgres);
@@ -739,6 +741,17 @@ mod tests {
         assert_eq!(
             p,
             "CAST(\"payload\" AS TEXT) IS NOT DISTINCT FROM '{\"k\":\"v\"}'"
+        );
+    }
+
+    #[test]
+    fn predicate_jsonb_compares_natively_not_as_text() {
+        // jsonb HAS `=` and canonicalizes input, so it must recast to jsonb
+        // (a text compare would false-mismatch on key/whitespace reordering).
+        let p = column_predicate("payload", &SqlType::Jsonb, Some("{\"k\":\"v\"}"), true);
+        assert_eq!(
+            p,
+            "\"payload\" IS NOT DISTINCT FROM CAST('{\"k\":\"v\"}' AS JSONB)"
         );
     }
 

--- a/src/verify/value_check.rs
+++ b/src/verify/value_check.rs
@@ -1,9 +1,12 @@
 //! L3 value verification: build the server-side recast-compare query and
 //! diff the source (re-read, decoded TEXT) against the target by primary
-//! key. The DB is the type authority — a source field is pushed back
-//! through the same `CAST` the loader used at INSERT, compared null-safe
-//! (`IS NOT DISTINCT FROM` on Postgres/DSQL, `IS` on SQLite), so canonical
-//! forms (`1.5` vs `1.50`, `\N` vs NULL) match without a client normalizer.
+//! key. The DB is the type authority — a source field is recast through the
+//! column's *parameterized* type and compared null-safe (`IS NOT DISTINCT
+//! FROM` on Postgres/DSQL, `IS` on SQLite), so the comparison reproduces the
+//! column's assignment-time coercion: canonical forms (`1.5` vs `1.50`, `\N`
+//! vs NULL) and typmod rounding (`numeric(10,2)` storing `1.005`→`1.01`)
+//! match without a client normalizer. See [`column_types`] for why the type
+//! name must carry its precision/scale.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -238,11 +241,33 @@ fn is_match(matches_text: &str) -> bool {
     matches!(matches_text, "true" | "1")
 }
 
-/// name → Postgres type name (the [`SqlType::to_postgres`] form) for every
-/// column of the target table. Verify compares on the type *name* string —
-/// the same currency the worker's INSERT casts through — so it never needs
-/// the `SqlType` vocabulary itself, only the name it would have written.
+/// name → the column's fully-parameterized type name for every column of the
+/// target table, e.g. `numeric(10,2)`, `timestamp(0) without time zone`.
+/// Verify recasts each source value through this *exact* type so the compare
+/// reproduces the column's assignment-time coercion: a `numeric(10,2)` column
+/// rounds `'1.005'`→`1.01` on load, and recasting through the bare `NUMERIC`
+/// (no scale) keeps `1.005`, false-mismatching a faithful load. The
+/// parameterized recast rounds identically. (Verified on a live DSQL cluster.)
+///
+/// `pg_catalog.format_type(atttypid, atttypmod)` yields the parameterized
+/// spelling in one castable string. SQLite (tests) has no such catalog, so it
+/// falls back to the inferred [`SqlType::to_postgres`] name — SQLite's type
+/// affinity makes the recast forgiving and tests don't exercise typmod.
 async fn column_types(pool: &Pool, schema: &str, table: &str) -> Result<HashMap<String, String>> {
+    if pool.is_postgres() {
+        let sql = "SELECT a.attname, format_type(a.atttypid, a.atttypmod) \
+                   FROM pg_attribute a \
+                   JOIN pg_class c ON c.oid = a.attrelid \
+                   JOIN pg_namespace n ON n.oid = c.relnamespace \
+                   WHERE n.nspname = $1 AND c.relname = $2 \
+                     AND a.attnum > 0 AND NOT a.attisdropped";
+        let rows: Vec<(String, String)> = pool
+            .fetch_all_with_binds(sql, &[schema, table])
+            .await
+            .with_context(|| format!("verify=full: type lookup for {schema}.{table}"))?;
+        return Ok(rows.into_iter().collect());
+    }
+    // SQLite test path: no pg_catalog; use the inferred type names.
     let resolved = query_table_schema(pool, schema, table).await?;
     Ok(resolved
         .columns
@@ -303,15 +328,18 @@ fn null_safe_eq(is_postgres: bool) -> &'static str {
     }
 }
 
-/// `true` for a type name (`to_postgres()` form) that must be compared as
-/// text rather than recast natively: `JSON` has no `=` operator (a direct
-/// `IS NOT DISTINCT FROM` against a `CAST(.. AS JSON)` errors), but it stores
-/// the verbatim source COPY text, so `CAST("col" AS TEXT)` vs the bare source
-/// text is exact and equality-capable. `JSONB` is deliberately excluded: it
-/// *has* `=` and canonicalizes input (key order / whitespace), so it recasts
-/// natively (a text compare would false-mismatch on the canonicalization).
+/// `true` for a type name that must be compared as text rather than recast
+/// natively: `json` has no `=` operator (a direct `IS NOT DISTINCT FROM`
+/// against a `CAST(.. AS json)` errors), but it stores the verbatim source
+/// COPY text, so `CAST("col" AS TEXT)` vs the bare source text is exact and
+/// equality-capable. `jsonb` is deliberately excluded: it *has* `=` and
+/// canonicalizes input (key order / whitespace), so it recasts natively (a
+/// text compare would false-mismatch on the canonicalization).
+///
+/// Case-insensitive: the name may be the worker's `to_postgres()` form
+/// (`JSON`) or the catalog's `format_type` form (`json`).
 fn compares_as_text(pg_type: &str) -> bool {
-    pg_type == "JSON"
+    pg_type.eq_ignore_ascii_case("json")
 }
 
 /// Per-column match predicate: `None` (source `\N`) → `"col" IS NULL`;
@@ -806,6 +834,53 @@ mod tests {
         assert_eq!(
             p,
             "\"payload\" IS NOT DISTINCT FROM CAST('{\"k\":\"v\"}' AS JSONB)"
+        );
+    }
+
+    #[test]
+    fn predicate_parameterized_type_recasts_with_precision() {
+        // The catalog (format_type) hands verify the *parameterized* type, so
+        // the recast reproduces the column's assignment-time rounding —
+        // `numeric(10,2)` stores '1.005' as 1.01 and the recast must round the
+        // same way (validated against live DSQL). The bare `NUMERIC` would
+        // keep 1.005 and false-mismatch a faithful load.
+        let p = column_predicate("amt", "numeric(10,2)", Some("1.005"), true);
+        assert_eq!(
+            p,
+            "\"amt\" IS NOT DISTINCT FROM CAST('1.005' AS numeric(10,2))"
+        );
+        let p = column_predicate(
+            "ts",
+            "timestamp(0) without time zone",
+            Some("2024-01-01 10:23:54.6"),
+            true,
+        );
+        assert_eq!(
+            p,
+            "\"ts\" IS NOT DISTINCT FROM CAST('2024-01-01 10:23:54.6' AS timestamp(0) without time zone)"
+        );
+    }
+
+    #[test]
+    fn predicate_lowercase_json_takes_text_path() {
+        // format_type yields lowercase `json`; compares_as_text must still
+        // route it to the text-compare (json has no `=` operator).
+        let p = column_predicate("payload", "json", Some("{\"k\":\"v\"}"), true);
+        assert_eq!(
+            p,
+            "CAST(\"payload\" AS TEXT) IS NOT DISTINCT FROM '{\"k\":\"v\"}'"
+        );
+    }
+
+    #[test]
+    fn predicate_parameterized_varchar_casts_with_length() {
+        // Verify casts the TEXT family through the parameterized name (it
+        // carries the length, unlike the worker's bare `VARCHAR`), so
+        // character varying(5) blank-/length-coerces faithfully.
+        let p = column_predicate("vc", "character varying(5)", Some("ab"), true);
+        assert_eq!(
+            p,
+            "\"vc\" IS NOT DISTINCT FROM CAST('ab' AS character varying(5))"
         );
     }
 

--- a/src/verify/value_check.rs
+++ b/src/verify/value_check.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result};
 
 use super::{L3Details, L3Outcome, SchemaCheck};
 use crate::db::Pool;
-use crate::db::schema::{SqlType, escape_sql_literal, inserts_as_bare_literal, query_table_schema};
+use crate::db::schema::{escape_sql_literal, query_table_schema, recast_literal};
 use crate::formats::pgdump::{CopyBlock, PgDumpReader, find_copy_block};
 use crate::formats::reader::{FileReader, Record};
 use crate::io::{ByteReader, LocalFileByteReader, S3ByteReader, SourceUri};
@@ -161,8 +161,8 @@ pub(crate) async fn verify_table_values(
     };
 
     let col_types = column_types(pool, &block.schema, &block.table).await?;
-    // Every COPY column must resolve to a type for the recast compare.
-    let types: Vec<SqlType> = block
+    // Every COPY column must resolve to a type name for the recast compare.
+    let types: Vec<String> = block
         .columns
         .iter()
         .map(|c| {
@@ -238,13 +238,16 @@ fn is_match(matches_text: &str) -> bool {
     matches!(matches_text, "true" | "1")
 }
 
-/// name → SqlType for every column of the target table.
-async fn column_types(pool: &Pool, schema: &str, table: &str) -> Result<HashMap<String, SqlType>> {
+/// name → Postgres type name (the [`SqlType::to_postgres`] form) for every
+/// column of the target table. Verify compares on the type *name* string —
+/// the same currency the worker's INSERT casts through — so it never needs
+/// the `SqlType` vocabulary itself, only the name it would have written.
+async fn column_types(pool: &Pool, schema: &str, table: &str) -> Result<HashMap<String, String>> {
     let resolved = query_table_schema(pool, schema, table).await?;
     Ok(resolved
         .columns
         .into_iter()
-        .map(|c| (c.name, c.sql_type))
+        .map(|c| (c.name, c.sql_type.to_postgres().to_string()))
         .collect())
 }
 
@@ -271,7 +274,7 @@ fn source_row<'a>(
     rec: &'a Record,
     block: &'a CopyBlock,
     pk_idx: usize,
-    types: &'a [SqlType],
+    types: &'a [String],
 ) -> Result<SourceRow<'a>> {
     let pk_value = rec.fields[pk_idx].as_deref().with_context(|| {
         format!(
@@ -284,7 +287,7 @@ fn source_row<'a>(
         .iter()
         .enumerate()
         .filter(|(i, _)| *i != pk_idx)
-        .map(|(i, name)| (name.as_str(), &types[i], rec.fields[i].as_deref()))
+        .map(|(i, name)| (name.as_str(), types[i].as_str(), rec.fields[i].as_deref()))
         .collect();
     Ok(SourceRow { pk_value, columns })
 }
@@ -300,41 +303,31 @@ fn null_safe_eq(is_postgres: bool) -> &'static str {
     }
 }
 
-/// Render a value as the SQL literal the worker would have inserted: bare
-/// `'v'` for the TEXT family, `CAST('v' AS TYPE)` otherwise. Shares
-/// `inserts_as_bare_literal` with the worker so the bare-vs-CAST decision
-/// matches the write path on Postgres/DSQL (SQLite tests accept the extra
-/// CAST harmlessly — the worker inserts bare there).
-fn recast_literal(ty: &SqlType, value: &str) -> String {
-    let lit = format!("'{}'", escape_sql_literal(value));
-    if inserts_as_bare_literal(ty.to_postgres()) {
-        lit
-    } else {
-        format!("CAST({lit} AS {})", ty.to_postgres())
-    }
+/// `true` for a type name (`to_postgres()` form) that must be compared as
+/// text rather than recast natively: `JSON` has no `=` operator (a direct
+/// `IS NOT DISTINCT FROM` against a `CAST(.. AS JSON)` errors), but it stores
+/// the verbatim source COPY text, so `CAST("col" AS TEXT)` vs the bare source
+/// text is exact and equality-capable. `JSONB` is deliberately excluded: it
+/// *has* `=` and canonicalizes input (key order / whitespace), so it recasts
+/// natively (a text compare would false-mismatch on the canonicalization).
+fn compares_as_text(pg_type: &str) -> bool {
+    pg_type == "JSON"
 }
 
 /// Per-column match predicate: `None` (source `\N`) → `"col" IS NULL`;
 /// `Some(v)` → `"col" <nseq> <recast literal>`. `col` is double-quoted.
-///
-/// `json` is special-cased: it has no `=` operator (a direct
-/// `IS NOT DISTINCT FROM` errors), but it stores the verbatim source COPY
-/// text, so we compare `CAST("col" AS text)` against the bare source text —
-/// exact and equality-capable. This is textual, not semantic-JSON. `jsonb`
-/// is NOT special-cased: it *has* `=` and canonicalizes input (key order /
-/// whitespace), so it must compare via native `CAST('v' AS jsonb)` (a text
-/// compare would false-mismatch on the canonicalization) — that's the
-/// default `recast_literal` arm below.
-fn column_predicate(col: &str, ty: &SqlType, value: Option<&str>, is_postgres: bool) -> String {
+/// `ty` is the column's `to_postgres()` type name; `JSON` takes the
+/// text-compare path (see [`compares_as_text`]), everything else recasts.
+fn column_predicate(col: &str, ty: &str, value: Option<&str>, is_postgres: bool) -> String {
     let quoted = format!("\"{col}\"");
     let nseq = null_safe_eq(is_postgres);
-    match (value, ty) {
-        (None, _) => format!("{quoted} IS NULL"),
-        (Some(v), SqlType::Json) => {
+    match value {
+        None => format!("{quoted} IS NULL"),
+        Some(v) if compares_as_text(ty) => {
             let lit = format!("'{}'", escape_sql_literal(v));
             format!("CAST({quoted} AS TEXT) {nseq} {lit}")
         }
-        (Some(v), _) => format!("{quoted} {nseq} {}", recast_literal(ty, v)),
+        Some(v) => format!("{quoted} {nseq} {}", recast_literal(ty, v)),
     }
 }
 
@@ -342,7 +335,7 @@ fn column_predicate(col: &str, ty: &SqlType, value: Option<&str>, is_postgres: b
 /// (column, type, value) tuples for every non-PK loaded column.
 pub(crate) struct SourceRow<'a> {
     pub pk_value: &'a str,
-    pub columns: Vec<(&'a str, &'a SqlType, Option<&'a str>)>,
+    pub columns: Vec<(&'a str, &'a str, Option<&'a str>)>,
 }
 
 /// Build the projected-bool batch query: for each `SourceRow`, return
@@ -358,7 +351,7 @@ pub(crate) struct SourceRow<'a> {
 fn build_batch_query(
     qualified_table: &str,
     pk_col: &str,
-    pk_type: &SqlType,
+    pk_type: &str,
     rows: &[SourceRow<'_>],
     is_postgres: bool,
 ) -> String {
@@ -756,38 +749,38 @@ mod tests {
 
     #[test]
     fn predicate_null_source_is_is_null() {
-        let p = column_predicate("note", &SqlType::Text, None, true);
+        let p = column_predicate("note", "TEXT", None, true);
         assert_eq!(p, "\"note\" IS NULL");
     }
 
     #[test]
     fn predicate_text_column_no_cast() {
         // TEXT family inserts bare, so verify compares bare.
-        let p = column_predicate("name", &SqlType::Text, Some("alice"), true);
+        let p = column_predicate("name", "TEXT", Some("alice"), true);
         assert_eq!(p, "\"name\" IS NOT DISTINCT FROM 'alice'");
     }
 
     #[test]
     fn predicate_numeric_column_casts() {
-        let p = column_predicate("amount", &SqlType::Numeric, Some("1.5"), true);
+        let p = column_predicate("amount", "NUMERIC", Some("1.5"), true);
         assert_eq!(p, "\"amount\" IS NOT DISTINCT FROM CAST('1.5' AS NUMERIC)");
     }
 
     #[test]
     fn predicate_sqlite_uses_is() {
-        let p = column_predicate("amount", &SqlType::Numeric, Some("1.5"), false);
+        let p = column_predicate("amount", "NUMERIC", Some("1.5"), false);
         assert_eq!(p, "\"amount\" IS CAST('1.5' AS NUMERIC)");
     }
 
     #[test]
     fn predicate_escapes_single_quotes() {
-        let p = column_predicate("note", &SqlType::Text, Some("o'brien"), true);
+        let p = column_predicate("note", "TEXT", Some("o'brien"), true);
         assert_eq!(p, "\"note\" IS NOT DISTINCT FROM 'o''brien'");
     }
 
     #[test]
     fn predicate_timestamptz_uses_full_type_name() {
-        let p = column_predicate("ts", &SqlType::TimestampTz, Some("2024-01-01Z"), true);
+        let p = column_predicate("ts", "TIMESTAMP WITH TIME ZONE", Some("2024-01-01Z"), true);
         assert_eq!(
             p,
             "\"ts\" IS NOT DISTINCT FROM CAST('2024-01-01Z' AS TIMESTAMP WITH TIME ZONE)"
@@ -798,7 +791,7 @@ mod tests {
     fn predicate_json_compares_column_as_text() {
         // json has no `=`; compare CAST(col AS TEXT) against the bare source
         // text instead of CAST('..' AS JSON) IS NOT DISTINCT FROM (which errors).
-        let p = column_predicate("payload", &SqlType::Json, Some("{\"k\":\"v\"}"), true);
+        let p = column_predicate("payload", "JSON", Some("{\"k\":\"v\"}"), true);
         assert_eq!(
             p,
             "CAST(\"payload\" AS TEXT) IS NOT DISTINCT FROM '{\"k\":\"v\"}'"
@@ -809,7 +802,7 @@ mod tests {
     fn predicate_jsonb_compares_natively_not_as_text() {
         // jsonb HAS `=` and canonicalizes input, so it must recast to jsonb
         // (a text compare would false-mismatch on key/whitespace reordering).
-        let p = column_predicate("payload", &SqlType::Jsonb, Some("{\"k\":\"v\"}"), true);
+        let p = column_predicate("payload", "JSONB", Some("{\"k\":\"v\"}"), true);
         assert_eq!(
             p,
             "\"payload\" IS NOT DISTINCT FROM CAST('{\"k\":\"v\"}' AS JSONB)"
@@ -818,20 +811,20 @@ mod tests {
 
     #[test]
     fn batch_query_projects_pk_and_match_bool_over_range() {
-        let int = SqlType::Integer;
-        let text = SqlType::Text;
-        let num = SqlType::Numeric;
         let rows = vec![
             SourceRow {
                 pk_value: "1",
-                columns: vec![("name", &text, Some("alice")), ("amt", &num, Some("1.5"))],
+                columns: vec![
+                    ("name", "TEXT", Some("alice")),
+                    ("amt", "NUMERIC", Some("1.5")),
+                ],
             },
             SourceRow {
                 pk_value: "2",
-                columns: vec![("name", &text, None), ("amt", &num, Some("2"))],
+                columns: vec![("name", "TEXT", None), ("amt", "NUMERIC", Some("2"))],
             },
         ];
-        let sql = build_batch_query("\"t\"", "id", &int, &rows, true);
+        let sql = build_batch_query("\"t\"", "id", "INTEGER", &rows, true);
 
         // PK projected as text; per-row CASE arm keyed by recast PK; the IN
         // list holds the same recast literals; null source field → IS NULL.
@@ -859,12 +852,11 @@ mod tests {
     #[test]
     fn batch_query_empty_columns_matches_true() {
         // A row with only a PK (no other loaded columns) trivially matches.
-        let int = SqlType::Integer;
         let rows = vec![SourceRow {
             pk_value: "5",
             columns: vec![],
         }];
-        let sql = build_batch_query("\"t\"", "id", &int, &rows, true);
+        let sql = build_batch_query("\"t\"", "id", "INTEGER", &rows, true);
         assert!(sql.contains("THEN (TRUE)"), "{sql}");
         assert!(
             sql.contains("WHERE \"id\" IN (CAST('5' AS INTEGER))"),
@@ -874,13 +866,11 @@ mod tests {
 
     #[test]
     fn batch_query_uuid_pk_casts_in_arm_and_in_list() {
-        let uuid = SqlType::Uuid;
-        let text = SqlType::Text;
         let rows = vec![SourceRow {
             pk_value: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
-            columns: vec![("v", &text, Some("x"))],
+            columns: vec![("v", "TEXT", Some("x"))],
         }];
-        let sql = build_batch_query("\"t\"", "id", &uuid, &rows, true);
+        let sql = build_batch_query("\"t\"", "id", "UUID", &rows, true);
         // PK literal recast in both the CASE arm and the IN list.
         assert_eq!(
             sql.matches("CAST('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' AS UUID)")

--- a/src/verify/value_check.rs
+++ b/src/verify/value_check.rs
@@ -203,7 +203,7 @@ pub(crate) async fn verify_table_values(
                     rows_missing_at_target += 1;
                     push_capped(&mut details.missing_pks, pk);
                 }
-                Some(m) if is_falsey(m) => {
+                Some(m) if !is_match(m) => {
                     value_mismatches += 1;
                     push_capped(&mut details.mismatch_pks, pk);
                 }
@@ -228,12 +228,13 @@ fn push_capped(list: &mut Vec<String>, pk: &str) {
     }
 }
 
-/// `true` when the projected match-bool text is the backend's false form.
-/// Postgres renders `bool::text` as `t`/`f`; SQLite renders the boolean
-/// expression as `1`/`0`. A NULL match column (CASE fell through — should
-/// not happen since the PK was requested) is treated as a mismatch.
-fn is_falsey(matches_text: &str) -> bool {
-    matches!(matches_text, "f" | "0" | "false" | "FALSE")
+/// `true` only when the projected match-bool text is the backend's true
+/// form: `CAST(bool AS TEXT)` yields `true` on Postgres/DSQL, `1` on SQLite.
+/// Fail-closed: anything else — the false form, or any unexpected token —
+/// counts as a mismatch, so a verification tool never silently passes a row
+/// it couldn't positively confirm matched.
+fn is_match(matches_text: &str) -> bool {
+    matches!(matches_text, "true" | "1")
 }
 
 /// name → SqlType for every column of the target table.
@@ -346,10 +347,9 @@ pub(crate) struct SourceRow<'a> {
 ///
 /// The `WHERE pk IN (...)` list and the per-row `CASE WHEN pk <nseq> ...`
 /// arms are built from the SAME recast PK literals, so the batch is exact
-/// regardless of PK type. (An earlier draft used `pk BETWEEN lo AND hi`,
-/// but that requires the caller to sort PKs in the DB's type order; a
-/// lexical sort of integer/uuid text would mis-window the batch. `IN` of
-/// the exact PKs sidesteps that — confirmed runnable on DSQL by the POC.)
+/// regardless of PK type. `IN` of the exact PKs (not `pk BETWEEN lo AND hi`)
+/// avoids needing the caller to sort PKs in the DB's type order — a lexical
+/// sort of integer/uuid text would mis-window a range.
 fn build_batch_query(
     qualified_table: &str,
     pk_col: &str,
@@ -388,8 +388,8 @@ fn build_batch_query(
         .join(", ");
 
     // Both columns are fetched as text: the match bool is wrapped in
-    // CAST(... AS TEXT) so it decodes uniformly — Postgres yields `t`/`f`,
-    // SQLite yields `1`/`0` (see `is_falsey`).
+    // CAST(... AS TEXT) so it decodes uniformly — Postgres yields
+    // `true`/`false`, SQLite yields `1`/`0` (see `is_match`).
     format!(
         "SELECT CAST({quoted_pk} AS TEXT), CAST(CASE\n{arms}\n    END AS TEXT)\n  \
          FROM {qualified_table}\n  WHERE {quoted_pk} IN ({in_list})"
@@ -456,10 +456,9 @@ mod tests {
 
     #[tokio::test]
     async fn l3_json_column_compares_as_text_no_equality_error() {
-        // Regression for the CI-breaking bug the real-DSQL E2E exposed:
         // `json` has no `=` operator, so the recast compare must route json
-        // through CAST(col AS TEXT). A clean load must Match (not error),
-        // and a corrupted json value must surface as a mismatch.
+        // through CAST(col AS TEXT): a clean load must Match (not error), and
+        // a corrupted json value must surface as a mismatch.
         let pool = Pool::sqlite_in_memory().await.unwrap();
         pool.execute_query("CREATE TABLE evts (id INTEGER PRIMARY KEY, payload JSON)")
             .await
@@ -586,9 +585,9 @@ mod tests {
 
     #[tokio::test]
     async fn l3_boolean_column_mismatch_counted() {
-        // BOOLEAN is where is_falsey's backend divergence bites: the match
-        // bool serializes as 0/1 (SQLite) vs t/f (PG). Pin that a real
-        // boolean-column mismatch is caught, not silently passed.
+        // BOOLEAN is where is_match's backend divergence bites: the match
+        // bool serializes as 0/1 (SQLite) vs false/true (PG). Pin that a
+        // real boolean-column mismatch is caught, not silently passed.
         let pool = Pool::sqlite_in_memory().await.unwrap();
         pool.execute_query("CREATE TABLE flags (id INTEGER PRIMARY KEY, ok BOOLEAN)")
             .await
@@ -675,6 +674,21 @@ mod tests {
                 rows_missing_at_target: 0
             }
         );
+    }
+
+    #[test]
+    fn is_match_is_fail_closed() {
+        // True forms: `true` (Postgres/DSQL `CAST(bool AS TEXT)`), `1` (SQLite).
+        assert!(is_match("true"));
+        assert!(is_match("1"));
+        // False forms and any unexpected token are NOT a match — a value the
+        // tool can't positively confirm must count as a mismatch, never a
+        // silent pass.
+        assert!(!is_match("false"));
+        assert!(!is_match("0"));
+        assert!(!is_match(""));
+        assert!(!is_match("t"));
+        assert!(!is_match("unexpected"));
     }
 
     #[test]

--- a/src/verify/value_check.rs
+++ b/src/verify/value_check.rs
@@ -1,0 +1,804 @@
+//! L3 value verification: build the server-side recast-compare query and
+//! diff the source (re-read, decoded TEXT) against the target by primary
+//! key. The DB is the type authority — a source field is pushed back
+//! through the same `CAST` the loader used at INSERT, compared null-safe
+//! (`IS NOT DISTINCT FROM` on Postgres/DSQL, `IS` on SQLite), so canonical
+//! forms (`1.5` vs `1.50`, `\N` vs NULL) match without a client normalizer.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+
+use super::{L3Details, L3Outcome, SchemaCheck};
+use crate::db::Pool;
+use crate::db::schema::{SqlType, escape_sql_literal, inserts_as_bare_literal, query_table_schema};
+use crate::formats::pgdump::{CopyBlock, PgDumpReader, find_copy_block};
+use crate::formats::reader::{FileReader, Record};
+use crate::io::{ByteReader, LocalFileByteReader, S3ByteReader, SourceUri};
+
+/// Where + how the load-path verification locates and reads the source.
+/// Bundled so `run_load_value_check` stays under the argument-count bar and
+/// the `run_load` call site reads clearly.
+pub(crate) struct LoadVerifyTarget<'a> {
+    pub source_uri: &'a str,
+    pub region: &'a str,
+    pub schema: &'a str,
+    pub table: &'a str,
+    pub is_pgdump: bool,
+    /// Run the per-row L3 value check (mode=Full); schema check runs regardless.
+    pub run_value_check: bool,
+    pub chunk_size_bytes: u64,
+}
+
+/// Load-path verification entry: resolve the COPY block for
+/// `(schema, table)` from the source URI, run the affirmative schema check
+/// (always — the MUST #3 floor, same as migrate), and — when
+/// `run_value_check` (mode=Full) — the per-row L3 value check. Used by
+/// `run_load` where, unlike migrate, the block isn't pre-resolved.
+///
+/// Non-pgdump formats can't anchor a per-row compare or count COPY columns
+/// here, so they report PK presence only and `L3Outcome::Skipped`.
+pub(crate) async fn run_load_value_check(
+    pool: &Pool,
+    target: LoadVerifyTarget<'_>,
+) -> Result<(SchemaCheck, L3Outcome, L3Details)> {
+    let LoadVerifyTarget {
+        source_uri,
+        region,
+        schema,
+        table,
+        is_pgdump,
+        run_value_check,
+        chunk_size_bytes,
+    } = target;
+
+    if !is_pgdump {
+        // No COPY block to anchor a per-row compare or count columns; report
+        // PK presence only and skip the value check.
+        let pk_present = !pool
+            .get_unique_constraint_columns(schema, table)
+            .await
+            .with_context(|| format!("verify: PK lookup for {schema}.{table}"))?
+            .is_empty();
+        let sc = SchemaCheck {
+            columns_matched: 0,
+            pk_present,
+        };
+        return Ok((sc, L3Outcome::Skipped, L3Details::default()));
+    }
+
+    let parsed = SourceUri::parse(source_uri)?;
+    let reader: Arc<dyn ByteReader> = match &parsed {
+        SourceUri::Local(path) => Arc::new(LocalFileByteReader::new(path)),
+        SourceUri::S3 { bucket, key } => {
+            let cfg = aws_config::defaults(aws_config::BehaviorVersion::latest())
+                .region(aws_config::Region::new(region.to_string()))
+                .load()
+                .await;
+            let s3 = Arc::new(aws_sdk_s3::Client::new(&cfg));
+            Arc::new(S3ByteReader::new(s3, bucket.clone(), key.clone()))
+        }
+    };
+    let block = find_copy_block(&*reader, schema, table)
+        .await
+        .with_context(|| format!("verify: locating COPY block for {schema}.{table}"))?;
+
+    let sc = schema_check(pool, &block).await?;
+    let (outcome, details) = if run_value_check {
+        verify_table_values(pool, reader, &block, chunk_size_bytes).await?
+    } else {
+        (L3Outcome::Skipped, L3Details::default())
+    };
+    Ok((sc, outcome, details))
+}
+
+/// Affirmative schema-conformance line (MUST #3): a successful load already
+/// proves the COPY column set matched the target (otherwise
+/// `align_pgdump_schema_to_copy_columns` would have bailed), so
+/// `columns_matched` is just the COPY column count; `pk_present` reflects
+/// whether the target has a primary/unique key. Catalog-only, runs under
+/// both `Count` and `Full`.
+pub(crate) async fn schema_check(pool: &Pool, block: &CopyBlock) -> Result<SchemaCheck> {
+    let pk_present = !pool
+        .get_unique_constraint_columns(&block.schema, &block.table)
+        .await
+        .with_context(|| format!("verify: PK lookup for {}.{}", block.schema, block.table))?
+        .is_empty();
+    Ok(SchemaCheck {
+        columns_matched: block.columns.len() as u64,
+        pk_present,
+    })
+}
+
+/// Target-fetch batch size: how many source PKs are checked per `IN (...)`
+/// query. Bounds query size + memory to one batch.
+const VALUE_CHECK_BATCH: usize = 1000;
+
+/// Max offending PKs recorded per category in [`L3Details`] (the verdict
+/// magnitude still carries the true total — this only caps the report).
+const DETAIL_CAP: usize = 100;
+
+/// Re-read the COPY block's rows and verify each landed at the target by
+/// primary key, comparing every loaded column through the same server-side
+/// `CAST` the worker used at INSERT. Returns the aggregate [`L3Outcome`]
+/// plus the first-K offending PKs in [`L3Details`].
+///
+/// `L3Outcome::Skipped` (never a silent pass) when the table has no usable
+/// single-column primary key — the only key shape v1 verifies.
+///
+/// Reuses the live source `reader` (no re-open) and the existing pgdump
+/// decode path; assumes the pgdump/migrate field mapping where
+/// `record.fields[i]` corresponds to `block.columns[i]` and no columns are
+/// excluded (the migrate path never excludes).
+///
+/// Assumes source PK values are unique (guaranteed for any real
+/// single-column-PK dump). A hand-corrupted dump with duplicate PKs would
+/// mis-count by the duplicate multiplicity but cannot panic.
+pub(crate) async fn verify_table_values(
+    pool: &Pool,
+    reader: Arc<dyn ByteReader>,
+    block: &CopyBlock,
+    chunk_size_bytes: u64,
+) -> Result<(L3Outcome, L3Details)> {
+    let pk_cols = pool
+        .get_unique_constraint_columns(&block.schema, &block.table)
+        .await
+        .with_context(|| {
+            format!(
+                "verify=full: PK lookup for {}.{}",
+                block.schema, block.table
+            )
+        })?;
+    // v1 verifies a single-column PK only; composite / no-PK → explicit skip.
+    let [pk_col] = pk_cols.as_slice() else {
+        return Ok((L3Outcome::Skipped, L3Details::default()));
+    };
+    let Some(pk_idx) = block.columns.iter().position(|c| c == pk_col) else {
+        // PK column isn't in the COPY set (can't align positionally) → skip.
+        return Ok((L3Outcome::Skipped, L3Details::default()));
+    };
+
+    let col_types = column_types(pool, &block.schema, &block.table).await?;
+    // Every COPY column must resolve to a type for the recast compare.
+    let types: Vec<SqlType> = block
+        .columns
+        .iter()
+        .map(|c| {
+            col_types
+                .get(c)
+                .cloned()
+                .with_context(|| format!("verify=full: no type for column {c}"))
+        })
+        .collect::<Result<_>>()?;
+
+    let records = read_source_records(reader, block, chunk_size_bytes).await?;
+    let qualified = pool.qualified_table_name(&block.schema, &block.table);
+    let is_postgres = pool.is_postgres();
+
+    let mut value_mismatches = 0u64;
+    let mut rows_missing_at_target = 0u64;
+    let mut details = L3Details::default();
+
+    for batch in records.chunks(VALUE_CHECK_BATCH) {
+        let rows = batch
+            .iter()
+            .map(|rec| source_row(rec, block, pk_idx, &types))
+            .collect::<Result<Vec<_>>>()?;
+        let requested: Vec<&str> = rows.iter().map(|r| r.pk_value).collect();
+
+        let sql = build_batch_query(&qualified, pk_col, &types[pk_idx], &rows, is_postgres);
+        let returned: Vec<(String, String)> = pool
+            .fetch_all_with_binds(&sql, &[])
+            .await
+            .with_context(|| format!("verify=full: compare query for {qualified}"))?;
+
+        let returned_map: HashMap<&str, &str> = returned
+            .iter()
+            .map(|(pk, m)| (pk.as_str(), m.as_str()))
+            .collect();
+        for pk in requested {
+            match returned_map.get(pk) {
+                None => {
+                    rows_missing_at_target += 1;
+                    push_capped(&mut details.missing_pks, pk);
+                }
+                Some(m) if is_falsey(m) => {
+                    value_mismatches += 1;
+                    push_capped(&mut details.mismatch_pks, pk);
+                }
+                Some(_) => {}
+            }
+        }
+    }
+
+    Ok((
+        L3Outcome::Ran {
+            value_mismatches,
+            rows_missing_at_target,
+        },
+        details,
+    ))
+}
+
+/// Append `pk` to a detail list unless it's already at [`DETAIL_CAP`].
+fn push_capped(list: &mut Vec<String>, pk: &str) {
+    if list.len() < DETAIL_CAP {
+        list.push(pk.to_string());
+    }
+}
+
+/// `true` when the projected match-bool text is the backend's false form.
+/// Postgres renders `bool::text` as `t`/`f`; SQLite renders the boolean
+/// expression as `1`/`0`. A NULL match column (CASE fell through — should
+/// not happen since the PK was requested) is treated as a mismatch.
+fn is_falsey(matches_text: &str) -> bool {
+    matches!(matches_text, "f" | "0" | "false" | "FALSE")
+}
+
+/// name → SqlType for every column of the target table.
+async fn column_types(pool: &Pool, schema: &str, table: &str) -> Result<HashMap<String, SqlType>> {
+    let resolved = query_table_schema(pool, schema, table).await?;
+    Ok(resolved
+        .columns
+        .into_iter()
+        .map(|c| (c.name, c.sql_type))
+        .collect())
+}
+
+/// Re-read every record from the COPY block using the existing pgdump
+/// decode path (no re-open: `reader` is the already-open source).
+async fn read_source_records(
+    reader: Arc<dyn ByteReader>,
+    block: &CopyBlock,
+    chunk_size_bytes: u64,
+) -> Result<Vec<Record>> {
+    let pgdump = PgDumpReader::from_block(reader, block.clone());
+    let chunks = pgdump.create_chunks(chunk_size_bytes).await?;
+    let mut records = Vec::new();
+    for chunk in &chunks {
+        records.extend(pgdump.read_chunk(chunk).await?.records);
+    }
+    Ok(records)
+}
+
+/// Borrow a decoded `Record` into a `SourceRow`: the PK field value plus
+/// every non-PK column's (name, type, value). Errors if the PK field is
+/// SQL NULL (a NULL PK can't anchor the row-alignment).
+fn source_row<'a>(
+    rec: &'a Record,
+    block: &'a CopyBlock,
+    pk_idx: usize,
+    types: &'a [SqlType],
+) -> Result<SourceRow<'a>> {
+    let pk_value = rec.fields[pk_idx].as_deref().with_context(|| {
+        format!(
+            "verify=full: NULL primary key in source row of {}",
+            block.table
+        )
+    })?;
+    let columns = block
+        .columns
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i != pk_idx)
+        .map(|(i, name)| (name.as_str(), &types[i], rec.fields[i].as_deref()))
+        .collect();
+    Ok(SourceRow { pk_value, columns })
+}
+
+/// Null-safe-equality operator for the backend: `IS NOT DISTINCT FROM` on
+/// Postgres/DSQL, `IS` on SQLite (which lacks the former but gives `IS` the
+/// same null-safe semantics).
+fn null_safe_eq(is_postgres: bool) -> &'static str {
+    if is_postgres {
+        "IS NOT DISTINCT FROM"
+    } else {
+        "IS"
+    }
+}
+
+/// Render a value as the SQL literal the worker would have inserted: bare
+/// `'v'` for the TEXT family, `CAST('v' AS TYPE)` otherwise. Shares
+/// `inserts_as_bare_literal` with the worker so verify coerces identically.
+fn recast_literal(ty: &SqlType, value: &str) -> String {
+    let lit = format!("'{}'", escape_sql_literal(value));
+    if inserts_as_bare_literal(ty.to_postgres()) {
+        lit
+    } else {
+        format!("CAST({lit} AS {})", ty.to_postgres())
+    }
+}
+
+/// Per-column match predicate: `None` (source `\N`) → `"col" IS NULL`;
+/// `Some(v)` → `"col" <nseq> <recast literal>`. `col` is double-quoted.
+///
+/// `json` has no `=` operator, so a direct `IS NOT DISTINCT FROM` errors on
+/// Postgres/DSQL. The loader stores `json` as the verbatim source COPY text
+/// (the type preserves input formatting), so we compare `CAST("col" AS
+/// text)` against the bare source text — exact and equality-capable. This
+/// is a textual, not semantic-JSON, comparison (whitespace-sensitive),
+/// which is correct here because the target text IS the source text.
+fn column_predicate(col: &str, ty: &SqlType, value: Option<&str>, is_postgres: bool) -> String {
+    let quoted = format!("\"{col}\"");
+    let nseq = null_safe_eq(is_postgres);
+    match (value, ty) {
+        (None, _) => format!("{quoted} IS NULL"),
+        (Some(v), SqlType::Json) => {
+            let lit = format!("'{}'", escape_sql_literal(v));
+            format!("CAST({quoted} AS TEXT) {nseq} {lit}")
+        }
+        (Some(v), _) => format!("{quoted} {nseq} {}", recast_literal(ty, v)),
+    }
+}
+
+/// One source row to verify: its primary-key text value plus the
+/// (column, type, value) tuples for every non-PK loaded column.
+pub(crate) struct SourceRow<'a> {
+    pub pk_value: &'a str,
+    pub columns: Vec<(&'a str, &'a SqlType, Option<&'a str>)>,
+}
+
+/// Build the projected-bool batch query: for each `SourceRow`, return
+/// `(pk::text, matches)` where `matches` ANDs every column predicate. A
+/// requested PK absent from the result set is a missing row (the caller
+/// diffs requested vs returned PKs).
+///
+/// The `WHERE pk IN (...)` list and the per-row `CASE WHEN pk <nseq> ...`
+/// arms are built from the SAME recast PK literals, so the batch is exact
+/// regardless of PK type. (An earlier draft used `pk BETWEEN lo AND hi`,
+/// but that requires the caller to sort PKs in the DB's type order; a
+/// lexical sort of integer/uuid text would mis-window the batch. `IN` of
+/// the exact PKs sidesteps that — confirmed runnable on DSQL by the POC.)
+fn build_batch_query(
+    qualified_table: &str,
+    pk_col: &str,
+    pk_type: &SqlType,
+    rows: &[SourceRow<'_>],
+    is_postgres: bool,
+) -> String {
+    let pk_lit = |v: &str| recast_literal(pk_type, v);
+    let quoted_pk = format!("\"{pk_col}\"");
+    let nseq = null_safe_eq(is_postgres);
+
+    let arms: String = rows
+        .iter()
+        .map(|row| {
+            let row_match = if row.columns.is_empty() {
+                "TRUE".to_string()
+            } else {
+                row.columns
+                    .iter()
+                    .map(|(col, ty, val)| column_predicate(col, ty, *val, is_postgres))
+                    .collect::<Vec<_>>()
+                    .join(" AND ")
+            };
+            format!(
+                "      WHEN {quoted_pk} {nseq} {} THEN ({row_match})",
+                pk_lit(row.pk_value)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let in_list = rows
+        .iter()
+        .map(|row| pk_lit(row.pk_value))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    // Both columns are fetched as text: the match bool is wrapped in
+    // CAST(... AS TEXT) so it decodes uniformly — Postgres yields `t`/`f`,
+    // SQLite yields `1`/`0` (see `is_falsey`).
+    format!(
+        "SELECT CAST({quoted_pk} AS TEXT), CAST(CASE\n{arms}\n    END AS TEXT)\n  \
+         FROM {qualified_table}\n  WHERE {quoted_pk} IN ({in_list})"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::formats::pgdump::list_copy_blocks;
+    use crate::io::LocalFileByteReader;
+    use std::io::Write;
+
+    /// Write a one-table pgdump COPY block to a temp file and resolve its
+    /// `CopyBlock` — the migrate orchestrator's per-table input.
+    async fn fixture_block(
+        copy_header: &str,
+        rows: &[&str],
+    ) -> (tempfile::NamedTempFile, CopyBlock) {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "{copy_header}").unwrap();
+        for r in rows {
+            writeln!(f, "{r}").unwrap();
+        }
+        writeln!(f, "\\.").unwrap();
+        f.flush().unwrap();
+        let reader = LocalFileByteReader::new(f.path());
+        let block = list_copy_blocks(&reader).await.unwrap().pop().unwrap();
+        (f, block)
+    }
+
+    fn reader_for(f: &tempfile::NamedTempFile) -> Arc<dyn ByteReader> {
+        Arc::new(LocalFileByteReader::new(f.path()))
+    }
+
+    #[tokio::test]
+    async fn l3_clean_load_is_ran_zero() {
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        pool.execute_query("CREATE TABLE things (id INTEGER PRIMARY KEY, amt NUMERIC, note TEXT)")
+            .await
+            .unwrap();
+        // Stored exactly what the source says (1.50 vs source 1.5 must still match).
+        pool.execute_query("INSERT INTO things VALUES (1, 1.50, 'a'), (2, NULL, 'b')")
+            .await
+            .unwrap();
+
+        let (f, block) = fixture_block(
+            "COPY public.things (id, amt, note) FROM stdin;",
+            &["1\t1.5\ta", "2\t\\N\tb"],
+        )
+        .await;
+
+        let (out, _details) = verify_table_values(&pool, reader_for(&f), &block, 1 << 20)
+            .await
+            .unwrap();
+        assert_eq!(
+            out,
+            L3Outcome::Ran {
+                value_mismatches: 0,
+                rows_missing_at_target: 0
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn l3_json_column_compares_as_text_no_equality_error() {
+        // Regression for the CI-breaking bug the real-DSQL E2E exposed:
+        // `json` has no `=` operator, so the recast compare must route json
+        // through CAST(col AS TEXT). A clean load must Match (not error),
+        // and a corrupted json value must surface as a mismatch.
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        pool.execute_query("CREATE TABLE evts (id INTEGER PRIMARY KEY, payload JSON)")
+            .await
+            .unwrap();
+        pool.execute_query("INSERT INTO evts VALUES (1, '{\"k\":\"v\"}'), (2, '[1,2,3]')")
+            .await
+            .unwrap();
+
+        let (f, block) = fixture_block(
+            "COPY public.evts (id, payload) FROM stdin;",
+            &["1\t{\"k\":\"v\"}", "2\t[1,2,3]"],
+        )
+        .await;
+        let (out, _d) = verify_table_values(&pool, reader_for(&f), &block, 1 << 20)
+            .await
+            .unwrap();
+        assert_eq!(
+            out,
+            L3Outcome::Ran {
+                value_mismatches: 0,
+                rows_missing_at_target: 0
+            },
+            "clean json load must Match without an equality-operator error"
+        );
+
+        // Corrupt row 2's json at the target → mismatch on that PK.
+        pool.execute_query("UPDATE evts SET payload = '[9,9,9]' WHERE id = 2")
+            .await
+            .unwrap();
+        let (out, details) = verify_table_values(&pool, reader_for(&f), &block, 1 << 20)
+            .await
+            .unwrap();
+        assert_eq!(
+            out,
+            L3Outcome::Ran {
+                value_mismatches: 1,
+                rows_missing_at_target: 0
+            }
+        );
+        assert_eq!(details.mismatch_pks, vec!["2".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn l3_value_mismatch_counted() {
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        pool.execute_query("CREATE TABLE things (id INTEGER PRIMARY KEY, note TEXT)")
+            .await
+            .unwrap();
+        // Target row 2 holds the wrong note vs the source.
+        pool.execute_query("INSERT INTO things VALUES (1, 'a'), (2, 'WRONG')")
+            .await
+            .unwrap();
+
+        let (f, block) = fixture_block(
+            "COPY public.things (id, note) FROM stdin;",
+            &["1\ta", "2\tb"],
+        )
+        .await;
+
+        let (out, details) = verify_table_values(&pool, reader_for(&f), &block, 1 << 20)
+            .await
+            .unwrap();
+        assert_eq!(
+            out,
+            L3Outcome::Ran {
+                value_mismatches: 1,
+                rows_missing_at_target: 0
+            }
+        );
+        // The offending PK is localized for the operator.
+        assert_eq!(details.mismatch_pks, vec!["2".to_string()]);
+        assert!(details.missing_pks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn l3_missing_row_counted() {
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        pool.execute_query("CREATE TABLE things (id INTEGER PRIMARY KEY, note TEXT)")
+            .await
+            .unwrap();
+        // Row 2 never landed at the target.
+        pool.execute_query("INSERT INTO things VALUES (1, 'a')")
+            .await
+            .unwrap();
+
+        let (f, block) = fixture_block(
+            "COPY public.things (id, note) FROM stdin;",
+            &["1\ta", "2\tb"],
+        )
+        .await;
+
+        let (out, details) = verify_table_values(&pool, reader_for(&f), &block, 1 << 20)
+            .await
+            .unwrap();
+        assert_eq!(
+            out,
+            L3Outcome::Ran {
+                value_mismatches: 0,
+                rows_missing_at_target: 1
+            }
+        );
+        assert_eq!(details.missing_pks, vec!["2".to_string()]);
+        assert!(details.mismatch_pks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn l3_no_primary_key_is_skipped() {
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        pool.execute_query("CREATE TABLE things (id INTEGER, note TEXT)")
+            .await
+            .unwrap();
+        pool.execute_query("INSERT INTO things VALUES (1, 'a')")
+            .await
+            .unwrap();
+
+        let (f, block) =
+            fixture_block("COPY public.things (id, note) FROM stdin;", &["1\ta"]).await;
+
+        let (out, _details) = verify_table_values(&pool, reader_for(&f), &block, 1 << 20)
+            .await
+            .unwrap();
+        assert_eq!(out, L3Outcome::Skipped);
+    }
+
+    #[tokio::test]
+    async fn l3_boolean_column_mismatch_counted() {
+        // BOOLEAN is where is_falsey's backend divergence bites: the match
+        // bool serializes as 0/1 (SQLite) vs t/f (PG). Pin that a real
+        // boolean-column mismatch is caught, not silently passed.
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        pool.execute_query("CREATE TABLE flags (id INTEGER PRIMARY KEY, ok BOOLEAN)")
+            .await
+            .unwrap();
+        // Row 1 stored true (matches source 't'); row 2 stored false but
+        // source says true → mismatch.
+        pool.execute_query("INSERT INTO flags VALUES (1, 1), (2, 0)")
+            .await
+            .unwrap();
+
+        let (f, block) =
+            fixture_block("COPY public.flags (id, ok) FROM stdin;", &["1\tt", "2\tt"]).await;
+
+        let (out, _details) = verify_table_values(&pool, reader_for(&f), &block, 1 << 20)
+            .await
+            .unwrap();
+        assert_eq!(
+            out,
+            L3Outcome::Ran {
+                value_mismatches: 1,
+                rows_missing_at_target: 0
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn l3_null_primary_key_in_source_errors() {
+        // A NULL single-column PK can't anchor row-alignment — it signals a
+        // corrupt dump and must surface as an error, not a silent skip.
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        pool.execute_query("CREATE TABLE things (id INTEGER PRIMARY KEY, note TEXT)")
+            .await
+            .unwrap();
+        pool.execute_query("INSERT INTO things VALUES (1, 'a')")
+            .await
+            .unwrap();
+
+        let (f, block) =
+            fixture_block("COPY public.things (id, note) FROM stdin;", &["\\N\ta"]).await;
+
+        let err = verify_table_values(&pool, reader_for(&f), &block, 1 << 20)
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("NULL primary key"),
+            "expected NULL-PK error, got: {err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn l3_batches_across_multiple_queries() {
+        // More rows than VALUE_CHECK_BATCH would be ideal, but that's slow;
+        // instead force a tiny chunk size so the re-read spans many chunks
+        // and assert the per-chunk records all aggregate into one verdict.
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        pool.execute_query("CREATE TABLE things (id INTEGER PRIMARY KEY, note TEXT)")
+            .await
+            .unwrap();
+        let mut insert = String::from("INSERT INTO things VALUES ");
+        let mut rows = Vec::new();
+        for i in 0..50 {
+            if i > 0 {
+                insert.push(',');
+            }
+            // Row 7 is wrong at the target; the rest match.
+            let stored = if i == 7 { "X" } else { "ok" };
+            insert.push_str(&format!("({i}, '{stored}')"));
+            rows.push(format!("{i}\tok"));
+        }
+        pool.execute_query(&insert).await.unwrap();
+        let row_refs: Vec<&str> = rows.iter().map(String::as_str).collect();
+
+        let (f, block) =
+            fixture_block("COPY public.things (id, note) FROM stdin;", &row_refs).await;
+
+        // Tiny chunk → many chunks during re-read (exercises the loop).
+        let (out, _details) = verify_table_values(&pool, reader_for(&f), &block, 16)
+            .await
+            .unwrap();
+        assert_eq!(
+            out,
+            L3Outcome::Ran {
+                value_mismatches: 1,
+                rows_missing_at_target: 0
+            }
+        );
+    }
+
+    #[test]
+    fn predicate_null_source_is_is_null() {
+        let p = column_predicate("note", &SqlType::Text, None, true);
+        assert_eq!(p, "\"note\" IS NULL");
+    }
+
+    #[test]
+    fn predicate_text_column_no_cast() {
+        // TEXT family inserts bare, so verify compares bare.
+        let p = column_predicate("name", &SqlType::Text, Some("alice"), true);
+        assert_eq!(p, "\"name\" IS NOT DISTINCT FROM 'alice'");
+    }
+
+    #[test]
+    fn predicate_numeric_column_casts() {
+        let p = column_predicate("amount", &SqlType::Numeric, Some("1.5"), true);
+        assert_eq!(p, "\"amount\" IS NOT DISTINCT FROM CAST('1.5' AS NUMERIC)");
+    }
+
+    #[test]
+    fn predicate_sqlite_uses_is() {
+        let p = column_predicate("amount", &SqlType::Numeric, Some("1.5"), false);
+        assert_eq!(p, "\"amount\" IS CAST('1.5' AS NUMERIC)");
+    }
+
+    #[test]
+    fn predicate_escapes_single_quotes() {
+        let p = column_predicate("note", &SqlType::Text, Some("o'brien"), true);
+        assert_eq!(p, "\"note\" IS NOT DISTINCT FROM 'o''brien'");
+    }
+
+    #[test]
+    fn predicate_timestamptz_uses_full_type_name() {
+        let p = column_predicate("ts", &SqlType::TimestampTz, Some("2024-01-01Z"), true);
+        assert_eq!(
+            p,
+            "\"ts\" IS NOT DISTINCT FROM CAST('2024-01-01Z' AS TIMESTAMP WITH TIME ZONE)"
+        );
+    }
+
+    #[test]
+    fn predicate_json_compares_column_as_text() {
+        // json has no `=`; compare CAST(col AS TEXT) against the bare source
+        // text instead of CAST('..' AS JSON) IS NOT DISTINCT FROM (which errors).
+        let p = column_predicate("payload", &SqlType::Json, Some("{\"k\":\"v\"}"), true);
+        assert_eq!(
+            p,
+            "CAST(\"payload\" AS TEXT) IS NOT DISTINCT FROM '{\"k\":\"v\"}'"
+        );
+    }
+
+    #[test]
+    fn batch_query_projects_pk_and_match_bool_over_range() {
+        let int = SqlType::Integer;
+        let text = SqlType::Text;
+        let num = SqlType::Numeric;
+        let rows = vec![
+            SourceRow {
+                pk_value: "1",
+                columns: vec![("name", &text, Some("alice")), ("amt", &num, Some("1.5"))],
+            },
+            SourceRow {
+                pk_value: "2",
+                columns: vec![("name", &text, None), ("amt", &num, Some("2"))],
+            },
+        ];
+        let sql = build_batch_query("\"t\"", "id", &int, &rows, true);
+
+        // PK projected as text; per-row CASE arm keyed by recast PK; the IN
+        // list holds the same recast literals; null source field → IS NULL.
+        assert!(
+            sql.contains("SELECT CAST(\"id\" AS TEXT), CAST(CASE"),
+            "{sql}"
+        );
+        assert!(sql.contains("END AS TEXT)"), "{sql}");
+        assert!(
+            sql.contains("WHEN \"id\" IS NOT DISTINCT FROM CAST('1' AS INTEGER) THEN ("),
+            "{sql}"
+        );
+        assert!(
+            sql.contains("\"name\" IS NOT DISTINCT FROM 'alice' AND \"amt\" IS NOT DISTINCT FROM CAST('1.5' AS NUMERIC)"),
+            "{sql}"
+        );
+        assert!(sql.contains("\"name\" IS NULL AND"), "{sql}");
+        assert!(
+            sql.contains("WHERE \"id\" IN (CAST('1' AS INTEGER), CAST('2' AS INTEGER))"),
+            "{sql}"
+        );
+        assert!(sql.contains("FROM \"t\""), "{sql}");
+    }
+
+    #[test]
+    fn batch_query_empty_columns_matches_true() {
+        // A row with only a PK (no other loaded columns) trivially matches.
+        let int = SqlType::Integer;
+        let rows = vec![SourceRow {
+            pk_value: "5",
+            columns: vec![],
+        }];
+        let sql = build_batch_query("\"t\"", "id", &int, &rows, true);
+        assert!(sql.contains("THEN (TRUE)"), "{sql}");
+        assert!(
+            sql.contains("WHERE \"id\" IN (CAST('5' AS INTEGER))"),
+            "{sql}"
+        );
+    }
+
+    #[test]
+    fn batch_query_uuid_pk_casts_in_arm_and_in_list() {
+        let uuid = SqlType::Uuid;
+        let text = SqlType::Text;
+        let rows = vec![SourceRow {
+            pk_value: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+            columns: vec![("v", &text, Some("x"))],
+        }];
+        let sql = build_batch_query("\"t\"", "id", &uuid, &rows, true);
+        // PK literal recast in both the CASE arm and the IN list.
+        assert_eq!(
+            sql.matches("CAST('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' AS UUID)")
+                .count(),
+            2,
+            "{sql}"
+        );
+    }
+}

--- a/src/verify/value_check.rs
+++ b/src/verify/value_check.rs
@@ -62,7 +62,7 @@ pub(crate) async fn run_load_value_check(
             .with_context(|| format!("verify: PK lookup for {schema}.{table}"))?
             .is_empty();
         let sc = SchemaCheck {
-            columns_matched: 0,
+            columns_matched: None,
             pk_present,
         };
         return Ok((sc, L3Outcome::Skipped, L3Details::default()));
@@ -106,7 +106,7 @@ pub(crate) async fn schema_check(pool: &Pool, block: &CopyBlock) -> Result<Schem
         .with_context(|| format!("verify: PK lookup for {}.{}", block.schema, block.table))?
         .is_empty();
     Ok(SchemaCheck {
-        columns_matched: block.columns.len() as u64,
+        columns_matched: Some(block.columns.len() as u64),
         pk_present,
     })
 }
@@ -125,7 +125,7 @@ const DETAIL_CAP: usize = 100;
 /// plus the first-K offending PKs in [`L3Details`].
 ///
 /// `L3Outcome::Skipped` (never a silent pass) when the table has no usable
-/// single-column primary key — the only key shape v1 verifies.
+/// single-column key (primary or unique) — the only key shape v1 verifies.
 ///
 /// Reuses the live source `reader` (no re-open) and the existing pgdump
 /// decode path; assumes the pgdump/migrate field mapping where
@@ -150,7 +150,8 @@ pub(crate) async fn verify_table_values(
                 block.schema, block.table
             )
         })?;
-    // v1 verifies a single-column PK only; composite / no-PK → explicit skip.
+    // v1 verifies a single-column key (primary or unique) only; composite /
+    // no-key → explicit skip.
     let [pk_col] = pk_cols.as_slice() else {
         return Ok((L3Outcome::Skipped, L3Details::default()));
     };
@@ -301,7 +302,9 @@ fn null_safe_eq(is_postgres: bool) -> &'static str {
 
 /// Render a value as the SQL literal the worker would have inserted: bare
 /// `'v'` for the TEXT family, `CAST('v' AS TYPE)` otherwise. Shares
-/// `inserts_as_bare_literal` with the worker so verify coerces identically.
+/// `inserts_as_bare_literal` with the worker so the bare-vs-CAST decision
+/// matches the write path on Postgres/DSQL (SQLite tests accept the extra
+/// CAST harmlessly — the worker inserts bare there).
 fn recast_literal(ty: &SqlType, value: &str) -> String {
     let lit = format!("'{}'", escape_sql_literal(value));
     if inserts_as_bare_literal(ty.to_postgres()) {
@@ -578,6 +581,64 @@ mod tests {
 
         let (f, block) =
             fixture_block("COPY public.things (id, note) FROM stdin;", &["1\ta"]).await;
+
+        let (out, _details) = verify_table_values(&pool, reader_for(&f), &block, 1 << 20)
+            .await
+            .unwrap();
+        assert_eq!(out, L3Outcome::Skipped);
+    }
+
+    #[tokio::test]
+    async fn run_load_value_check_non_pgdump_skips_with_uncounted_columns() {
+        // csv/parquet under --verify=full: no COPY block to anchor a per-row
+        // compare or count columns → report PK presence only, columns
+        // uncounted (None, NOT Some(0)), and L3 Skipped (never a silent
+        // Match). The early return must not touch the source URI.
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        pool.execute_query("CREATE TABLE things (id INTEGER PRIMARY KEY, note TEXT)")
+            .await
+            .unwrap();
+
+        let (sc, outcome, details) = run_load_value_check(
+            &pool,
+            LoadVerifyTarget {
+                source_uri: "s3://unused/for-non-pgdump",
+                region: "us-west-2",
+                schema: "public",
+                table: "things",
+                is_pgdump: false,
+                run_value_check: true,
+                chunk_size_bytes: 1 << 20,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            sc,
+            SchemaCheck {
+                columns_matched: None,
+                pk_present: true,
+            }
+        );
+        assert_eq!(outcome, L3Outcome::Skipped);
+        assert_eq!(details, L3Details::default());
+    }
+
+    #[tokio::test]
+    async fn l3_composite_primary_key_is_skipped() {
+        // v1 aligns rows on a single-column key only; a composite PK must
+        // Skip (explicit "not checked"), never silently verify on the first
+        // column. A regression to `pk_cols.first()` would mis-align rows.
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        pool.execute_query("CREATE TABLE parts (a INTEGER, b INTEGER, v TEXT, PRIMARY KEY (a, b))")
+            .await
+            .unwrap();
+        pool.execute_query("INSERT INTO parts VALUES (1, 2, 'x')")
+            .await
+            .unwrap();
+
+        let (f, block) =
+            fixture_block("COPY public.parts (a, b, v) FROM stdin;", &["1\t2\tx"]).await;
 
         let (out, _details) = verify_table_values(&pool, reader_for(&f), &block, 1 << 20)
             .await


### PR DESCRIPTION
## Summary

Adds the **SHOULD tier** from the verification requirements: opt-in per-row value verification (`--verify=full` / L3), plus the **default-on affirmative schema-conformance line** (MUST #3). v1 (L1+L2) proved *completeness* (row counts); L3 proves the target reproduces the value the loader computed from the source, by primary key.

This is scoped to the **self-as-oracle ceiling**: it verifies *load fidelity* (the target matches what the loader did), not *translation correctness* (it trusts the reader + dsql-lint). Closing the latter needs a v3 live-source oracle — explicitly out of scope. Our true loader peers (pg_dump = no verification, pgloader = count-only) ship below this; the validators (DMS/MOLT/DVT) ship value-level but **off by default**, which is the posture matched here.

## How L3 works (server-side recast, no client normalizer)

- Re-read the source COPY block (reuses the pgdump decode path; `impl ByteReader for Arc<R>` lets the open source feed the re-read with no re-open) and fetch target rows by `pk IN (...)`, projecting a per-row match boolean.
- Push each source TEXT field back through the **same `CAST(... AS coltype)`** the worker used at INSERT, compared null-safe (`IS NOT DISTINCT FROM` on Postgres/DSQL, `IS` on SQLite). So `1.5`≡`1.50`, `\N`≡NULL canonicalize **without a client-side normalizer** — the DB is the type authority, symmetric with the write. Verified against a live DSQL cluster (timestamptz µs round-trip, jsonb canonicalization); numeric-scale and uuid-case canonicalization are pinned by SQLite recast-predicate unit tests.
- `json` has no `=` operator → compared as `CAST(col AS TEXT)` (the type stores verbatim source text). `jsonb` **does** have `=` and canonicalizes its input (key order / whitespace), so it is compared **natively** via `CAST('src' AS jsonb)` — a text compare would false-mismatch on the canonicalization. Both compare shapes are pinned by SQLite predicate tests, and the json-equality case was caught by the real-DSQL E2E.

## Surface

- `--verify=full` on both `migrate` and `load`. Verdicts (single most-actionable per table, precedence `source > L1 > L2 > L3`): `ValueMismatch(N)` / `ValueRowMissingAtTarget(N)` / `ValueCheckSkipped`, with first-K offending PKs in `l3_details`.
- Affirmative `schema_check` (column-set + PK presence — **not** types) rides a separate field so it shows even on `Match`, default-on under both `count` and `full`, on migrate and load.
- CLI renders the verdict, schema line, offending PKs, and a discoverability nudge under `count`.

## Reuse / refactors

- Extracted shared `escape_sql_literal` + `inserts_as_bare_literal` into `db::schema` (worker INSERT and verify compare now coerce identically; deleted the worker's private duplicates).
- `SqlType` gained `Json` and `Jsonb` variants. Bumped `dsql-lint` to `>=0.2.6, <1`: <0.2.6 wrongly rewrote `jsonb`→`json` (lossy — jsonb canonicalizes and has more operators/indexing); 0.2.6 dropped that rule, so migrate now preserves `jsonb` natively.

## Test plan

- [x] Unit: classify verdict matrix (precedence, all 9 variants), SQL-builder (incl. json-text vs jsonb-native predicate shapes), `VerifyMode`/`is_bad_verdict` round-trips, `format_verdict` L3 rendering.
- [x] 10 SQLite-backed `value_check` integration tests: clean / value-mismatch / missing-row / no-PK-skip / **composite-PK-skip** / **non-pgdump-skip** / boolean / **json** / multi-chunk / NULL-PK-errors.
- [x] Orchestrator + load end-to-end (`run_migrate` / `run_load` with `--verify=full`): Match + populated schema_check; no-PK → ValueCheckSkipped.
- [x] Resume guard widened to reject `count|full` (+ allows `off`).
- [x] **Real-DSQL E2E** now runs `--verify=full`, asserts `Match` per table (proving recast canonicalization on real DSQL), plus a deliberate post-load `UPDATE` → `ValueMismatch(1)` with PK localization.
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test` — all clean (322 lib + 26 main + 1 doctest, 1 ignored E2E).

Two review-found bugs (json equality error; resume guard missing `full`) are fixed and regression-tested. Follow-up: the self-review hardened the L3 match check to **fail-closed** (an unexpected match-bool token now counts as a mismatch, never a silent pass), corrected the BIGINT-identity E2E to read `id` as i64, made `SchemaCheck.columns_matched` an `Option<u64>` (distinguishes "not counted" on non-pgdump from a real zero), and fixed the in-memory test pool to a shared-cache DB so multi-connection lookups can't flake.
