### PR TITLE
Add opt-in --atomic flag for all-or-nothing loads

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,9 @@ aurora-dsql-loader load \
   --atomic
 ```
 
-On any failure the loader drops the table it created and exits non-zero. If that cleanup DROP itself fails, the loader says so and names the table for you to drop manually. `--atomic` requires `--if-not-exists` and refuses to run if the table already exists or can't be verified absent (it will not drop pre-existing data—drop it yourself first). It can't be combined with `--resume-job-id`. Loading into an existing table atomically is not yet supported.
+On any load failure (an error, or one or more failed records) the loader drops the table it created and exits non-zero. If that cleanup DROP itself fails, the loader says so and names the table for you to drop manually. `--atomic` requires `--if-not-exists` and refuses to run if the table already exists or can't be verified absent (it will not drop pre-existing data—drop it yourself first). It can't be combined with `--resume-job-id`. Loading into an existing table atomically is not yet supported.
+
+Rollback covers load failures only. A non-fatal `--verify` mismatch or row-count warning still exits non-zero but keeps the table so you can inspect it.
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ aurora-dsql-loader load \
   --atomic
 ```
 
-On any failure the loader drops the table it created and exits non-zero, leaving the cluster as it was. `--atomic` requires `--if-not-exists` and refuses to run if the table already exists (it will not drop pre-existing data—drop it yourself first). Loading into an existing table atomically is not yet supported.
+On any failure the loader drops the table it created and exits non-zero. If that cleanup DROP itself fails, the loader says so and names the table for you to drop manually. `--atomic` requires `--if-not-exists` and refuses to run if the table already exists or can't be verified absent (it will not drop pre-existing data—drop it yourself first). It can't be combined with `--resume-job-id`. Loading into an existing table atomically is not yet supported.
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -343,6 +343,21 @@ aurora-dsql-loader load \
 
 Resume automatically retries failed chunks and skips completed ones. For safety against duplicates on retry, use unique constraints on your table—the loader will use `ON CONFLICT DO NOTHING` to skip duplicates.
 
+## Atomic Loads (all-or-nothing)
+
+DSQL caps every transaction at 3,000 rows / 10 MiB / 5 min and has no `SAVEPOINT`, so a parallel bulk load can't be one atomic transaction. The one clean rollback is to drop a table the loader created this run, so `--atomic` covers exactly that case:
+
+```bash
+aurora-dsql-loader load \
+  --endpoint your-cluster.dsql.us-east-1.on.aws \
+  --source-uri data.csv \
+  --table new_table \
+  --if-not-exists \
+  --atomic
+```
+
+On any failure the loader drops the table it created and exits non-zero, leaving the cluster as it was. `--atomic` requires `--if-not-exists` and refuses to run if the table already exists (it will not drop pre-existing data—drop it yourself first). Loading into an existing table atomically is not yet supported.
+
 ## Verification
 
 After a load, `--verify` cross-checks what landed and prints one verdict per table. Pick the level by how much assurance you need vs. how much extra time you'll spend.

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -564,4 +564,16 @@ mod tests {
         let pool = Pool::sqlite_in_memory().await.unwrap();
         assert_eq!(pool.qualified_table_name("public", "orders"), "\"orders\"");
     }
+
+    /// `table_exists` must distinguish absent (`Ok(false)`) from present
+    /// (`Ok(true)`) — the contract `--atomic` relies on to fail closed.
+    #[tokio::test]
+    async fn table_exists_reports_absent_then_present() {
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+        assert!(!pool.table_exists("public", "t").await.unwrap());
+        pool.execute_query("CREATE TABLE t (id TEXT)")
+            .await
+            .unwrap();
+        assert!(pool.table_exists("public", "t").await.unwrap());
+    }
 }

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -256,6 +256,46 @@ impl Pool {
         }
     }
 
+    /// True if the table exists. Unlike probing `query_table_schema(...).is_ok()`,
+    /// this distinguishes "absent" (`Ok(false)`) from "could not check" (`Err`),
+    /// so a transient probe failure is never silently read as "table absent".
+    /// Callers that gate a destructive action on non-existence MUST treat `Err`
+    /// as "stop", not "proceed".
+    pub async fn table_exists(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+    ) -> Result<bool, sqlx::Error> {
+        match &self.inner {
+            PoolInner::Postgres(pool) => {
+                let mut conn = pool.acquire().await?;
+                let sql = r#"
+                    SELECT EXISTS (
+                        SELECT 1 FROM information_schema.tables
+                        WHERE table_schema = $1 AND table_name = $2
+                    )
+                "#;
+                let (exists,): (bool,) = sqlx::query_as(sql)
+                    .bind(schema_name)
+                    .bind(table_name)
+                    .fetch_one(&mut *conn)
+                    .await?;
+                Ok(exists)
+            }
+            #[cfg(test)]
+            PoolInner::Sqlite(pool) => {
+                let (_, sqlite_table) = self.table_identifier(schema_name, table_name);
+                let (n,): (i64,) = sqlx::query_as(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name = ?",
+                )
+                .bind(sqlite_table)
+                .fetch_one(pool)
+                .await?;
+                Ok(n > 0)
+            }
+        }
+    }
+
     /// Check if a table has unique constraints (primary key or unique index)
     pub async fn has_unique_constraints(
         &self,

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -333,6 +333,8 @@ mod tests {
         // (not the hard-Err arm, and not the "rollback INCOMPLETE" wording).
         assert!(err.contains("record(s) failed"), "{err}");
         assert!(err.contains("rolled back — dropped table"), "{err}");
+        // The failure manifest path must be surfaced, not orphaned.
+        assert!(err.contains("Failure manifest preserved at"), "{err}");
         assert!(
             !sqlite_table_exists(&pool, "atomic_rollback").await,
             "atomic load must DROP the table it created on failure"

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -329,10 +329,31 @@ mod tests {
 
         let args = atomic_load_args(&pool, "atomic_rollback", &csv_path, true, true);
         let err = run_load(args).await.unwrap_err().to_string();
-        assert!(err.contains("rolled back"), "{err}");
+        // Pins the partial-failure arm and the truthful "dropped" message
+        // (not the hard-Err arm, and not the "rollback INCOMPLETE" wording).
+        assert!(err.contains("record(s) failed"), "{err}");
+        assert!(err.contains("rolled back — dropped table"), "{err}");
         assert!(
             !sqlite_table_exists(&pool, "atomic_rollback").await,
             "atomic load must DROP the table it created on failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_atomic_rejects_resume() {
+        // Library callers bypass clap's `conflicts_with`, so run_load must
+        // also refuse --atomic + --resume-job-id (a dropped-table rollback
+        // can't be coherently resumed).
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path = create_test_csv(&temp_dir, "ok.csv", 5).await;
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+
+        let mut args = atomic_load_args(&pool, "atomic_resume", &csv_path, true, true);
+        args.resume_job_id = Some("job-123".to_string());
+        let err = run_load(args).await.unwrap_err().to_string();
+        assert!(
+            err.contains("--atomic cannot be combined with --resume-job-id"),
+            "{err}"
         );
     }
 

--- a/src/integ_tests.rs
+++ b/src/integ_tests.rs
@@ -221,6 +221,134 @@ mod tests {
         0
     }
 
+    /// True if `table_name` exists in the SQLite test DB (sqlite_master lookup).
+    async fn sqlite_table_exists(pool: &Pool, table_name: &str) -> bool {
+        if let Ok(mut conn) = pool.acquire().await
+            && let PoolConnection::Sqlite(ref mut sqlite_conn) = conn
+        {
+            let (n,): (i64,) = sqlx::query_as(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name = ?",
+            )
+            .bind(table_name)
+            .fetch_one(&mut **sqlite_conn)
+            .await
+            .unwrap();
+            return n > 0;
+        }
+        false
+    }
+
+    /// Build a `LoadArgs` for a CSV load against `pool`, with the atomic and
+    /// if-not-exists toggles exposed (everything else defaulted).
+    fn atomic_load_args(
+        pool: &Pool,
+        table: &str,
+        csv_path: &str,
+        atomic: bool,
+        if_not_exists: bool,
+    ) -> LoadArgs {
+        LoadArgs {
+            endpoint: "test".to_string(),
+            region: "us-west-2".to_string(),
+            username: "test".to_string(),
+            source_uri: csv_path.to_string(),
+            target_table: table.to_string(),
+            schema: "public".to_string(),
+            format: Format::Csv,
+            worker_count: 1,
+            chunk_size_bytes: 1_000_000,
+            batch_size: 10,
+            batch_concurrency: 1,
+            create_table_if_missing: if_not_exists,
+            atomic,
+            manifest_dir: None,
+            quiet: true,
+            debug: false,
+            column_mappings: HashMap::new(),
+            resume_job_id: None,
+            on_conflict: crate::coordination::manifest::OnConflict::DoNothing,
+            exclude_columns: Vec::new(),
+            delimiter: None,
+            quote: None,
+            escape: None,
+            has_header: Some(true),
+            verify: VerifyMode::Off,
+            test_pool: Some(pool.clone()),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_atomic_requires_if_not_exists() {
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path = create_test_csv(&temp_dir, "ok.csv", 5).await;
+        let pool =
+            setup_sqlite_table("atomic_pre", "id TEXT, name TEXT, value TEXT, amount TEXT").await;
+
+        let args = atomic_load_args(&pool, "atomic_pre", &csv_path, true, false);
+        let err = run_load(args).await.unwrap_err().to_string();
+        assert!(err.contains("--atomic requires --if-not-exists"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn test_atomic_refuses_existing_table() {
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path = create_test_csv(&temp_dir, "ok.csv", 5).await;
+        // Pre-existing table with a row: --atomic must never drop it.
+        let pool = setup_sqlite_table(
+            "atomic_exists",
+            "id TEXT, name TEXT, value TEXT, amount TEXT",
+        )
+        .await;
+        pool.execute_query("INSERT INTO atomic_exists VALUES ('x','x','x','x')")
+            .await
+            .unwrap();
+
+        let args = atomic_load_args(&pool, "atomic_exists", &csv_path, true, true);
+        let err = run_load(args).await.unwrap_err().to_string();
+        assert!(err.contains("refuses to load into existing table"), "{err}");
+        assert_eq!(get_table_count(&pool, "atomic_exists").await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_atomic_drops_table_on_failure() {
+        let temp_dir = TempDir::new().unwrap();
+        // Inconsistent column counts force a deterministic partial failure.
+        let csv_path = create_csv_with_content(
+            &temp_dir,
+            "bad.csv",
+            &[
+                "id,name,value\n",
+                "1,alice,100\n",
+                "2,bob\n", // missing column → fails
+                "3,charlie,300\n",
+                "4,diana,400,extra\n", // extra column → fails
+            ],
+        )
+        .await;
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+
+        let args = atomic_load_args(&pool, "atomic_rollback", &csv_path, true, true);
+        let err = run_load(args).await.unwrap_err().to_string();
+        assert!(err.contains("rolled back"), "{err}");
+        assert!(
+            !sqlite_table_exists(&pool, "atomic_rollback").await,
+            "atomic load must DROP the table it created on failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_atomic_keeps_table_on_success() {
+        let temp_dir = TempDir::new().unwrap();
+        let csv_path = create_test_csv(&temp_dir, "ok.csv", 20).await;
+        let pool = Pool::sqlite_in_memory().await.unwrap();
+
+        let args = atomic_load_args(&pool, "atomic_success", &csv_path, true, true);
+        let result = run_load(args).await.unwrap();
+        assert_eq!(result.records_failed, 0);
+        assert!(sqlite_table_exists(&pool, "atomic_success").await);
+        assert_eq!(get_table_count(&pool, "atomic_success").await, 20);
+    }
+
     // ============ Tests ============
 
     #[tokio::test]
@@ -500,6 +628,7 @@ mod tests {
             batch_size: 10,
             batch_concurrency: 2,
             create_table_if_missing: false, // Table already created
+            atomic: false,
             manifest_dir: None,
             quiet: true,
             debug: true,
@@ -589,6 +718,7 @@ mod tests {
             batch_size: 20,
             batch_concurrency: 2,
             create_table_if_missing: false,
+            atomic: false,
             manifest_dir: None,
             quiet: true,
             debug: true,
@@ -731,6 +861,7 @@ mod tests {
             batch_size: 10,
             batch_concurrency: 1,
             create_table_if_missing: false,
+            atomic: false,
             manifest_dir: None, // Don't specify manifest dir - this is key
             quiet: true,
             debug: true,
@@ -1002,6 +1133,7 @@ mod tests {
             batch_size: 10,
             batch_concurrency: 2,
             create_table_if_missing: false,
+            atomic: false,
             manifest_dir: None,
             quiet: true,
             debug: true,
@@ -1105,6 +1237,7 @@ mod tests {
             batch_size: 10,
             batch_concurrency: 1,
             create_table_if_missing: false,
+            atomic: false,
             manifest_dir: Some(manifest_path.clone()),
             quiet: true,
             debug: true,
@@ -1196,6 +1329,7 @@ mod tests {
             batch_size: 10,
             batch_concurrency: 1,
             create_table_if_missing: false,
+            atomic: false,
             manifest_dir: Some(manifest_path.clone()),
             quiet: true,
             debug: true,
@@ -1319,6 +1453,7 @@ mod tests {
             batch_size: 5,
             batch_concurrency: 1,
             create_table_if_missing: false,
+            atomic: false,
             manifest_dir: Some(manifest_path.clone()),
             quiet: true,
             debug: true,
@@ -1432,6 +1567,7 @@ mod tests {
             batch_size: 5,
             batch_concurrency: 1,
             create_table_if_missing: false,
+            atomic: false,
             manifest_dir: Some(manifest_path.clone()),
             quiet: true,
             debug: true,
@@ -1934,6 +2070,7 @@ mod tests {
             batch_size: 10,
             batch_concurrency: 1,
             create_table_if_missing: false,
+            atomic: false,
             manifest_dir: None,
             quiet: true,
             debug: false,
@@ -2108,6 +2245,7 @@ mod tests {
             batch_size: 100,
             batch_concurrency: 1,
             create_table_if_missing: false,
+            atomic: false,
             manifest_dir: None,
             quiet: true,
             debug: false,
@@ -2234,6 +2372,7 @@ mod tests {
             batch_size: 100,
             batch_concurrency: 1,
             create_table_if_missing: false,
+            atomic: false,
             manifest_dir: None,
             quiet: true,
             debug: false,
@@ -2284,6 +2423,7 @@ mod tests {
             batch_size: 100,
             batch_concurrency: 1,
             create_table_if_missing: false,
+            atomic: false,
             manifest_dir: None,
             quiet: true,
             debug: false,
@@ -2359,6 +2499,7 @@ mod tests {
             batch_size: 100,
             batch_concurrency: 1,
             create_table_if_missing: false,
+            atomic: false,
             manifest_dir: None,
             quiet: true,
             debug: false,
@@ -4020,6 +4161,7 @@ mod tests {
             batch_size: 100,
             batch_concurrency: 1,
             create_table_if_missing: false,
+            atomic: false,
             manifest_dir: None,
             quiet: true,
             debug: false,
@@ -4323,6 +4465,7 @@ mod tests {
             batch_size: 100,
             batch_concurrency: 1,
             create_table_if_missing: false,
+            atomic: false,
             manifest_dir: None,
             quiet: true,
             debug: false,
@@ -5446,6 +5589,7 @@ mod tests {
             batch_size: 100,
             batch_concurrency: 1,
             create_table_if_missing: false,
+            atomic: false,
             manifest_dir: None,
             quiet: true,
             debug: false,
@@ -5491,6 +5635,7 @@ mod tests {
             batch_size: 100,
             batch_concurrency: 1,
             create_table_if_missing: false,
+            atomic: false,
             manifest_dir: None,
             quiet: true,
             debug: false,
@@ -5554,6 +5699,7 @@ mod tests {
             batch_size: 100,
             batch_concurrency: 1,
             create_table_if_missing: true,
+            atomic: false,
             manifest_dir: None,
             quiet: true,
             debug: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ struct LoadParams {
     /// and refuses to run if the table already exists (it will not drop
     /// pre-existing data). DSQL can't do a single-transaction bulk load
     /// (3,000-row/txn cap, no SAVEPOINT), so this is the only clean rollback.
-    #[arg(long, requires = "if_not_exists")]
+    #[arg(long, requires = "if_not_exists", conflicts_with = "resume_job_id")]
     atomic: bool,
 
     /// Column mapping from source to destination (format: src:dest,src2:dest2)
@@ -1349,6 +1349,32 @@ mod tests {
             Err(e) => e,
         };
         assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn atomic_conflicts_with_resume_at_parse_time() {
+        let result = Args::try_parse_from([
+            "aurora-dsql-loader",
+            "load",
+            "--endpoint",
+            "xxxx.dsql.us-east-1.on.aws",
+            "--source-uri",
+            "test.csv",
+            "--table",
+            "t",
+            "--if-not-exists",
+            "--atomic",
+            "--manifest-dir",
+            "/tmp/m",
+            "--resume-job-id",
+            "job-123",
+            "--dry-run",
+        ]);
+        let err = match result {
+            Ok(_) => panic!("clap should reject --atomic + --resume-job-id"),
+            Err(e) => e,
+        };
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,11 +100,12 @@ struct LoadParams {
     #[arg(long)]
     if_not_exists: bool,
 
-    /// All-or-nothing: on any failure, DROP the table the loader created and
-    /// exit non-zero, leaving the cluster as it was. Requires --if-not-exists
-    /// and refuses to run if the table already exists (it will not drop
-    /// pre-existing data). DSQL can't do a single-transaction bulk load
-    /// (3,000-row/txn cap, no SAVEPOINT), so this is the only clean rollback.
+    /// All-or-nothing: on any load failure, DROP the table the loader created
+    /// and exit non-zero. Requires --if-not-exists and refuses to run if the
+    /// table already exists or its absence can't be verified (it will not drop
+    /// pre-existing data); cannot be combined with --resume-job-id. DSQL can't
+    /// do a single-transaction bulk load (3,000-row/txn cap, no SAVEPOINT), so
+    /// this is the only clean rollback.
     #[arg(long, requires = "if_not_exists", conflicts_with = "resume_job_id")]
     atomic: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,14 @@ struct LoadParams {
     #[arg(long)]
     if_not_exists: bool,
 
+    /// All-or-nothing: on any failure, DROP the table the loader created and
+    /// exit non-zero, leaving the cluster as it was. Requires --if-not-exists
+    /// and refuses to run if the table already exists (it will not drop
+    /// pre-existing data). DSQL can't do a single-transaction bulk load
+    /// (3,000-row/txn cap, no SAVEPOINT), so this is the only clean rollback.
+    #[arg(long, requires = "if_not_exists")]
+    atomic: bool,
+
     /// Column mapping from source to destination (format: src:dest,src2:dest2)
     #[arg(long)]
     column_map: Option<String>,
@@ -889,6 +897,7 @@ async fn run_loader(
         batch_size: load.batch_size,
         batch_concurrency: load.batch_concurrency,
         create_table_if_missing: load.if_not_exists,
+        atomic: load.atomic,
         manifest_dir: output.manifest_dir.clone().map(PathBuf::from),
         quiet: output.quiet,
         debug: output.debug,
@@ -1319,6 +1328,27 @@ mod tests {
         // Assert on ErrorKind (the stable contract) rather than message wording,
         // which clap is free to re-phrase between releases.
         assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn atomic_requires_if_not_exists_at_parse_time() {
+        let result = Args::try_parse_from([
+            "aurora-dsql-loader",
+            "load",
+            "--endpoint",
+            "xxxx.dsql.us-east-1.on.aws",
+            "--source-uri",
+            "test.csv",
+            "--table",
+            "t",
+            "--atomic",
+            "--dry-run",
+        ]);
+        let err = match result {
+            Ok(_) => panic!("clap should reject --atomic without --if-not-exists"),
+            Err(e) => e,
+        };
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
     }
 
     #[test]

--- a/src/migrate/orchestrator.rs
+++ b/src/migrate/orchestrator.rs
@@ -463,6 +463,8 @@ fn build_load_args(args: &MigrateArgs, table: &str, schema: &str) -> LoadArgs {
         // already exists; the IF-NOT-EXISTS path is gated against pg_dump
         // anyway by validate_load_args.
         create_table_if_missing: false,
+        // migrate applies DDL itself before loading; no per-table atomic drop.
+        atomic: false,
         column_mappings: HashMap::new(),
         manifest_dir: None,
         quiet: args.quiet,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -38,6 +38,7 @@ use tempfile::TempDir;
 use crate::coordination::manifest::{LocalManifestStorage, ParquetConfig, PgDumpConfig};
 use crate::coordination::{Coordinator, DsqlConfig, FileFormat, LoadConfigBuilder};
 use crate::db::pool::PoolArgsBuilder;
+use crate::db::schema::query_table_schema;
 use crate::db::{self as db_pool, SchemaInferrer};
 use crate::formats::pgdump::{CopyBlock, PgDumpReader, list_copy_blocks};
 use crate::formats::{DelimitedConfig, ReaderFactory};
@@ -110,6 +111,11 @@ pub struct LoadArgs {
 
     // Options
     pub create_table_if_missing: bool,
+    /// Opt-in all-or-nothing. DSQL can't run a multi-worker bulk load in one
+    /// transaction (3,000-row/txn cap, no SAVEPOINT), so the only clean
+    /// rollback is to DROP a table the loader created this run. Requires
+    /// `create_table_if_missing`; refuses if the table already exists.
+    pub atomic: bool,
     pub manifest_dir: Option<PathBuf>,
     pub quiet: bool,
     pub debug: bool,
@@ -197,6 +203,7 @@ pub struct LoadResult {
 ///     batch_size: 3000,
 ///     batch_concurrency: 20,
 ///     create_table_if_missing: true,
+///     atomic: false,
 ///     manifest_dir: None,
 ///     column_mappings: HashMap::new(),
 ///     quiet: true,
@@ -222,6 +229,34 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     // who skip `run_load` still get the same checks.
     validate_load_args(&args)?;
     let pool = build_pool(&args).await?;
+
+    // Only a table the loader creates this run is safe to DROP on failure;
+    // gate out the cases where rollback would destroy pre-existing data.
+    if args.atomic {
+        if !args.create_table_if_missing {
+            anyhow::bail!(
+                "--atomic requires --if-not-exists: rollback drops the table the loader \
+                 creates this run, so the table must not already exist (DSQL has no \
+                 SAVEPOINT and caps transactions at 3,000 rows, so a bulk load can't be \
+                 one atomic transaction)."
+            );
+        }
+        if query_table_schema(&pool, &args.schema, &args.target_table)
+            .await
+            .is_ok()
+        {
+            anyhow::bail!(
+                "--atomic refuses to load into existing table {}.{}: rollback would DROP it, \
+                 destroying pre-existing data. Drop it yourself first, or run without --atomic.",
+                args.schema,
+                args.target_table
+            );
+        }
+    }
+
+    let atomic = args.atomic;
+    let atomic_schema = args.schema.clone();
+    let atomic_table = args.target_table.clone();
 
     // L2 needs a stable pre/post pair AND an exact source count to be
     // meaningful. Skip on `--if-not-exists` (table may not exist yet, and a
@@ -262,7 +297,25 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     let format = args.format;
     let chunk_size_bytes = args.chunk_size_bytes;
 
-    let mut result = run_load_with_pool(pool.clone(), args).await?;
+    let mut result = match run_load_with_pool(pool.clone(), args).await {
+        Ok(r) if atomic && r.records_failed > 0 => {
+            drop_atomic_table(&pool, &atomic_schema, &atomic_table).await;
+            anyhow::bail!(
+                "--atomic: rolled back — {} record(s) failed; dropped table {}.{}.",
+                r.records_failed,
+                atomic_schema,
+                atomic_table
+            );
+        }
+        Ok(r) => r,
+        Err(e) if atomic => {
+            drop_atomic_table(&pool, &atomic_schema, &atomic_table).await;
+            return Err(e.context(format!(
+                "--atomic: rolled back — load failed; dropped table {atomic_schema}.{atomic_table}"
+            )));
+        }
+        Err(e) => return Err(e),
+    };
 
     if verify_on {
         let target_post = if l2_runs {
@@ -324,6 +377,19 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     }
 
     Ok(result)
+}
+
+/// Drop the table created by an `--atomic` load that's about to fail. The
+/// DROP error is logged, not propagated, so it can't mask the load error the
+/// caller is already returning (the original cause is what the operator needs).
+async fn drop_atomic_table(pool: &crate::db::Pool, schema: &str, table: &str) {
+    let ddl = format!("DROP TABLE {}", pool.qualified_table_name(schema, table));
+    if let Err(e) = pool.execute_query(&ddl).await {
+        tracing::error!(
+            "--atomic: rollback DROP of {schema}.{table} failed: {e:#}. \
+             Drop it manually to restore the prior state."
+        );
+    }
 }
 
 /// Build the connection pool. Honors `args.test_pool` in `#[cfg(test)]`.
@@ -870,6 +936,7 @@ mod tests {
             batch_size: 1,
             batch_concurrency: 1,
             create_table_if_missing: false,
+            atomic: false,
             manifest_dir: None,
             quiet: true,
             debug: false,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -112,8 +112,10 @@ pub struct LoadArgs {
     pub create_table_if_missing: bool,
     /// Opt-in all-or-nothing. DSQL can't run a multi-worker bulk load in one
     /// transaction (3,000-row/txn cap, no SAVEPOINT), so the only clean
-    /// rollback is to DROP a table the loader created this run. Requires
-    /// `create_table_if_missing`; refuses if the table already exists.
+    /// rollback is to DROP a table the loader created this run. On any load
+    /// failure it drops that table and exits non-zero. Requires
+    /// `create_table_if_missing`; refuses if the table already exists or its
+    /// absence can't be verified; cannot be combined with `resume_job_id`.
     pub atomic: bool,
     pub manifest_dir: Option<PathBuf>,
     pub quiet: bool,
@@ -838,6 +840,18 @@ mod tests {
     fn format_parse_accepts_pgdump() {
         assert_eq!(Format::parse("pgdump").unwrap(), Format::PgDump);
         assert_eq!(Format::parse("PGDUMP").unwrap(), Format::PgDump);
+    }
+
+    #[test]
+    fn rollback_note_is_truthful_about_drop() {
+        let dropped = rollback_note(true, "public", "t");
+        assert!(
+            dropped.contains("rolled back — dropped table public.t"),
+            "{dropped}"
+        );
+        let failed = rollback_note(false, "public", "t");
+        assert!(failed.contains("rollback INCOMPLETE"), "{failed}");
+        assert!(failed.contains("drop it manually"), "{failed}");
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -38,7 +38,6 @@ use tempfile::TempDir;
 use crate::coordination::manifest::{LocalManifestStorage, ParquetConfig, PgDumpConfig};
 use crate::coordination::{Coordinator, DsqlConfig, FileFormat, LoadConfigBuilder};
 use crate::db::pool::PoolArgsBuilder;
-use crate::db::schema::query_table_schema;
 use crate::db::{self as db_pool, SchemaInferrer};
 use crate::formats::pgdump::{CopyBlock, PgDumpReader, list_copy_blocks};
 use crate::formats::{DelimitedConfig, ReaderFactory};
@@ -230,33 +229,32 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     validate_load_args(&args)?;
     let pool = build_pool(&args).await?;
 
-    // Only a table the loader creates this run is safe to DROP on failure;
-    // gate out the cases where rollback would destroy pre-existing data.
-    if args.atomic {
-        if !args.create_table_if_missing {
-            anyhow::bail!(
-                "--atomic requires --if-not-exists: rollback drops the table the loader \
-                 creates this run, so the table must not already exist (DSQL has no \
-                 SAVEPOINT and caps transactions at 3,000 rows, so a bulk load can't be \
-                 one atomic transaction)."
-            );
-        }
-        if query_table_schema(&pool, &args.schema, &args.target_table)
+    // Only a table the loader creates this run is safe to DROP on failure.
+    // Fail CLOSED: a probe failure must abort, never be read as "table absent"
+    // and proceed — otherwise a transient error could let the load run against
+    // pre-existing data and then DROP it. (The flag-only `--atomic requires
+    // --if-not-exists` / no-resume checks live in `validate_load_args`.)
+    if args.atomic
+        && pool
+            .table_exists(&args.schema, &args.target_table)
             .await
-            .is_ok()
-        {
-            anyhow::bail!(
-                "--atomic refuses to load into existing table {}.{}: rollback would DROP it, \
-                 destroying pre-existing data. Drop it yourself first, or run without --atomic.",
-                args.schema,
-                args.target_table
-            );
-        }
+            .with_context(|| {
+                format!(
+                    "--atomic: could not verify whether target table {}.{} already exists; \
+                     refusing to run so rollback can never DROP pre-existing data",
+                    args.schema, args.target_table
+                )
+            })?
+    {
+        anyhow::bail!(
+            "--atomic refuses to load into existing table {}.{}: rollback would DROP it, \
+             destroying pre-existing data. Drop it yourself first, or run without --atomic.",
+            args.schema,
+            args.target_table
+        );
     }
 
     let atomic = args.atomic;
-    let atomic_schema = args.schema.clone();
-    let atomic_table = args.target_table.clone();
 
     // L2 needs a stable pre/post pair AND an exact source count to be
     // meaningful. Skip on `--if-not-exists` (table may not exist yet, and a
@@ -299,22 +297,27 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
 
     let mut result = match run_load_with_pool(pool.clone(), args).await {
         Ok(r) if atomic && r.records_failed > 0 => {
-            drop_atomic_table(&pool, &atomic_schema, &atomic_table).await;
+            let dropped = drop_atomic_table(&pool, &schema, &target_table).await;
+            let manifest = r
+                .persisted_manifest_dir
+                .as_ref()
+                .map(|p| format!(" Failure manifest preserved at {}.", p.display()))
+                .unwrap_or_default();
             anyhow::bail!(
-                "--atomic: rolled back — {} record(s) failed; dropped table {}.{}.",
+                "--atomic: {} record(s) failed; {}.{manifest}",
                 r.records_failed,
-                atomic_schema,
-                atomic_table
+                rollback_note(dropped, &schema, &target_table),
             );
         }
-        Ok(r) => r,
         Err(e) if atomic => {
-            drop_atomic_table(&pool, &atomic_schema, &atomic_table).await;
+            let dropped = drop_atomic_table(&pool, &schema, &target_table).await;
             return Err(e.context(format!(
-                "--atomic: rolled back — load failed; dropped table {atomic_schema}.{atomic_table}"
+                "--atomic: load failed; {}",
+                rollback_note(dropped, &schema, &target_table)
             )));
         }
-        Err(e) => return Err(e),
+        // Clean success, or a non-atomic error to propagate unchanged.
+        other => other?,
     };
 
     if verify_on {
@@ -379,16 +382,38 @@ pub async fn run_load(args: LoadArgs) -> Result<LoadResult> {
     Ok(result)
 }
 
-/// Drop the table created by an `--atomic` load that's about to fail. The
-/// DROP error is logged, not propagated, so it can't mask the load error the
-/// caller is already returning (the original cause is what the operator needs).
-async fn drop_atomic_table(pool: &crate::db::Pool, schema: &str, table: &str) {
-    let ddl = format!("DROP TABLE {}", pool.qualified_table_name(schema, table));
-    if let Err(e) = pool.execute_query(&ddl).await {
-        tracing::error!(
-            "--atomic: rollback DROP of {schema}.{table} failed: {e:#}. \
-             Drop it manually to restore the prior state."
-        );
+/// Drop the table created by an `--atomic` load that's about to fail. Returns
+/// `true` if the DROP succeeded. `IF EXISTS` keeps it idempotent when the load
+/// failed before the table was created. The DROP error is logged, not
+/// propagated, so it can't mask the load failure the caller reports — but the
+/// returned bool lets the caller tell the operator the truth (see
+/// `rollback_note`) instead of always claiming the table was dropped.
+async fn drop_atomic_table(pool: &crate::db::Pool, schema: &str, table: &str) -> bool {
+    let ddl = format!(
+        "DROP TABLE IF EXISTS {}",
+        pool.qualified_table_name(schema, table)
+    );
+    match pool.execute_query(&ddl).await {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::error!(
+                "--atomic: rollback DROP of {schema}.{table} failed: {e:#}. \
+                 Drop it manually to restore the prior state."
+            );
+            false
+        }
+    }
+}
+
+/// Operator-facing rollback status, honest about whether the DROP succeeded.
+fn rollback_note(dropped: bool, schema: &str, table: &str) -> String {
+    if dropped {
+        format!("rolled back — dropped table {schema}.{table}")
+    } else {
+        format!(
+            "rollback INCOMPLETE — cleanup DROP of {schema}.{table} also failed; \
+             the table may still exist with partial data, drop it manually"
+        )
     }
 }
 
@@ -654,6 +679,31 @@ fn validate_load_args(args: &LoadArgs) -> Result<()> {
             "--verify (count/full) cannot be combined with --resume-job-id: pre-count \
              would not include rows from the original run. Re-run with --verify=off."
         );
+    }
+
+    if args.atomic {
+        // Rollback drops the table the loader creates this run, so the table
+        // must not already exist. (DSQL has no SAVEPOINT and caps transactions
+        // at 3,000 rows, so a bulk load can't be one atomic transaction.) clap
+        // also enforces `requires`, but library callers of `run_load` bypass it.
+        if !args.create_table_if_missing {
+            anyhow::bail!(
+                "--atomic requires --if-not-exists: rollback drops the table the loader \
+                 creates this run, so the table must not already exist."
+            );
+        }
+        // Resume re-creates the table and replays only the not-yet-completed
+        // chunks against it, so an atomic rollback (which dropped the table)
+        // can't be retried coherently — the result would be a partial load
+        // reported as success. Refuse the combination.
+        if args.resume_job_id.is_some() {
+            anyhow::bail!(
+                "--atomic cannot be combined with --resume-job-id: an atomic rollback \
+                 drops the table, so a resume would replay only the remaining chunks \
+                 into a freshly created table and silently land a partial dataset. \
+                 Re-run the full load with --atomic instead."
+            );
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## What

Adds an opt-in `--atomic` flag to `load` for all-or-nothing semantics: if the load fails partially, the cluster is left exactly as it was before.

## Why this scope

DSQL caps every transaction at 3,000 rows / 10 MiB / 5 min and has no `SAVEPOINT`, and the loader commits batches independently across workers by design (see the cancellation-safety note in `worker.rs`). So a bulk load **cannot** be wrapped in a single atomic transaction.

The one clean, truly-correct rollback is to **drop a table the loader created this run**. `--atomic` covers exactly that case:

- Requires `--if-not-exists` (there must be a table the loader owns to drop).
- Refuses up front if the target table already exists — it will **never** drop pre-existing data.
- **Fails closed:** if it can't verify the table is absent (a probe error), it refuses to run rather than risk dropping pre-existing data.
- Cannot be combined with `--resume-job-id` (a dropped-table rollback can't be coherently resumed).
- On any load failure (`Err` *or* `records_failed > 0`), drops the created table and exits non-zero. If the cleanup DROP itself fails, it says so and names the table for manual cleanup.

Rollback covers load failures only: a non-fatal `--verify` mismatch or row-count warning still exits non-zero but keeps the table for inspection.

Loading into a **pre-existing** table atomically would require tracking and deleting inserted PKs — still not truly atomic under the same txn caps, and a much larger change. Left for a follow-up.

## Implementation

Logic lives in `run_load` (`runner.rs`), the `drop_atomic_table` / `rollback_note` helpers (`runner.rs`), a new fail-closed `Pool::table_exists` (`db/pool.rs`), one `LoadArgs` field, and the CLI flag — no coordinator, manifest, or `LoadResult` changes.

## Testing

- `test_atomic_requires_if_not_exists` — refused without `--if-not-exists`
- `test_atomic_refuses_existing_table` — refused on existing table; pre-existing data untouched
- `test_atomic_drops_table_on_failure` — partial failure drops the created table; truthful message + manifest path surfaced
- `test_atomic_keeps_table_on_success` — clean load keeps the table + all rows
- `test_atomic_rejects_resume` — `--atomic` + `--resume-job-id` refused (library path)
- `atomic_requires_if_not_exists_at_parse_time` / `atomic_conflicts_with_resume_at_parse_time` — CLI parse-gates
- `rollback_note_is_truthful_about_drop`, `table_exists_reports_absent_then_present` — unit tests

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and the full test suite all pass.
