### PR TITLE
fix(verify): address PR #36 review — false-positive PK match, fail-closed floor, TTY defang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,15 +39,21 @@
   formats up front with a diagnostic that points to `-Fp`, instead of
   failing later with a generic "no COPY block found" after streaming the
   binary file.
-- New `--verify <off|count>` flag on `load` and `migrate`. `count` adds
-  pre/post `count(*)` per loaded table and emits one verdict —
+- New `--verify <off|count|full>` flag on `load` and `migrate`. `count` adds
+  pre/post `count(*)` per loaded table plus an affirmative schema check
+  (column set + primary/unique key present), and emits one verdict —
   `Match`, `LoaderDropped(N)`, `MissingTarget(N)`, `ExtraTarget(N)`,
-  `RowsConflictedAtTarget(N)`, or `SkippedNoExactSourceCount`. Source-row
-  counting (L1) runs parser-side regardless of the flag for pgdump and
-  parquet. Defaults: `load=off` (avoid `count(*)` on populated targets),
-  `migrate=count` (fresh-cluster pre-counts are sub-ms). Any verdict
-  other than `Match` or `SkippedNoExactSourceCount` exits non-zero.
-  Assumes the loader is the sole writer to the target during the run.
+  `RowsConflictedAtTarget(N)`, or `SkippedNoExactSourceCount`. `full` adds
+  per-row value verification (L3): each row is re-read from the source and
+  compared to the target by primary key via a server-side recast, adding the
+  verdicts `ValueMismatch(N)`, `ValueRowMissingAtTarget(N)`, and
+  `ValueCheckSkipped` (and listing the offending PKs). It costs roughly one
+  extra full read of each table. Source-row counting (L1) runs parser-side
+  regardless of the flag for pgdump and parquet. Defaults: `load=off` (avoid
+  `count(*)` on populated targets), `migrate=count` (fresh-cluster pre-counts
+  are sub-ms). Any verdict other than `Match`, `SkippedNoExactSourceCount`, or
+  `ValueCheckSkipped` exits non-zero. Assumes the loader is the sole writer to
+  the target during the run.
 
 ### Changed
 - A worker-crash that leaves a chunk result file unwritten now fails

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ After a load, `--verify` cross-checks what landed and prints one verdict per tab
 | `--verify` | What it confirms | Cost |
 |------------|------------------|------|
 | `off` | Nothing (load only). | None. |
-| `count` | **No rows were lost.** Source row count = rows loaded + rows that failed, and the target table grew by exactly the number loaded. Also confirms the target's columns match the file and it has a primary/unique key. | Two `COUNT(*)` per table. Negligible. |
+| `count` | **No rows were lost.** Source row count = rows loaded + rows that failed, and the target table grew by exactly the number loaded. Also confirms the target's columns match the file and it has a primary/unique key. (csv/tsv have no exact source count, so the row-count check reports `SkippedNoExactSourceCount` — use pgdump or parquet for it.) | Two `COUNT(*)` per table. Negligible. |
 | `full` | Everything `count` does, **plus every value landed correctly.** Each row is re-read from the source and compared to the target by primary key, letting the database decide equality (so `1.50` vs `1.5`, JSON key order, timestamp precision, etc. are not false alarms). | One extra full read of each table — roughly doubles load time. Opt-in. |
 
 Default: `off` for `load`, `count` for `migrate`. Both `count` and `full` assume the loader is the sole writer to the target during the run.

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -34,14 +34,15 @@ pub enum SqlType {
     /// `jsonb` — canonicalizes input (key order / whitespace) but **has `=`**,
     /// so L3 compares it natively via `CAST('src' AS jsonb)`. (A text compare
     /// would false-mismatch on the canonicalization.) DSQL supports it
-    /// natively; dsql-lint >=0.2.6 preserves it.
+    /// natively and dsql-lint preserves it (the Cargo.toml dep floor pins the
+    /// version that stopped rewriting it to `json`).
     Jsonb,
 }
 
 /// Escape a value for a single-quoted SQL string literal (doubles embedded
 /// quotes). Shared between the worker's INSERT generation and verify's
 /// recast-compare so the two paths escape identically.
-pub fn escape_sql_literal(value: &str) -> String {
+pub(crate) fn escape_sql_literal(value: &str) -> String {
     value.replace('\'', "''")
 }
 
@@ -55,7 +56,7 @@ pub fn escape_sql_literal(value: &str) -> String {
 /// (e.g. `character varying(5)`), which carries the length and so casts
 /// faithfully; those names don't match here, so verify always casts. Bare and
 /// parameterized-cast yield the same stored comparison either way.
-pub fn inserts_as_bare_literal(pg_type: &str) -> bool {
+pub(crate) fn inserts_as_bare_literal(pg_type: &str) -> bool {
     matches!(pg_type, "TEXT" | "VARCHAR" | "CHAR")
 }
 
@@ -71,7 +72,7 @@ pub fn inserts_as_bare_literal(pg_type: &str) -> bool {
 /// on both. (SQLite isn't Postgres, so the worker bypasses this and emits a
 /// bare literal there; verify still recasts so its comparison matches the
 /// affinity-coerced stored value.)
-pub fn recast_literal(pg_type: &str, value: &str) -> String {
+pub(crate) fn recast_literal(pg_type: &str, value: &str) -> String {
     let lit = format!("'{}'", escape_sql_literal(value));
     if inserts_as_bare_literal(pg_type) {
         lit

--- a/src/formats/pgdump/mod.rs
+++ b/src/formats/pgdump/mod.rs
@@ -16,4 +16,5 @@ mod scan;
 mod tests;
 
 pub use reader::PgDumpReader;
-pub use scan::{CopyBlock, extract_ddl, find_copy_block, list_copy_blocks};
+pub(crate) use scan::find_copy_block;
+pub use scan::{CopyBlock, extract_ddl, list_copy_blocks};

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -4998,6 +4998,91 @@ mod tests {
         Ok(())
     }
 
+    /// Regression: `load --verify=full` on a table whose PRIMARY KEY is a type
+    /// the target canonicalizes (numeric scale, uuid case) must verify as
+    /// `Match`. L3 keys its row diff on the verbatim source PK text; if the
+    /// query projected `CAST(pk AS TEXT)` (target-canonical) instead, a source
+    /// PK `1.5` stored as `1.50` would miss the lookup and false-report
+    /// `ValueRowMissingAtTarget` on a faithful load.
+    ///
+    /// `#[ignore]` — needs a real DSQL cluster + IAM (CI `e2e-dsql`). SQLite
+    /// doesn't canonicalize numeric scale, so only DSQL exercises the gap.
+    #[tokio::test]
+    #[ignore]
+    async fn pgdump_load_verify_full_canonicalizing_pk_matches() -> anyhow::Result<()> {
+        let dsql_endpoint = std::env::var("LOADER_DSQL_E2E_ENDPOINT").map_err(|_| {
+            anyhow::anyhow!("LOADER_DSQL_E2E_ENDPOINT must be set (<cluster>.dsql.<region>.on.aws)")
+        })?;
+        let dsql_region =
+            std::env::var("LOADER_DSQL_E2E_REGION").unwrap_or_else(|_| "us-east-1".to_string());
+        anyhow::ensure!(
+            !dsql_endpoint.is_empty(),
+            "LOADER_DSQL_E2E_ENDPOINT is empty"
+        );
+
+        let dsql_pool = build_dsql_pool(
+            PoolArgsBuilder::default()
+                .endpoint(&dsql_endpoint)
+                .region(&dsql_region)
+                .username("admin")
+                .build()?,
+        )
+        .await?;
+
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let table = format!("e2e_canonpk_{suffix}");
+
+        // numeric(10,2) PK: source text `1.5` is stored canonical as `1.50`.
+        dsql_pool
+            .execute_query(&format!(
+                "CREATE TABLE {table} (id numeric(10,2) PRIMARY KEY, note text)"
+            ))
+            .await?;
+
+        let mut f = tempfile::NamedTempFile::new()?;
+        writeln!(f, "COPY public.{table} (id, note) FROM stdin;")?;
+        writeln!(f, "1.5\talpha")?;
+        writeln!(f, "2.675\tbeta")?;
+        writeln!(f, "\\.")?;
+        f.flush()?;
+
+        let mut args = pgdump_load_args(
+            f.path().to_string_lossy().into_owned(),
+            &table,
+            dsql_pool.clone(),
+        );
+        args.verify = VerifyMode::Full;
+
+        let result = run_load(args).await?;
+
+        let v = result.verify.expect("verify=full must populate verify");
+        assert_eq!(
+            v.verdict,
+            crate::verify::VerifyVerdict::Match,
+            "canonicalizing PK must verify as Match, got {:?} (l3_details={:?})",
+            v.verdict,
+            v.l3_details,
+        );
+
+        // Guard against a trivial pass: prove the PK actually canonicalized
+        // (so the source-text echo genuinely had to differ from the target's
+        // CAST(pk AS TEXT)). Source `1.5` must be stored as `1.50`.
+        let (stored_pk,): (String,) = sqlx::query_as(&format!(
+            "SELECT id::text FROM {table} WHERE note = 'alpha'"
+        ))
+        .fetch_one(&dsql_pool)
+        .await?;
+        assert_eq!(
+            stored_pk, "1.50",
+            "PK must have canonicalized 1.5→1.50 (else the test isn't exercising the gap)"
+        );
+
+        let _ = dsql_pool
+            .execute_query(&format!("DROP TABLE IF EXISTS {table}"))
+            .await;
+        Ok(())
+    }
+
     #[tokio::test]
     async fn pgdump_errors_on_column_set_mismatch() -> anyhow::Result<()> {
         // Target table has an extra column not present in the dump's COPY clause.

--- a/src/main.rs
+++ b/src/main.rs
@@ -617,15 +617,41 @@ fn print_verify_detail(v: &VerifyOutcome, nested: bool) {
         failed = v.records_failed,
     );
 
-    // First offending PKs (capped) so the operator can inspect them.
+    // First offending PKs (capped) so the operator can inspect them. PK
+    // values are dump ROW data (never run through identifier validation), so
+    // defang control/bidi bytes before they hit the terminal — a crafted dump
+    // could otherwise smuggle an ANSI escape or RTL-override to stdout.
     if let Some(d) = &v.l3_details {
         if !d.mismatch_pks.is_empty() {
-            println!("{indent}  mismatched PKs: {}", d.mismatch_pks.join(", "));
+            println!(
+                "{indent}  mismatched PKs: {}",
+                defang_pk_list(&d.mismatch_pks)
+            );
         }
         if !d.missing_pks.is_empty() {
-            println!("{indent}  missing PKs: {}", d.missing_pks.join(", "));
+            println!("{indent}  missing PKs: {}", defang_pk_list(&d.missing_pks));
         }
     }
+}
+
+/// Render offending PK values for the terminal with control and bidi/format
+/// bytes escaped (reusing the `list-tables` defang set), so untrusted dump row
+/// data can't reorder or hide output. Comma-joined for the report line.
+fn defang_pk_list(pks: &[String]) -> String {
+    pks.iter()
+        .map(|pk| {
+            pk.chars()
+                .map(|c| {
+                    if c.is_control() || aurora_dsql_loader::runner::is_bidi_or_format_char(c) {
+                        c.escape_default().to_string()
+                    } else {
+                        c.to_string()
+                    }
+                })
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// One-line CLI summary per VerifyVerdict.
@@ -662,7 +688,12 @@ fn format_verdict(v: &VerifyVerdict) -> String {
             format!("MISSING AT TARGET {n} row(s) — source primary key not found in target")
         }
         VerifyVerdict::ValueCheckSkipped => {
-            "SKIPPED value check — no single-column primary/unique key to align rows".to_string()
+            // Covers every reason L3 couldn't align rows: no single-column
+            // primary/unique key, the key absent from the COPY set, or a
+            // non-pgdump format. Stay general — a specific cause here can
+            // contradict the schema line (which may show a key IS present).
+            "SKIPPED value check — could not align source rows to the target by primary key"
+                .to_string()
         }
         _ => format!("UNKNOWN VERDICT: {v:?}"),
     }

--- a/src/migrate/orchestrator.rs
+++ b/src/migrate/orchestrator.rs
@@ -14,8 +14,7 @@ use crate::runner::{
     Format, LoadArgs, OnConflict, VerifyMode, run_load_with_pool_for_pgdump_block,
 };
 use crate::verify::{
-    L2Counts, L3Outcome, VerifyInputs, VerifyOutcome, count_table_rows, schema_check,
-    verify_table_values,
+    L2Counts, VerifyInputs, VerifyOutcome, count_table_rows, schema_check, verify_table_values,
 };
 use anyhow::{Context, Result};
 use aws_config::{BehaviorVersion, Region};
@@ -419,8 +418,7 @@ async fn build_table_verify(
     let (l3, l3_details) = if args.verify == VerifyMode::Full {
         let (outcome, details) =
             verify_table_values(pool, reader, block, args.chunk_size_bytes).await?;
-        let details = matches!(outcome, L3Outcome::Ran { .. }).then_some(details);
-        (Some(outcome), details)
+        outcome.with_details(details)
     } else {
         (None, None)
     };

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -295,9 +295,8 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
             )
             .await?;
             if run_value_check {
-                let details =
-                    matches!(outcome, crate::verify::L3Outcome::Ran { .. }).then_some(details);
-                (Some(outcome), Some(sc), details)
+                let (l3, details) = outcome.with_details(details);
+                (l3, Some(sc), details)
             } else {
                 (None, Some(sc), None)
             }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -79,7 +79,7 @@ pub struct L2Counts {
 /// the aggregate counts across all PK batches; `Skipped` means L3 was
 /// requested but could not run (no usable PK / non-exact-count format).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum L3Outcome {
+pub(crate) enum L3Outcome {
     Ran {
         /// True total of rows whose target value diverged, summed across
         /// every batch (not capped — the detail list is capped separately).
@@ -90,6 +90,16 @@ pub enum L3Outcome {
     Skipped,
 }
 
+impl L3Outcome {
+    /// Pair this outcome with its per-PK detail, keeping `details` only when
+    /// L3 actually `Ran` (a `Skipped` run has no PKs to localize). Centralizes
+    /// the "details only when Ran" invariant the migrate and load paths share.
+    pub(crate) fn with_details(self, details: L3Details) -> (Option<L3Outcome>, Option<L3Details>) {
+        let details = matches!(self, L3Outcome::Ran { .. }).then_some(details);
+        (Some(self), details)
+    }
+}
+
 /// Affirmative schema-conformance line (MUST #3): the column set the load
 /// enforced matched the dump's COPY columns, and whether the table has a
 /// primary or unique key. Scoped to **column-set + key presence only** —
@@ -97,6 +107,7 @@ pub enum L3Outcome {
 /// the column set matches via `align_pgdump_schema_to_copy_columns`; deeper
 /// checks are out of scope, see the requirements doc).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct SchemaCheck {
     /// `Some(n)` = the load enforced an n-column COPY set; `None` = not
     /// counted (non-pgdump format has no COPY block to measure), distinct
@@ -113,6 +124,7 @@ pub struct SchemaCheck {
 /// `DETAILS`) is a follow-up. Lists are capped; the verdict magnitude
 /// carries the true total.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub struct L3Details {
     pub mismatch_pks: Vec<String>,
     pub missing_pks: Vec<String>,

--- a/src/verify/value_check.rs
+++ b/src/verify/value_check.rs
@@ -138,6 +138,13 @@ const DETAIL_CAP: usize = 100;
 /// Assumes source PK values are unique (guaranteed for any real
 /// single-column-PK dump). A hand-corrupted dump with duplicate PKs would
 /// mis-count by the duplicate multiplicity but cannot panic.
+///
+/// Recast comparison assumes pg_dump's canonical COPY output: `timestamptz`
+/// values carry an explicit UTC offset (so the recast is session-`timezone`
+/// independent). A hand-edited dump with an *unqualified* timestamp for a
+/// `timestamptz` column could false-mismatch if the load and verify
+/// connections run under different session `timezone` — offset-bearing
+/// literals (what pg_dump emits) are immune.
 pub(crate) async fn verify_table_values(
     pool: &Pool,
     reader: Arc<dyn ByteReader>,
@@ -177,6 +184,22 @@ pub(crate) async fn verify_table_values(
         .collect::<Result<_>>()?;
 
     let records = read_source_records(reader, block, chunk_size_bytes).await?;
+
+    // Fail-closed floor: a non-empty COPY payload that re-reads to zero rows
+    // is a decode/short-read failure, not a clean table. Without this guard it
+    // would fall through to `Ran{0,0}` → `Match` (L1's counts are frozen at
+    // load time and can't see the re-read), silently passing the exact
+    // fidelity gap L3 exists to catch.
+    if records.is_empty() && block.data_end > block.data_start {
+        anyhow::bail!(
+            "verify=full: re-read of {}.{} decoded 0 rows from a non-empty COPY block \
+             ({} bytes) — possible short read or decode failure; not reporting Match",
+            block.schema,
+            block.table,
+            block.data_end - block.data_start,
+        );
+    }
+
     let qualified = pool.qualified_table_name(&block.schema, &block.table);
     let is_postgres = pool.is_postgres();
 
@@ -344,8 +367,10 @@ fn compares_as_text(pg_type: &str) -> bool {
 
 /// Per-column match predicate: `None` (source `\N`) → `"col" IS NULL`;
 /// `Some(v)` → `"col" <nseq> <recast literal>`. `col` is double-quoted.
-/// `ty` is the column's `to_postgres()` type name; `JSON` takes the
-/// text-compare path (see [`compares_as_text`]), everything else recasts.
+/// `ty` is the column's parameterized type name — `format_type(atttypid,
+/// atttypmod)` on Postgres/DSQL, `to_postgres()` on the SQLite test path;
+/// `json` takes the text-compare path (see [`compares_as_text`]), everything
+/// else recasts.
 fn column_predicate(col: &str, ty: &str, value: Option<&str>, is_postgres: bool) -> String {
     let quoted = format!("\"{col}\"");
     let nseq = null_safe_eq(is_postgres);
@@ -367,9 +392,18 @@ pub(crate) struct SourceRow<'a> {
 }
 
 /// Build the projected-bool batch query: for each `SourceRow`, return
-/// `(pk::text, matches)` where `matches` ANDs every column predicate. A
-/// requested PK absent from the result set is a missing row (the caller
+/// `(source_pk_text, matches)` where `matches` ANDs every column predicate.
+/// A requested PK absent from the result set is a missing row (the caller
 /// diffs requested vs returned PKs).
+///
+/// The first column echoes back the row's **verbatim source PK text**, not
+/// `CAST(pk AS TEXT)`. The target canonicalizes on cast (`numeric` `1.5`→
+/// `1.50`, `uuid` upper→lower), so projecting the target's text and matching
+/// it against the raw source text would false-miss every canonicalized PK and
+/// report `ValueRowMissingAtTarget` on a faithful load. Echoing the source
+/// text via a CASE that shares the recast `IS NOT DISTINCT FROM` arms keeps
+/// the row-match server-side (canonicalization-correct) while the caller's
+/// diff compares like-for-like.
 ///
 /// The `WHERE pk IN (...)` list and the per-row `CASE WHEN pk <nseq> ...`
 /// arms are built from the SAME recast PK literals, so the batch is exact
@@ -387,7 +421,22 @@ fn build_batch_query(
     let quoted_pk = format!("\"{pk_col}\"");
     let nseq = null_safe_eq(is_postgres);
 
-    let arms: String = rows
+    // Two CASE expressions over the same `WHEN pk <nseq> <recast literal>`
+    // arms: one echoes the verbatim source PK text (the map key), the other
+    // ANDs the row's column predicates (the match bool).
+    let key_arms: String = rows
+        .iter()
+        .map(|row| {
+            format!(
+                "      WHEN {quoted_pk} {nseq} {} THEN '{}'",
+                pk_lit(row.pk_value),
+                escape_sql_literal(row.pk_value),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let match_arms: String = rows
         .iter()
         .map(|row| {
             let row_match = if row.columns.is_empty() {
@@ -413,11 +462,10 @@ fn build_batch_query(
         .collect::<Vec<_>>()
         .join(", ");
 
-    // Both columns are fetched as text: the match bool is wrapped in
-    // CAST(... AS TEXT) so it decodes uniformly — Postgres yields
-    // `true`/`false`, SQLite yields `1`/`0` (see `is_match`).
+    // The match bool is wrapped in CAST(... AS TEXT) so it decodes uniformly —
+    // Postgres yields `true`/`false`, SQLite yields `1`/`0` (see `is_match`).
     format!(
-        "SELECT CAST({quoted_pk} AS TEXT), CAST(CASE\n{arms}\n    END AS TEXT)\n  \
+        "SELECT CASE\n{key_arms}\n    END, CAST(CASE\n{match_arms}\n    END AS TEXT)\n  \
          FROM {qualified_table}\n  WHERE {quoted_pk} IN ({in_list})"
     )
 }
@@ -607,6 +655,56 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(out, L3Outcome::Skipped);
+    }
+
+    #[tokio::test]
+    async fn l3_pk_not_in_copy_set_is_skipped() {
+        // Target has a PK (`id`), but the COPY block doesn't include it — the
+        // row can't be aligned positionally, so L3 must Skip (never a silent
+        // pass), distinct from the no-PK case.
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        pool.execute_query("CREATE TABLE things (id INTEGER PRIMARY KEY, note TEXT)")
+            .await
+            .unwrap();
+        pool.execute_query("INSERT INTO things VALUES (1, 'a')")
+            .await
+            .unwrap();
+
+        // COPY clause omits the PK column `id`.
+        let (f, block) = fixture_block("COPY public.things (note) FROM stdin;", &["a"]).await;
+
+        let (out, details) = verify_table_values(&pool, reader_for(&f), &block, 1 << 20)
+            .await
+            .unwrap();
+        assert_eq!(out, L3Outcome::Skipped);
+        assert_eq!(details, L3Details::default());
+    }
+
+    #[tokio::test]
+    async fn l3_empty_block_does_not_trip_zero_row_floor() {
+        // A genuinely empty COPY block (header then `\.`, no data) has
+        // data_end == data_start, so the fail-closed floor must NOT fire — it
+        // reports a clean Ran{0,0}, not an error.
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        pool.execute_query("CREATE TABLE things (id INTEGER PRIMARY KEY, note TEXT)")
+            .await
+            .unwrap();
+        let (f, block) = fixture_block("COPY public.things (id, note) FROM stdin;", &[]).await;
+        assert_eq!(
+            block.data_end, block.data_start,
+            "empty block must have a zero-length payload"
+        );
+
+        let (out, _details) = verify_table_values(&pool, reader_for(&f), &block, 1 << 20)
+            .await
+            .unwrap();
+        assert_eq!(
+            out,
+            L3Outcome::Ran {
+                value_mismatches: 0,
+                rows_missing_at_target: 0
+            }
+        );
     }
 
     #[tokio::test]
@@ -901,13 +999,18 @@ mod tests {
         ];
         let sql = build_batch_query("\"t\"", "id", "INTEGER", &rows, true);
 
-        // PK projected as text; per-row CASE arm keyed by recast PK; the IN
-        // list holds the same recast literals; null source field → IS NULL.
+        // First column is a CASE that echoes the verbatim source PK text (not
+        // CAST(pk AS TEXT)); the match bool is the second CAST(... AS TEXT)
+        // CASE. Per-row arms keyed by recast PK; IN list holds the same
+        // recast literals; null source field → IS NULL.
+        assert!(sql.contains("SELECT CASE"), "{sql}");
+        assert!(sql.contains("END, CAST(CASE"), "{sql}");
+        assert!(sql.contains("END AS TEXT)"), "{sql}");
+        // Source PK text echoed as the key for row 1.
         assert!(
-            sql.contains("SELECT CAST(\"id\" AS TEXT), CAST(CASE"),
+            sql.contains("WHEN \"id\" IS NOT DISTINCT FROM CAST('1' AS INTEGER) THEN '1'"),
             "{sql}"
         );
-        assert!(sql.contains("END AS TEXT)"), "{sql}");
         assert!(
             sql.contains("WHEN \"id\" IS NOT DISTINCT FROM CAST('1' AS INTEGER) THEN ("),
             "{sql}"
@@ -922,6 +1025,30 @@ mod tests {
             "{sql}"
         );
         assert!(sql.contains("FROM \"t\""), "{sql}");
+    }
+
+    #[test]
+    fn batch_query_echoes_source_pk_text_not_target_canonical() {
+        // Regression: a numeric(10,2) PK with source text `1.5` is stored as
+        // `1.50`. The key column must echo the SOURCE text `1.5` so the
+        // caller's diff (keyed on raw source text) matches — projecting
+        // CAST(pk AS TEXT) would yield `1.50` and false-report missing.
+        let rows = vec![SourceRow {
+            pk_value: "1.5",
+            columns: vec![("v", "TEXT", Some("x"))],
+        }];
+        let sql = build_batch_query("\"t\"", "id", "numeric(10,2)", &rows, true);
+        assert!(
+            sql.contains(
+                "WHEN \"id\" IS NOT DISTINCT FROM CAST('1.5' AS numeric(10,2)) THEN '1.5'"
+            ),
+            "key column must echo verbatim source text '1.5': {sql}"
+        );
+        // The target's canonical form must NOT be what we key on.
+        assert!(
+            !sql.contains("CAST(\"id\" AS TEXT)"),
+            "must not project target-canonical PK text: {sql}"
+        );
     }
 
     #[test]
@@ -946,11 +1073,11 @@ mod tests {
             columns: vec![("v", "TEXT", Some("x"))],
         }];
         let sql = build_batch_query("\"t\"", "id", "UUID", &rows, true);
-        // PK literal recast in both the CASE arm and the IN list.
+        // PK literal recast in: key-CASE arm, match-CASE arm, and IN list.
         assert_eq!(
             sql.matches("CAST('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' AS UUID)")
                 .count(),
-            2,
+            3,
             "{sql}"
         );
     }


### PR DESCRIPTION
Follow-up to #36 (merged), addressing @anwesham-lab's [code review](https://github.com/aws-samples/aurora-dsql-loader/pull/36#issuecomment-4734823399). Each of the 14 findings was validated against the actual code — and the load-bearing ones on a **live DSQL cluster** — before deciding whether to apply it.

## Applied

**Correctness**
- **#2 — false `ValueRowMissingAtTarget` on canonicalizing PKs.** `build_batch_query` keyed its row diff on `CAST(pk AS TEXT)` (target-canonical) but looked it up with raw source text, so a `numeric(10,2)` PK source `1.5` (stored `1.50`) or an uppercase `uuid` false-missed → non-zero exit on a faithful load. Now the query echoes the **verbatim source PK text** via a CASE sharing the recast `IS NOT DISTINCT FROM` arms; the row match stays server-side (canonicalization-correct). **Red-green confirmed on a live cluster**: the new `#[ignore]` E2E `pgdump_load_verify_full_canonicalizing_pk_matches` fails (`ValueRowMissingAtTarget`) without the fix, `Match` with it.
- **#1 — silent `Ran{0,0}` → Match floor.** A non-empty COPY payload that re-reads to zero rows now fails closed instead of falling through to a clean verdict (L1's load-time counts can't see the re-read).

**Security**
- **#6 — TTY defang.** Offending PK values are dump *row data* (never identifier-validated); they're now control/bidi-defanged before printing, matching the existing `list-tables` hardening.

**Clarity / API**
- **#7** hoist `L3Outcome::with_details`, collapsing the "details only when Ran" invariant duplicated across the migrate and load paths.
- **#8** generalize the `ValueCheckSkipped` CLI string so it can't contradict the schema line (which may show a key present).
- **#10** `L3Outcome`, the three `schema.rs` SQL helpers, and the `find_copy_block` re-export → `pub(crate)`; `#[non_exhaustive]` on `SchemaCheck`/`L3Details` (consistent with `VerifyOutcome`).
- **#11 / #12a / #3** `column_predicate` rustdoc corrected (`format_type`, not `to_postgres`); dropped the `dsql-lint >=0.2.6` hard version pin; documented the `timestamptz` session-TZ caveat.
- **#13** README `count` row caveated for csv/tsv; CHANGELOG `--verify` entry updated to `<off|count|full>` with the L3 verdicts.

## Not applied (with reason)
- **#5 (json[] errors on native path)** — unreachable: DSQL forbids array column types, so `json[]` never reaches a DSQL table. No fix needed.
- **#14 ("1 ignored E2E" undercount)** — artifact of the already-merged PR body; no code action.

## Deferred to a follow-up (real, but out of scope here)
- **#4** — `verify=full` materializes the whole decoded table in memory; stream chunk-by-chunk to cap peak memory on multi-GB tables (~50-LOC behavioral refactor).
- **Full #8** — a `Skipped(SkipReason)` payload to render the exact skip cause (this PR does the minimal honest CLI-string fix).

## Validation
`cargo fmt` + `clippy --all-targets` clean; **329 lib tests pass, 3 ignored E2E**. The two verify E2Es (`typmod_narrower`, `canonicalizing_pk`) were run green on a live DSQL cluster this session; #2's E2E was red-green verified. Reviewed by an independent code-review agent — no high-confidence issues.