### PR TITLE
chore: release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [3.2.0] - 2026-06-23
 
 ### Added
 - New `export` subcommand: reads a source DSQL cluster's catalog directly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aurora-dsql-loader"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aurora-dsql-loader"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2024"
 description = "A data loader for Aurora DSQL with support for CSV, TSV, and Parquet files"
 homepage = "https://github.com/aws-samples/aurora-dsql-loader"


### PR DESCRIPTION
Minor (additive) release: **3.1.0 → 3.2.0**.

Bumps `Cargo.toml` / `Cargo.lock` and stamps the CHANGELOG `[Unreleased]` block under `[3.2.0]`.

### What's in it
- **New `export` subcommand** (#41): reads a source DSQL cluster's catalog directly — no `pg_dump`, no proxy — and writes a plain `pg_dump`-shaped `.sql` (DDL + `COPY ... FROM stdin`) that `migrate --source-uri` consumes unchanged. Makes a DSQL → DSQL move two commands. Output is DSQL-clean by construction (inline identity with `CACHE`, `setval` continuation, PK folded onto `CREATE TABLE`, indexes normalized by `migrate`). `--schema` / `--table` narrow it; omit `--output` for stdout. Rejects tables with generated columns or `CHECK` constraints rather than silently dropping them.

No user-facing breaking changes.

### Release steps after merge
Tag `v3.2.0` on the merge commit and push it — `release.yml` (triggered on `v*` tags) builds and publishes.
