### PR TITLE
chore: release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,14 @@
   the target during the run.
 
 ### Changed
+- `migrate`'s DDL apply and the load worker now retry on DSQL's
+  optimistic-concurrency conflict (SQLSTATE `OC000`/`OC001`, "schema has
+  been updated by another transaction") using the connector's
+  `retry_on_occ` (exponential backoff). Previously only `40001` and a few
+  other transient codes were retried, so a CREATE/ALTER whose snapshot
+  predated a just-committed catalog change — common in a DSQL→DSQL
+  migrate that re-creates objects — could fail the run instead of
+  transparently retrying.
 - A worker-crash that leaves a chunk result file unwritten now fails
   the load instead of being treated as 0 rows. Previously the missing
   rows were invisible: `records_failed` stayed 0 and `source_rows`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-06-19
+
 ### Added
 - `migrate` now supports **DSQL → DSQL** migration. A `pg_dump` taken from a
   DSQL cluster contains DSQL-native idioms the cluster cannot itself re-ingest:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aurora-dsql-loader"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-dsql",
  "derive_builder",
+ "rand 0.10.1",
  "regex",
  "sqlx",
  "thiserror 2.0.17",
@@ -1095,6 +1096,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,6 +1243,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1833,8 +1854,20 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2933,6 +2966,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2951,6 +2990,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2990,6 +3040,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -3400,7 +3456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3411,7 +3467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ aws-credential-types = "1.2"
 aws-sdk-dsql = "1.40"
 aws-sdk-s3 = "1.112"
 aws-types = "1.3"
-aurora-dsql-sqlx-connector = { version = "0.1", features = ["pool"] }
+aurora-dsql-sqlx-connector = { version = "0.1", features = ["pool", "occ"] }
 bytes = "1.11"
 chrono = "0.4"
 clap = { version = "4.5.53", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aurora-dsql-loader"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2024"
 description = "A data loader for Aurora DSQL with support for CSV, TSV, and Parquet files"
 homepage = "https://github.com/aws-samples/aurora-dsql-loader"

--- a/src/coordination/worker.rs
+++ b/src/coordination/worker.rs
@@ -844,6 +844,10 @@ impl Worker {
                         // 40001 - serialization_failure (transaction conflicts)
                         // 40P01 - deadlock_detected
                         // 42001 - DSQL-specific transient error
+                        // OC000/OC001 - DSQL optimistic-concurrency conflict
+                        //   ("schema has been updated by another transaction");
+                        //   transient, safe to retry (matches the connector's
+                        //   is_occ_error set).
                         // 08xxx - Connection errors (08000, 08003, 08006, 08P01)
                         // 53xxx - Insufficient resources (53000, 53100, 53200, 53300, 53400)
                         // 57xxx - Operator intervention (57000, 57014, 57P01, 57P02, 57P03)
@@ -853,6 +857,8 @@ impl Worker {
                             || code == "40001"
                             || code == "40P01"
                             || code == "42001"
+                            || code == "OC000"
+                            || code == "OC001"
                         {
                             return true;
                         }

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -5280,12 +5280,22 @@ mod tests {
         assert_eq!(report.tables[0].records_loaded, 2);
         assert_eq!(report.tables[0].records_failed, 0);
 
+        // The reads below run microseconds after the migrate's DDL committed,
+        // so they can trip DSQL's optimistic-concurrency check (OC001, "schema
+        // has been updated by another transaction") against the just-changed
+        // catalog. Wrap them in the connector's `retry_on_occ` (SQLSTATE-based
+        // detection + exponential backoff) rather than hand-rolling a retry.
+        let occ = aurora_dsql_sqlx_connector::OCCRetryConfig::default();
+
         // ── The identity column re-lands as an identity on the destination. ─
-        let (is_identity,): (String,) = sqlx::query_as(&format!(
-            "SELECT is_identity FROM information_schema.columns \
-             WHERE table_schema='public' AND table_name='{table}' AND column_name='id'"
-        ))
-        .fetch_one(&dsql_pool)
+        let (is_identity,): (String,) = aurora_dsql_sqlx_connector::retry_on_occ(&occ, || async {
+            sqlx::query_as(&format!(
+                "SELECT is_identity FROM information_schema.columns \
+                     WHERE table_schema='public' AND table_name='{table}' AND column_name='id'"
+            ))
+            .fetch_one(&dsql_pool)
+            .await
+        })
         .await?;
         assert_eq!(is_identity, "YES", "{table}.id must be an identity column");
 
@@ -5296,10 +5306,13 @@ mod tests {
             email: String,
             payload: Option<serde_json::Value>,
         }
-        let rows: Vec<Row> = sqlx::query_as(&format!(
-            "SELECT id, email, payload FROM public.{table} ORDER BY id"
-        ))
-        .fetch_all(&dsql_pool)
+        let rows: Vec<Row> = aurora_dsql_sqlx_connector::retry_on_occ(&occ, || async {
+            sqlx::query_as(&format!(
+                "SELECT id, email, payload FROM public.{table} ORDER BY id"
+            ))
+            .fetch_all(&dsql_pool)
+            .await
+        })
         .await?;
         assert_eq!(rows.len(), 2);
         // Identity values round-trip (the loaded id column carries the source values).
@@ -5312,10 +5325,15 @@ mod tests {
 
         // ── Counter advanced: the dump's trailing setval landed on the inline
         // identity's implicit sequence, so the next insert gets id=3. ────────
-        let (next_id,): (i64,) = sqlx::query_as(&format!(
-            "INSERT INTO public.{table} (email) VALUES ('c@example.com') RETURNING id"
-        ))
-        .fetch_one(&dsql_pool)
+        // Safe under retry: an OCC-conflicted INSERT does not commit, so a retry
+        // does not double-insert.
+        let (next_id,): (i64,) = aurora_dsql_sqlx_connector::retry_on_occ(&occ, || async {
+            sqlx::query_as(&format!(
+                "INSERT INTO public.{table} (email) VALUES ('c@example.com') RETURNING id"
+            ))
+            .fetch_one(&dsql_pool)
+            .await
+        })
         .await?;
         assert_eq!(
             next_id, 3,

--- a/src/migrate/apply.rs
+++ b/src/migrate/apply.rs
@@ -11,6 +11,7 @@
 
 use crate::db::Pool;
 use anyhow::{Context, Result};
+use aurora_dsql_sqlx_connector::{DsqlError, OCCRetryConfig, retry_on_occ};
 
 /// Outcome of a single applied DDL statement, captured so the migrate
 /// orchestrator can build a useful summary report and so callers (e.g. the
@@ -50,6 +51,7 @@ pub enum ApplyOutcome {
 pub async fn apply_ddl(pool: &Pool, ddl: &str) -> Result<Vec<AppliedStatement>> {
     let statements = split_sql_statements(ddl);
     let total = statements.len();
+    let occ = OCCRetryConfig::default();
     tracing::info!(statements = total, "applying DDL");
     let mut applied = Vec::with_capacity(total);
     for (i, stmt) in statements.into_iter().enumerate() {
@@ -59,7 +61,12 @@ pub async fn apply_ddl(pool: &Pool, ddl: &str) -> Result<Vec<AppliedStatement>> 
             preview = %safe_for_terminal(&stmt),
             "applying DDL statement"
         );
-        match pool.execute_query(&stmt).await {
+        // Retry on DSQL's optimistic-concurrency conflict (OC000/OC001/40001):
+        // a CREATE/ALTER whose snapshot predates a just-committed catalog change
+        // (e.g. a DROP of the same object, or concurrent DDL on a busy cluster)
+        // is rejected and is safe to re-run — each statement is its own txn and
+        // the already-exists skip below keeps re-application idempotent.
+        match apply_one(pool, &occ, &stmt).await {
             Ok(()) => applied.push(AppliedStatement {
                 sql: stmt,
                 outcome: ApplyOutcome::Applied,
@@ -79,6 +86,20 @@ pub async fn apply_ddl(pool: &Pool, ddl: &str) -> Result<Vec<AppliedStatement>> 
         }
     }
     Ok(applied)
+}
+
+/// Run one DDL statement with OCC retry, normalizing the connector's
+/// [`DsqlError`] back to the underlying [`sqlx::Error`] so the caller's
+/// already-exists classification (which inspects SQLSTATE on `sqlx::Error`)
+/// is unchanged. OCC-exhausted and non-database errors surface as a synthetic
+/// protocol-level `sqlx::Error` carrying the message.
+async fn apply_one(pool: &Pool, occ: &OCCRetryConfig, stmt: &str) -> Result<(), sqlx::Error> {
+    retry_on_occ(occ, || pool.execute_query(stmt))
+        .await
+        .map_err(|e| match e {
+            DsqlError::DatabaseError(inner) | DsqlError::ConnectionError(inner) => inner,
+            other => sqlx::Error::Protocol(other.to_string()),
+        })
 }
 
 /// Whether a sqlx error represents a target object that already exists


### PR DESCRIPTION
## Summary

Version bump **3.0.0 → 3.1.0** to cut a release of everything that has landed on `main` since v3.0.0. Minor (additive) bump per semver — no user-facing breaking changes.

Bumps `Cargo.toml` + `Cargo.lock` and stamps the CHANGELOG `[Unreleased]` section as `[3.1.0] - 2026-06-19`.

## What this release ships

- **DSQL → DSQL migration** (#37): a `pg_dump` taken from a DSQL cluster now migrates back into DSQL. The loader's `dsql-lint` requirement is `>=0.2.9`, which collapses the DSQL-native identity idiom (`ALTER … ADD GENERATED … AS IDENTITY`) inline onto the `CREATE TABLE` and strips `SET COMPRESSION`. Producing the dump uses the new pgdump-proxy in aurora-dsql-tools.
- **`migrate` subcommand**: one-command full `pg_dump -Fp` (DDL + data) → DSQL.
- **`--format pgdump`** loads and **`list-tables`** dump discovery.
- **`--verify <off|count|full>`**: per-table verdicts; `full` adds L3 per-row value verification.

See the CHANGELOG `[3.1.0]` section for the full list.

## After merge
Tag `v3.1.0` triggers `release.yml`, which builds the cross-platform binaries and publishes the GitHub Release.

## Verification
`cargo fmt --check`, `cargo clippy --all-targets --all-features`, and `cargo test` all green locally (330 lib + integration tests pass; 4 ignored real-cluster e2es).